### PR TITLE
feat: render contract, --doc <format> CLI, JSON renderer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,82 @@
+# Architecture
+
+This document describes how demokit is wired together internally — the files, the contracts between them, and the pitfalls that matter when extending it. For *what* demokit does and how to use it, see [README.md](README.md).
+
+## Module map
+
+| File | Responsibility |
+|---|---|
+| `demokit.go` | `Demo` builder, CLI flag parsing, the `Execute` loop, doc-emit dispatch |
+| `step.go` | `StepDef`, `SectionDef`, `ActorDef`, `Ref`, `ArrowView` — the static definition types |
+| `inputs.go` | `InputDef` + `String/Int/Choice/WithDefault` helpers |
+| `result.go` | `StepResult`, `StepContext`, `ResultStatus`, convenience constructors (`Errf`, `Warn`, `Info`) |
+| `recorder.go` | `TraceEntry`, `Recorder` interface, `MemoryRecorder`, `JSONFileRecorder`, `LoadTrace` |
+| `renderer.go` | `Renderer` interface + `PlainRenderer` (default zero-dep stdout renderer) |
+| `markdown.go` | `Demo.Markdown()` — the static-visitor markdown emitter (used by `--doc md` without `--from`) |
+| `render.go` | `RenderContext{Demo, Trace, State}` + `EntryOpts{StepNumber}` — the contract every doc renderer consumes |
+| `render_trace.go` | `RenderEntryMD/HTML`, `RenderDocumentMD/HTML`, legacy `MarkdownFromTrace`/`HTMLFromTrace` wrappers |
+| `render_json.go` | `RenderDocumentJSON`, `JSONFromTrace`, `Demo.JSON()` + projection view structs |
+| `term.go` | Terminal width detection with stdout/stderr fallback |
+| `logger.go` | Internal `print()` helper (writes to stderr — see gotchas) |
+| `tui/` | Lipgloss-based renderer + `FormPrompter` interface |
+
+## Render contract
+
+Every documentation renderer (markdown, HTML, JSON, future templ/React plugins) is a pure function of `RenderContext{Demo, Trace, State}`:
+
+- **Static** (`Trace == nil`): walks `Demo` definition only. Used by `Demo.Markdown()` and `Demo.JSON()`.
+- **Trace** (`Trace == loaded entries`): post-hoc record from `--record`. Used by `RenderDocument*(ctx)`.
+- **Live** (future): partial trace + state snapshot; reserved for WebSocket embeds.
+
+Renderers **never invoke `Run()`**. Computed values are produced by `Execute`, persisted to the trace, and consumed downstream. This guarantees:
+
+- Renderers are deterministic and side-effect-free.
+- Multiple format renderers consume the same trace without re-executing the demo.
+- A renderer can run in a different process (web server, embed host).
+
+The trace renderers (md, html) are layered into a per-entry primitive and a whole-document shell — `RenderEntryMD/HTML` for self-contained fragments (no preamble, no aggregations), `RenderDocumentMD/HTML` for full documents with title preamble, `## Walkthrough` header, and deduplicated references footer. JSON is a single document function (per-entry JSON would be a trivial `json.Marshal(entry)` and not worth wrapping).
+
+## Doc-emit dispatch (`--doc <format>` + `--from <path>`)
+
+| Flag | `--from`? | Renderer |
+|---|---|---|
+| `--doc md` | no | `Demo.Markdown()` (rich static visitor) |
+| `--doc md` | yes | `RenderDocumentMD(ctx)` (per-entry layered) |
+| `--doc html` | no | `RenderDocumentHTML(ctx)` (minimal: title + description) |
+| `--doc html` | yes | `RenderDocumentHTML(ctx)` |
+| `--doc json` | no | `RenderDocumentJSON(ctx)` (definition only) |
+| `--doc json` | yes | `RenderDocumentJSON(ctx)` (definition + trace) |
+
+Static-md and trace-md route to **different renderers** because they walk fundamentally different sources (declarations vs. recorded entries) and produce intentionally different shapes. The static visitor includes a "What you'll learn" notes summary, a consolidated mermaid sequence diagram, and a Run-it footer; the trace renderer produces a per-step walkthrough with captured outputs and inputs.
+
+Legacy flags `--readme`, `--readme-from`, `--readme-html-from` still work but print a one-line deprecation warning to stderr.
+
+## Gotchas
+
+### API shape
+
+- `Note()`/`Ref()` are setters — readers are `NoteText()`/`Refs()`.
+- `ID(s)` is a setter; reader is `StepID()` (Go has no overloading).
+- `WithDefault(v)` is the chainable setter; the underlying field is `Default`.
+
+### Output capture
+
+- `print()` (in `logger.go`) writes to **stderr** — use `fmt.Print()` for capturable stdout.
+- `term.GetSize(os.Stdout.Fd())` fails when stdout is piped — `TermWidth()` falls back to stderr.
+
+### Trace round-trip
+
+- JSON unmarshal widens numeric inputs to `float64`. Tests handle both int and float forms.
+- Replay forces deterministic `Next`: the user's `Run` can return anything, but the recorded `Next` wins so refactored demos still replay the original path.
+
+### Control flow
+
+- It's a **directed graph**, not a DAG — cycles are allowed (hence `MaxVisits`). Two guardrails: `Demo.MaxSteps(n)` (default 200) caps total visits; `Demo.MaxVisits(n)` caps per-step revisits.
+
+### Stdin handling
+
+- Cancellable stdin reads use `muesli/cancelreader`, not bare goroutines. Go has no portable stdin deadline; `os.Stdin.SetReadDeadline` is unreliable on terminals across macOS/Windows. See `WaitForEnterOrTimeout` in `renderer.go`.
+
+### Example READMEs
+
+- Regenerate via `make gen-readme` in `examples/basic/` (static linear via `--doc md`) and `examples/graph/` (trace-driven via `--doc md --from`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ cd examples/graph && make gen-readme
 - `demokit.go` — Demo, StepDef, StepResult, StepContext, Execute loop, PlainRenderer
 - `inputs.go` — InputDef + helpers (String/Int/Choice/WithDefault)
 - `recorder.go` — TraceEntry, Recorder, JSONFileRecorder, LoadTrace
-- `render_trace.go` — MarkdownFromTrace, HTMLFromTrace
+- `render.go` — RenderContext + EntryOpts (the (Demo, Trace, State) contract)
+- `render_trace.go` — RenderEntryMD/HTML, RenderDocumentMD/HTML; legacy MarkdownFromTrace/HTMLFromTrace wrappers
 - `tui/` — Lipgloss renderer + FormPrompter interface
 
 ## Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,44 +1,19 @@
 # CLAUDE.md — demokit
 
-See [README.md](README.md) for what demokit is and how to use it.
-See [examples/graph/main.go](examples/graph/main.go) for a working branching demo.
+Light router. Substantive content lives elsewhere:
 
-## Quick ref
+- **What demokit is, how to use it** → [README.md](README.md)
+- **Internal architecture, file map, gotchas** → [ARCHITECTURE.md](ARCHITECTURE.md)
+- **A working branching demo** → [examples/graph/main.go](examples/graph/main.go)
+
+## Must-know
+
+- It's a **directed graph**, not a DAG — cycles are allowed. `Demo.MaxSteps` and `Demo.MaxVisits` are the termination guardrails. Don't remove either.
+- Doc renderers (markdown, HTML, JSON) are **pure functions of `RenderContext{Demo, Trace, State}`** — they never invoke `Run()`. Maintain that invariant when adding new formats.
+- Static `--doc md` and trace `--doc md --from` route to **different renderers** by design (rich visitor vs. per-entry layered). Don't unify them; see ARCHITECTURE.md for why.
 
 ```bash
 go test ./...
-go run ./examples/graph/                                  # branching demo
-go run ./examples/graph/ --record /tmp/run.json           # save a trace
-go run ./examples/graph/ --replay /tmp/run.json           # replay it
-go run ./examples/graph/ --readme-from /tmp/run.json      # markdown of path
-
-# Per-example README regeneration (checked into repo)
-cd examples/basic && make gen-readme
-cd examples/graph && make gen-readme
+go run ./examples/graph/                                  # interactive
+go run ./examples/graph/ --doc md --from /tmp/run.json    # docs from a trace
 ```
-
-## Files
-
-- `demokit.go` — Demo, StepDef, StepResult, StepContext, Execute loop, PlainRenderer
-- `inputs.go` — InputDef + helpers (String/Int/Choice/WithDefault)
-- `recorder.go` — TraceEntry, Recorder, JSONFileRecorder, LoadTrace
-- `render.go` — RenderContext + EntryOpts (the (Demo, Trace, State) contract)
-- `render_trace.go` — RenderEntryMD/HTML, RenderDocumentMD/HTML; legacy MarkdownFromTrace/HTMLFromTrace wrappers
-- `tui/` — Lipgloss renderer + FormPrompter interface
-
-## Gotchas
-
-- `Note()`/`Ref()` are setters — readers are `NoteText()`/`Refs()`
-- `ID(s)` is a setter; reader is `StepID()` (no Go overloading)
-- `WithDefault` not `Default` on `InputDef` (Default is the public field)
-- `print()` writes to stderr — use `fmt.Print()` for capturable output
-- `term.GetSize(os.Stdout.Fd())` fails when piped — `TermWidth()` falls back to stderr
-- JSON round-trip widens numeric inputs to float64 — tests handle both
-- It's a **directed graph**, not a DAG — cycles allowed (hence MaxVisits)
-- Replay forces deterministic Next: user's Run can return anything, recorded Next wins
-- Cancellable stdin reads use `muesli/cancelreader` (not bare goroutines) — Go has no portable stdin deadline; `os.Stdin.SetReadDeadline` is unreliable on terminals across macOS/Windows. See `WaitForEnterOrTimeout` in demokit.go.
-- Regenerate example READMEs with `make gen-readme` in `examples/basic/` (static linear via `--readme`) and `examples/graph/` (trace-driven via `--readme-from`)
-
-## Open polish
-
-CLI arg parsing in `Demo.Execute` is ad-hoc `os.Args` walking. Refactor to stdlib `flag` with a `RegisterFlags(*flag.FlagSet)` hook so demos with their own flags compose cleanly. Tracked as a separate task in this PR.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ demo.Execute()
 A working version is in [`examples/graph/`](examples/graph/). Run it:
 
 ```bash
-go run ./examples/graph/                                # interactive
-go run ./examples/graph/ --tui                          # styled boxes
-go run ./examples/graph/ --record /tmp/run.json         # save a trace
-go run ./examples/graph/ --replay /tmp/run.json         # replay it
-go run ./examples/graph/ --readme-from /tmp/run.json    # markdown of that path
+go run ./examples/graph/                                  # interactive
+go run ./examples/graph/ --tui                            # styled boxes
+go run ./examples/graph/ --record /tmp/run.json           # save a trace
+go run ./examples/graph/ --replay /tmp/run.json           # replay it
+go run ./examples/graph/ --doc md                         # static markdown
+go run ./examples/graph/ --doc md --from /tmp/run.json    # markdown of that path
+go run ./examples/graph/ --doc html --from /tmp/run.json  # standalone HTML
+go run ./examples/graph/ --doc json --from /tmp/run.json  # JSON for embed hosts
 ```
 
 ## What's in the box
@@ -60,7 +63,9 @@ go run ./examples/graph/ --readme-from /tmp/run.json    # markdown of that path
 
 **Recording and replay.** `--record path.json` writes the path the user took, including inputs and step output. `--replay path.json` reruns the demo over that trace — same inputs, same path, same output. Steps that diverge (e.g., refactored to take a different branch) get their `Next` overridden so the replay is deterministic.
 
-**Trace-driven docs.** `--readme-from trace.json` renders the *actual visited path* as markdown — useful when one demo has many paths and you want to document each. `--readme-html-from` does the same for HTML. The static linear `--readme` is still there for non-branching demos.
+**Trace-driven docs.** `--doc md --from trace.json` renders the *actual visited path* as markdown — useful when one demo has many paths and you want to document each. `--doc html --from` does the same for HTML. `--doc json --from` produces structured data for embed hosts that want to render their own DOM. Without `--from`, `--doc md` falls back to a rich static walkthrough of the demo definition (mermaid diagram, notes summary, run-it commands).
+
+The legacy flags `--readme`, `--readme-from`, `--readme-html-from` still work but print a deprecation warning; new code should use `--doc <format>`.
 
 **Auto-advance with countdown.** `Demo.AutoAcceptAfter(5 * time.Second).ShowCountdown(true)` makes `WaitForStep` advance after a timer with a visible burn-down bar, while still letting Enter accept early. Useful for kiosks and timed demos.
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -105,8 +105,9 @@ func TestEmitDocFormatsProduceNonEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d := New("Matrix").Description("desc").
-		Actors(Actor("A", "A"))
+	// No actors declared on purpose — exercises the static md visitor's
+	// no-actors path (issue 6 regression).
+	d := New("Matrix").Description("desc")
 	d.Step("x").ID("x").Note("a note")
 
 	cases := []struct {

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,242 @@
+package demokit
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdoutStderr swaps os.Stdout and os.Stderr for pipes during fn,
+// then returns whatever was written. Used to assert CLI flag dispatch
+// produces the right output and warnings.
+func captureStdoutStderr(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	defer func() {
+		os.Stdout = origOut
+		os.Stderr = origErr
+	}()
+
+	fn()
+	wOut.Close()
+	wErr.Close()
+
+	outBytes, _ := io.ReadAll(rOut)
+	errBytes, _ := io.ReadAll(rErr)
+	return string(outBytes), string(errBytes)
+}
+
+// TestEmitDocMDStaticDispatchesToMarkdown verifies that --doc md without
+// --from routes to the rich Demo.Markdown() static visitor (which emits
+// a sequenceDiagram block) rather than to the per-entry trace renderer
+// (which would emit "## Walkthrough"). Pins the static-vs-trace split.
+func TestEmitDocMDStaticDispatchesToMarkdown(t *testing.T) {
+	d := New("Static MD").Description("desc").
+		Actors(Actor("A", "A"), Actor("B", "B"))
+	d.Step("step").Arrow("A", "B", "msg").Note("note")
+
+	out, _ := captureStdoutStderr(t, func() { d.emitDoc("md", "") })
+
+	if !strings.Contains(out, "sequenceDiagram") {
+		t.Errorf("--doc md (static) should call Demo.Markdown() — expected sequenceDiagram block:\n%s", out)
+	}
+	if strings.Contains(out, "## Walkthrough") {
+		t.Errorf("--doc md (static) should not produce trace-renderer output (## Walkthrough):\n%s", out)
+	}
+}
+
+// TestEmitDocMDTraceDispatchesToTraceRenderer verifies --doc md --from
+// routes to RenderDocumentMD (per-entry layered renderer with a
+// "## Walkthrough" header), not to the static visitor.
+func TestEmitDocMDTraceDispatchesToTraceRenderer(t *testing.T) {
+	tmp, err := os.CreateTemp("", "demokit-trace-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	rec := NewJSONFileRecorder(tmp.Name())
+	rec.Record(TraceEntry{Kind: KindStep, Title: "first", StepID: "x", Visit: 1})
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New("Trace MD").Description("desc")
+	d.Step("first").ID("x")
+
+	out, _ := captureStdoutStderr(t, func() { d.emitDoc("md", tmp.Name()) })
+
+	if !strings.Contains(out, "## Walkthrough") {
+		t.Errorf("--doc md --from should produce trace-renderer output (## Walkthrough):\n%s", out)
+	}
+	if strings.Contains(out, "sequenceDiagram") {
+		t.Errorf("--doc md --from should not produce static-visitor output (sequenceDiagram):\n%s", out)
+	}
+}
+
+// TestEmitDocFormatsProduceNonEmpty exercises the format×mode matrix —
+// every (md, html, json) × (static, trace) combination must produce
+// non-empty, format-recognizable output. Catches a wholesale dispatch
+// regression.
+func TestEmitDocFormatsProduceNonEmpty(t *testing.T) {
+	tmp, err := os.CreateTemp("", "demokit-trace-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	rec := NewJSONFileRecorder(tmp.Name())
+	rec.Record(TraceEntry{Kind: KindStep, Title: "x", StepID: "x", Visit: 1})
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d := New("Matrix").Description("desc").
+		Actors(Actor("A", "A"))
+	d.Step("x").ID("x").Note("a note")
+
+	cases := []struct {
+		name   string
+		format string
+		from   string
+		marker string // substring that must appear in output
+	}{
+		{"md-static", "md", "", "# Matrix"},
+		{"md-trace", "md", tmp.Name(), "## Walkthrough"},
+		{"html-static", "html", "", "<!doctype html>"},
+		{"html-trace", "html", tmp.Name(), "<!doctype html>"},
+		{"json-static", "json", "", "\"demo\""},
+		{"json-trace", "json", tmp.Name(), "\"trace\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _ := captureStdoutStderr(t, func() { d.emitDoc(tc.format, tc.from) })
+			if out == "" {
+				t.Fatalf("empty output for %s", tc.name)
+			}
+			if !strings.Contains(out, tc.marker) {
+				t.Errorf("%s output missing %q:\n%s", tc.name, tc.marker, out)
+			}
+		})
+	}
+}
+
+// TestEmitDocUnknownFormatErrors verifies an unknown --doc value writes
+// a descriptive error to stderr and produces no stdout. Silent empty
+// output here would be a bad UX trap.
+func TestEmitDocUnknownFormatErrors(t *testing.T) {
+	d := New("X")
+
+	out, errOut := captureStdoutStderr(t, func() { d.emitDoc("yaml", "") })
+
+	if out != "" {
+		t.Errorf("unknown format should produce no stdout, got: %s", out)
+	}
+	if !strings.Contains(errOut, "unknown --doc format") {
+		t.Errorf("expected stderr to describe unknown format, got: %s", errOut)
+	}
+}
+
+// TestEmitDocFromMissingFileErrors verifies a non-existent --from path
+// surfaces a stderr error and produces no stdout.
+func TestEmitDocFromMissingFileErrors(t *testing.T) {
+	d := New("X")
+
+	out, errOut := captureStdoutStderr(t, func() { d.emitDoc("md", "/no/such/path.json") })
+
+	if out != "" {
+		t.Errorf("missing trace file should produce no stdout, got: %s", out)
+	}
+	if !strings.Contains(errOut, "--from") {
+		t.Errorf("expected stderr to mention --from, got: %s", errOut)
+	}
+}
+
+// TestExecuteDeprecatedReadmeWarns verifies invoking the legacy --readme
+// flag prints a deprecation warning to stderr while still producing
+// the expected static markdown on stdout. Same shape applies to
+// --readme-from and --readme-html-from.
+func TestExecuteDeprecatedReadmeWarns(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"test", "--readme"}
+
+	d := New("Legacy").Description("d").Actors(Actor("A", "A"))
+	d.Step("only").Arrow("A", "A", "self")
+
+	out, errOut := captureStdoutStderr(t, func() { d.Execute() })
+
+	if !strings.Contains(out, "# Legacy") {
+		t.Errorf("--readme should still produce static markdown:\n%s", out)
+	}
+	if !strings.Contains(errOut, "deprecated") || !strings.Contains(errOut, "--doc md") {
+		t.Errorf("expected deprecation warning pointing at --doc md, got stderr:\n%s", errOut)
+	}
+}
+
+// TestExecuteDeprecatedReadmeFromWarns is the trace-md variant of the
+// deprecation-warning test.
+func TestExecuteDeprecatedReadmeFromWarns(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+
+	tmp, err := os.CreateTemp("", "demokit-trace-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	rec := NewJSONFileRecorder(tmp.Name())
+	rec.Record(TraceEntry{Kind: KindStep, Title: "x", StepID: "x", Visit: 1})
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	os.Args = []string{"test", "--readme-from", tmp.Name()}
+	d := New("Legacy")
+	d.Step("x").ID("x")
+
+	out, errOut := captureStdoutStderr(t, func() { d.Execute() })
+
+	if !strings.Contains(out, "## Walkthrough") {
+		t.Errorf("--readme-from should still emit trace markdown:\n%s", out)
+	}
+	if !strings.Contains(errOut, "deprecated") || !strings.Contains(errOut, "--doc md --from") {
+		t.Errorf("expected deprecation warning pointing at --doc md --from, got stderr:\n%s", errOut)
+	}
+}
+
+// TestExecuteDocFlagDispatch verifies the new --doc md flag plumbing
+// works end-to-end through Execute (covers scanOwnArgs + Execute
+// dispatch glue, not just emitDoc).
+func TestExecuteDocFlagDispatch(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"test", "--doc", "json"}
+
+	d := New("DocFlag").Description("d")
+	d.Step("a").ID("a")
+
+	out, errOut := captureStdoutStderr(t, func() { d.Execute() })
+
+	if errOut != "" {
+		t.Errorf("--doc json should not warn or error, got stderr: %s", errOut)
+	}
+	if !strings.Contains(out, "\"demo\"") || !strings.Contains(out, "\"DocFlag\"") {
+		t.Errorf("--doc json output missing expected fields:\n%s", out)
+	}
+}

--- a/demokit.go
+++ b/demokit.go
@@ -279,7 +279,7 @@ func (d *Demo) Execute() {
 			fmt.Fprintf(os.Stderr, "demokit: --readme-from %s: %v\n", d.flagReadmeFromPath, err)
 			return
 		}
-		fmt.Print(MarkdownFromTrace(d, entries))
+		fmt.Print(RenderDocumentMD(RenderContext{Demo: d, Trace: entries}))
 		return
 	}
 	if d.flagReadmeHTMLPath != "" {
@@ -288,7 +288,7 @@ func (d *Demo) Execute() {
 			fmt.Fprintf(os.Stderr, "demokit: --readme-html-from %s: %v\n", d.flagReadmeHTMLPath, err)
 			return
 		}
-		fmt.Print(HTMLFromTrace(d, entries))
+		fmt.Print(RenderDocumentHTML(RenderContext{Demo: d, Trace: entries}))
 		return
 	}
 

--- a/demokit.go
+++ b/demokit.go
@@ -59,6 +59,8 @@ type Demo struct {
 	flagReadmeHTMLPath  string
 	flagRecordPath      string
 	flagReplayPath      string
+	flagDoc             string // md|html|json (empty = not requested)
+	flagFrom            string // optional trace path used with --doc
 }
 
 // New creates a new Demo with the given title.
@@ -218,6 +220,10 @@ func (d *Demo) RegisterFlags(fs *flag.FlagSet) {
 		"record this run to the given trace file")
 	fs.StringVar(&d.flagReplayPath, "replay", "",
 		"replay from the given trace file (forces deterministic Next)")
+	fs.StringVar(&d.flagDoc, "doc", "",
+		"emit documentation in the given format (md|html|json) and exit")
+	fs.StringVar(&d.flagFrom, "from", "",
+		"trace file to render with --doc (omit for static-definition output)")
 }
 
 // scanOwnArgs is the default flag scanner used when RegisterFlags is
@@ -252,6 +258,16 @@ func (d *Demo) scanOwnArgs(args []string) {
 			i++
 		case strings.HasPrefix(arg, "--replay="):
 			d.flagReplayPath = strings.TrimPrefix(arg, "--replay=")
+		case arg == "--doc" && i+1 < len(args):
+			d.flagDoc = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--doc="):
+			d.flagDoc = strings.TrimPrefix(arg, "--doc=")
+		case arg == "--from" && i+1 < len(args):
+			d.flagFrom = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--from="):
+			d.flagFrom = strings.TrimPrefix(arg, "--from=")
 		}
 	}
 }
@@ -268,27 +284,26 @@ func (d *Demo) Execute() {
 		d.scanOwnArgs(os.Args[1:])
 	}
 
-	// Doc-emit shortcuts exit before doing anything else.
+	// Doc-emit shortcuts exit before doing anything else. The new
+	// --doc <format> [--from <trace>] surface dispatches first; the
+	// legacy --readme* flags fall through with a deprecation warning.
+	if d.flagDoc != "" {
+		d.emitDoc(d.flagDoc, d.flagFrom)
+		return
+	}
 	if d.flagReadme {
-		fmt.Print(d.Markdown())
+		fmt.Fprintln(os.Stderr, "demokit: --readme is deprecated; use --doc md")
+		d.emitDoc("md", "")
 		return
 	}
 	if d.flagReadmeFromPath != "" {
-		entries, err := LoadTrace(d.flagReadmeFromPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "demokit: --readme-from %s: %v\n", d.flagReadmeFromPath, err)
-			return
-		}
-		fmt.Print(RenderDocumentMD(RenderContext{Demo: d, Trace: entries}))
+		fmt.Fprintln(os.Stderr, "demokit: --readme-from is deprecated; use --doc md --from <path>")
+		d.emitDoc("md", d.flagReadmeFromPath)
 		return
 	}
 	if d.flagReadmeHTMLPath != "" {
-		entries, err := LoadTrace(d.flagReadmeHTMLPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "demokit: --readme-html-from %s: %v\n", d.flagReadmeHTMLPath, err)
-			return
-		}
-		fmt.Print(RenderDocumentHTML(RenderContext{Demo: d, Trace: entries}))
+		fmt.Fprintln(os.Stderr, "demokit: --readme-html-from is deprecated; use --doc html --from <path>")
+		d.emitDoc("html", d.flagReadmeHTMLPath)
 		return
 	}
 
@@ -466,6 +481,42 @@ walk:
 	}
 
 	r.RenderDone()
+}
+
+// emitDoc writes one documentation render to stdout and returns. The
+// format argument selects the renderer (md, html, json); from selects
+// the source — empty means static (definition only) and a non-empty
+// path is loaded as a trace. Errors are written to stderr; a malformed
+// trace or unknown format produces no stdout output.
+func (d *Demo) emitDoc(format, from string) {
+	var entries []TraceEntry
+	if from != "" {
+		loaded, err := LoadTrace(from)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "demokit: --from %s: %v\n", from, err)
+			return
+		}
+		entries = loaded
+	}
+
+	switch format {
+	case "md":
+		// Static md routes to the rich Demo.Markdown() visitor; trace
+		// md routes to the per-entry layered renderer. They walk
+		// different sources (declarations vs recorded entries) and
+		// produce intentionally different shapes.
+		if entries == nil {
+			fmt.Print(d.Markdown())
+		} else {
+			fmt.Print(RenderDocumentMD(RenderContext{Demo: d, Trace: entries}))
+		}
+	case "html":
+		fmt.Print(RenderDocumentHTML(RenderContext{Demo: d, Trace: entries}))
+	case "json":
+		fmt.Print(RenderDocumentJSON(RenderContext{Demo: d, Trace: entries}))
+	default:
+		fmt.Fprintf(os.Stderr, "demokit: unknown --doc format %q (want md|html|json)\n", format)
+	}
 }
 
 // collectInputs gathers a step's input payload. In interactive mode the

--- a/demokit_test.go
+++ b/demokit_test.go
@@ -809,6 +809,37 @@ func TestMarkdownGeneration(t *testing.T) {
 	}
 }
 
+// TestMarkdownGenerationWithoutActors verifies Demo.Markdown() produces
+// useful output for a demo with no actors — no panic, and crucially no
+// empty mermaid sequenceDiagram block (which doesn't render meaningfully
+// without participants). The "## Flow" section is skipped entirely;
+// title, notes, steps detail, and run-it footer all still appear.
+// Regression for issue 6.
+func TestMarkdownGenerationWithoutActors(t *testing.T) {
+	d := New("NoActors").Description("d")
+	d.Step("only").Note("a note")
+
+	md := d.Markdown()
+
+	if md == "" {
+		t.Fatalf("Markdown() returned empty for demo with no actors")
+	}
+	for _, want := range []string{"# NoActors", "a note", "## Steps"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("Markdown() missing %q for actor-less demo:\n%s", want, md)
+		}
+	}
+	// No participants ⇒ no sequenceDiagram block. Mermaid renders an
+	// empty sequenceDiagram as a broken/unhelpful figure, so we'd
+	// rather omit it than emit a placeholder.
+	if strings.Contains(md, "sequenceDiagram") {
+		t.Errorf("Markdown() should omit the Flow section when no actors are declared:\n%s", md)
+	}
+	if strings.Contains(md, "## Flow") {
+		t.Errorf("Markdown() should omit the Flow header when no actors are declared:\n%s", md)
+	}
+}
+
 func TestBuilderChaining(t *testing.T) {
 	demo := New("Chain").Description("d").Dir("dir").RunPrefix("ex")
 	if demo.title != "Chain" || demo.description != "d" || demo.dir != "dir" || demo.runPrefix != "ex" {

--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run demo runsmooth runquiet demo-quiet readme record replay readme-from readme-html-from gen-readme
+.PHONY: run demo runsmooth runquiet demo-quiet readme record replay readme-from readme-html-from gen-readme doc-md doc-html doc-json
 
 TRACE := /tmp/demokit-basic-trace.json
 
@@ -46,5 +46,18 @@ readme-html-from: record
 
 # Regenerate this example's README.md from the demo definition
 gen-readme:
-	go run . --readme > README.md
+	go run . --doc md > README.md
 	@echo "Wrote README.md"
+
+# New --doc <format> surface (replaces --readme*; old flags still work
+# but warn on stderr).
+doc-md:
+	go run . --doc md
+
+doc-html:
+	go run . --doc html
+
+# JSON for embed hosts. Without --from, emits the static demo definition
+# only (no trace).
+doc-json:
+	go run . --doc json

--- a/examples/graph/Makefile
+++ b/examples/graph/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run demo runquiet record replay readme-from readme-html-from gen-readme
+.PHONY: run demo runquiet record replay readme-from readme-html-from gen-readme doc-md doc-html doc-json
 
 TRACE := /tmp/demokit-graph-trace.json
 
@@ -37,5 +37,18 @@ readme-html-from: record
 # Regenerate this example's README.md from a recorded trace.
 # The default-input run captures the "expired token → refresh" branch.
 gen-readme: record
-	go run . --readme-from $(TRACE) > README.md
+	go run . --doc md --from $(TRACE) > README.md
 	@echo "Wrote README.md"
+
+# New --doc <format> surface (replaces --readme*; old flags still work
+# but warn on stderr).
+doc-md: record
+	go run . --doc md --from $(TRACE)
+
+doc-html: record
+	go run . --doc html --from $(TRACE)
+
+# JSON for embed hosts. Includes both the static demo definition and
+# the recorded trace.
+doc-json: record
+	go run . --doc json --from $(TRACE)

--- a/markdown.go
+++ b/markdown.go
@@ -44,36 +44,40 @@ func (d *Demo) Markdown() string {
 		b.WriteString("\n")
 	}
 
-	// Sequence diagram
-	b.WriteString("## Flow\n\n```mermaid\nsequenceDiagram\n")
-	for _, a := range d.actors {
-		if a.ID != a.Label {
-			fmt.Fprintf(&b, "    participant %s as %s\n", a.ID, a.Label)
-		} else {
-			fmt.Fprintf(&b, "    participant %s\n", a.ID)
+	// Sequence diagram — only meaningful when actors are declared. A
+	// `sequenceDiagram` with no participants doesn't render usefully in
+	// mermaid, so demos without actors skip the Flow section entirely
+	// and rely on the per-step detail below.
+	if len(d.actors) > 0 {
+		b.WriteString("## Flow\n\n```mermaid\nsequenceDiagram\n")
+		for _, a := range d.actors {
+			if a.ID != a.Label {
+				fmt.Fprintf(&b, "    participant %s as %s\n", a.ID, a.Label)
+			} else {
+				fmt.Fprintf(&b, "    participant %s\n", a.ID)
+			}
 		}
-	}
-	stepNum := 0
-	for _, it := range d.items {
-		switch v := it.(type) {
-		case *StepDef:
-			stepNum++
-			fmt.Fprintf(&b, "\n    Note over %s,%s: Step %d: %s\n",
-				d.actors[0].ID, d.actors[len(d.actors)-1].ID, stepNum, v.title)
-			for _, a := range v.arrows {
-				if a.dashed {
-					fmt.Fprintf(&b, "    %s-->>%s: %s\n", a.from, a.to, a.label)
-				} else {
-					fmt.Fprintf(&b, "    %s->>%s: %s\n", a.from, a.to, a.label)
+		stepNum := 0
+		for _, it := range d.items {
+			if v, ok := it.(*StepDef); ok {
+				stepNum++
+				fmt.Fprintf(&b, "\n    Note over %s,%s: Step %d: %s\n",
+					d.actors[0].ID, d.actors[len(d.actors)-1].ID, stepNum, v.title)
+				for _, a := range v.arrows {
+					if a.dashed {
+						fmt.Fprintf(&b, "    %s-->>%s: %s\n", a.from, a.to, a.label)
+					} else {
+						fmt.Fprintf(&b, "    %s->>%s: %s\n", a.from, a.to, a.label)
+					}
 				}
 			}
 		}
+		b.WriteString("```\n\n")
 	}
-	b.WriteString("```\n\n")
 
 	// Steps detail
 	b.WriteString("## Steps\n\n")
-	stepNum = 0
+	stepNum := 0
 	allRefs := make(map[string]Ref) // dedup by URL
 	for _, it := range d.items {
 		switch v := it.(type) {

--- a/render.go
+++ b/render.go
@@ -1,0 +1,37 @@
+package demokit
+
+// RenderContext is the input to every doc renderer. Renderers are pure
+// functions of these three values and never invoke Run; computed values
+// produced during execution live in Trace, the demo's static definition
+// lives in Demo, and live-state snapshots (future) flow through State.
+//
+// Three render modes share this contract:
+//
+//   - Static: Trace == nil. Walk Demo definition only. Suitable for
+//     declarative demos and sidecar markdown sources.
+//   - Trace:  Trace == loaded entries. Post-hoc record from --record.
+//   - Live:   Trace == partial entries; State == current snapshot.
+//     Reserved for future WebSocket-driven embeds.
+type RenderContext struct {
+	// Demo is the definition: title, description, items, actors, declared
+	// notes/arrows/refs. May be nil for trace-only renders without a
+	// document header.
+	Demo *Demo
+	// Trace is the recorded path of one execution. Nil means a static
+	// render; an empty non-nil slice produces an explicit empty-trace
+	// marker in document renderers.
+	Trace []TraceEntry
+	// State is reserved for future live-state interpolation in WS
+	// embeds. Renderers do not consume it today.
+	State any
+}
+
+// EntryOpts controls per-entry rendering. Whole-document renderers
+// compute these internally; incremental consumers (e.g. a WS embed
+// pushing one fragment at a time) supply them by hand.
+type EntryOpts struct {
+	// StepNumber is the 1-based absolute index of this entry across the
+	// current run. Used in step headings. Zero means "no number" — the
+	// renderer falls back to the entry's title alone.
+	StepNumber int
+}

--- a/render_json.go
+++ b/render_json.go
@@ -1,0 +1,124 @@
+package demokit
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// docOutput is the top-level JSON envelope. Both fields are omitempty so
+// that static renders (definition only) and trace-only renders produce
+// asymmetric documents — embed hosts use the presence of "trace" as the
+// mode discriminator.
+type docOutput struct {
+	Demo  *demoView    `json:"demo,omitempty"`
+	Trace []TraceEntry `json:"trace,omitempty"`
+}
+
+// demoView is the JSON-serializable projection of a *Demo. We project
+// (rather than tag *Demo directly) because Demo carries unexported state
+// — flag values, recorder hooks, items as an interface slice — that
+// shouldn't appear in the wire format.
+type demoView struct {
+	Title       string     `json:"title"`
+	Description string     `json:"description,omitempty"`
+	Actors      []ActorDef `json:"actors,omitempty"`
+	Items       []itemView `json:"items,omitempty"`
+}
+
+// itemView discriminates step and section items via the "kind" field,
+// matching the TraceKind values used in trace entries. Step-only fields
+// are omitempty for sections, and vice versa.
+type itemView struct {
+	Kind   TraceKind   `json:"kind"`
+	ID     string      `json:"id,omitempty"`
+	Title  string      `json:"title"`
+	Note   string      `json:"note,omitempty"`
+	Body   string      `json:"body,omitempty"` // sections only
+	Arrows []ArrowView `json:"arrows,omitempty"`
+	Refs   []Ref       `json:"refs,omitempty"`
+	Inputs []inputView `json:"inputs,omitempty"`
+}
+
+// inputView projects an InputDef without its Parse closure (which has
+// no JSON representation). Phase 2 ships Name/Prompt/Default; the typed
+// metadata (kind, options) lands with the inputs registry in Phase 3.
+type inputView struct {
+	Name    string `json:"name"`
+	Prompt  string `json:"prompt,omitempty"`
+	Default any    `json:"default,omitempty"`
+}
+
+// RenderDocumentJSON renders the demo definition (and optionally a
+// trace) as a single JSON object. Suitable for consumption by web embeds
+// and other host renderers that prefer structured data over rendered
+// markup.
+//
+// Output is pretty-printed with two-space indentation and a trailing
+// newline so that piping to a file produces a readable artifact.
+func RenderDocumentJSON(ctx RenderContext) string {
+	out := docOutput{}
+	if ctx.Demo != nil {
+		out.Demo = projectDemo(ctx.Demo)
+	}
+	out.Trace = ctx.Trace
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	// Encoder.Encode only fails when the value contains an unsupported
+	// type; our view structs deliberately exclude those, so an error
+	// here would be a programming bug worth surfacing.
+	if err := enc.Encode(out); err != nil {
+		panic("demokit: RenderDocumentJSON encode failed: " + err.Error())
+	}
+	return buf.String()
+}
+
+// JSONFromTrace is the trace-mode wrapper, mirroring MarkdownFromTrace
+// and HTMLFromTrace.
+func JSONFromTrace(d *Demo, entries []TraceEntry) string {
+	return RenderDocumentJSON(RenderContext{Demo: d, Trace: entries})
+}
+
+// JSON is the static-mode entry point on Demo, mirroring Markdown().
+// Suitable for embed hosts loading the definition once at page init.
+func (d *Demo) JSON() string {
+	return RenderDocumentJSON(RenderContext{Demo: d})
+}
+
+// projectDemo builds the JSON-serializable view of a Demo.
+func projectDemo(d *Demo) *demoView {
+	v := &demoView{
+		Title:       d.title,
+		Description: d.description,
+		Actors:      d.actors,
+	}
+	for _, it := range d.items {
+		switch x := it.(type) {
+		case *StepDef:
+			iv := itemView{
+				Kind:   KindStep,
+				ID:     x.id,
+				Title:  x.title,
+				Note:   x.note,
+				Arrows: x.Arrows(),
+				Refs:   x.refs,
+			}
+			for _, in := range x.inputs {
+				iv.Inputs = append(iv.Inputs, inputView{
+					Name:    in.Name,
+					Prompt:  in.Prompt,
+					Default: in.Default,
+				})
+			}
+			v.Items = append(v.Items, iv)
+		case *SectionDef:
+			v.Items = append(v.Items, itemView{
+				Kind:  KindSection,
+				Title: x.title,
+				Body:  x.body,
+			})
+		}
+	}
+	return v
+}

--- a/render_json_test.go
+++ b/render_json_test.go
@@ -1,0 +1,194 @@
+package demokit
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// fixtureDemoForJSON builds a demo exercising every projected field
+// (actors, step with note/arrows/refs/inputs, section).
+func fixtureDemoForJSON() (*Demo, []TraceEntry) {
+	d := New("JSON Demo").
+		Description("for JSON shape tests").
+		Actors(Actor("App", "Application"), Actor("AS", "Auth Server"))
+	d.Step("Pick a symptom").ID("triage").
+		Note("most failures fall into a handful of buckets").
+		Ref(Ref{Name: "RFC 6749", URL: "https://rfc.example/6749"}).
+		Input(Choice("expired", "scope").Named("symptom", "Symptom").WithDefault("expired"))
+	d.Step("Recover").ID("recover").
+		Arrow("App", "AS", "POST /token (refresh)").
+		DashedArrow("AS", "App", "{access_token}")
+	d.Section("How it works", "you'll be asked to pick a failure")
+
+	trace := []TraceEntry{
+		{Kind: KindStep, Title: "Pick a symptom", StepID: "triage", Visit: 1,
+			Inputs: map[string]any{"symptom": "expired"}, Next: "recover"},
+		{Kind: KindStep, Title: "Recover", StepID: "recover", Visit: 1},
+	}
+	return d, trace
+}
+
+// TestRenderDocumentJSONStaticShape verifies the static JSON envelope
+// has the expected demo block, no trace key, lowercase tags on Actors
+// and Refs, and projected step fields. Embed hosts depend on this exact
+// shape — drift here breaks every consumer.
+func TestRenderDocumentJSONStaticShape(t *testing.T) {
+	d, _ := fixtureDemoForJSON()
+
+	out := RenderDocumentJSON(RenderContext{Demo: d})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("RenderDocumentJSON produced invalid JSON: %v\n%s", err, out)
+	}
+
+	if _, ok := parsed["trace"]; ok {
+		t.Errorf("static JSON should omit \"trace\" key (embed hosts use it as a mode discriminator)")
+	}
+
+	demo, ok := parsed["demo"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing \"demo\" object in static JSON: %s", out)
+	}
+	if demo["title"] != "JSON Demo" {
+		t.Errorf("demo.title = %v, want %q", demo["title"], "JSON Demo")
+	}
+	if demo["description"] != "for JSON shape tests" {
+		t.Errorf("demo.description wrong: %v", demo["description"])
+	}
+
+	actors, ok := demo["actors"].([]any)
+	if !ok || len(actors) != 2 {
+		t.Fatalf("demo.actors not a 2-element list: %v", demo["actors"])
+	}
+	a0 := actors[0].(map[string]any)
+	if a0["id"] != "App" || a0["label"] != "Application" {
+		t.Errorf("actor[0] = %v; expected lowercase id/label tags", a0)
+	}
+	if _, hasUpper := a0["ID"]; hasUpper {
+		t.Errorf("actor[0] should not expose uppercase \"ID\" (json tags must be lowercase)")
+	}
+
+	items, ok := demo["items"].([]any)
+	if !ok || len(items) != 3 {
+		t.Fatalf("demo.items not a 3-element list: %v", demo["items"])
+	}
+	step0 := items[0].(map[string]any)
+	if step0["kind"] != "step" || step0["id"] != "triage" {
+		t.Errorf("items[0] wrong: %v", step0)
+	}
+	if step0["note"] == nil {
+		t.Errorf("items[0].note missing")
+	}
+
+	refs, ok := step0["refs"].([]any)
+	if !ok || len(refs) != 1 {
+		t.Fatalf("items[0].refs not a 1-element list: %v", step0["refs"])
+	}
+	r0 := refs[0].(map[string]any)
+	if r0["name"] != "RFC 6749" || r0["url"] != "https://rfc.example/6749" {
+		t.Errorf("ref[0] = %v; expected lowercase name/url tags", r0)
+	}
+
+	step1 := items[1].(map[string]any)
+	arrows, ok := step1["arrows"].([]any)
+	if !ok || len(arrows) != 2 {
+		t.Fatalf("items[1].arrows not a 2-element list: %v", step1["arrows"])
+	}
+	dashed := arrows[1].(map[string]any)["dashed"]
+	if dashed != true {
+		t.Errorf("arrow[1].dashed = %v, want true", dashed)
+	}
+
+	sec := items[2].(map[string]any)
+	if sec["kind"] != "section" || sec["title"] != "How it works" {
+		t.Errorf("items[2] wrong: %v", sec)
+	}
+}
+
+// TestRenderDocumentJSONInputsOmitParseFunc verifies a step's declared
+// inputs serialize via the view shim — Name/Prompt/Default — and never
+// surface the Parse closure. A bare json.Marshal of InputDef would
+// panic the encoder; this is the regression guard for that.
+func TestRenderDocumentJSONInputsOmitParseFunc(t *testing.T) {
+	d, _ := fixtureDemoForJSON()
+
+	out := RenderDocumentJSON(RenderContext{Demo: d})
+
+	if strings.Contains(out, "\"Parse\"") || strings.Contains(out, "\"parse\"") {
+		t.Errorf("JSON output should not expose the Parse closure: %s", out)
+	}
+
+	var parsed map[string]any
+	_ = json.Unmarshal([]byte(out), &parsed)
+	items := parsed["demo"].(map[string]any)["items"].([]any)
+	step0 := items[0].(map[string]any)
+	inputs, ok := step0["inputs"].([]any)
+	if !ok || len(inputs) != 1 {
+		t.Fatalf("step0.inputs not a 1-element list: %v", step0["inputs"])
+	}
+	in := inputs[0].(map[string]any)
+	if in["name"] != "symptom" || in["prompt"] != "Symptom" || in["default"] != "expired" {
+		t.Errorf("inputs[0] = %v; expected projected name/prompt/default", in)
+	}
+}
+
+// TestRenderDocumentJSONTraceRoundTrip verifies the trace section
+// survives the RenderDocumentJSON → json.Unmarshal round-trip with
+// step IDs and inputs intact. Embed hosts that re-parse the JSON output
+// depend on this contract.
+func TestRenderDocumentJSONTraceRoundTrip(t *testing.T) {
+	d, trace := fixtureDemoForJSON()
+
+	out := RenderDocumentJSON(RenderContext{Demo: d, Trace: trace})
+
+	var parsed struct {
+		Trace []TraceEntry `json:"trace"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("trace round-trip failed: %v", err)
+	}
+	if len(parsed.Trace) != 2 {
+		t.Fatalf("trace length = %d, want 2", len(parsed.Trace))
+	}
+	if parsed.Trace[0].StepID != "triage" || parsed.Trace[0].Next != "recover" {
+		t.Errorf("trace[0] wrong: %+v", parsed.Trace[0])
+	}
+	// JSON unmarshal widens numbers to float64 — assert input value
+	// survives, ignoring numeric-type drift.
+	if parsed.Trace[0].Inputs["symptom"] != "expired" {
+		t.Errorf("trace[0] inputs.symptom = %v, want \"expired\"", parsed.Trace[0].Inputs["symptom"])
+	}
+}
+
+// TestJSONFromTraceWrapperEquivalence verifies the legacy-style
+// JSONFromTrace wrapper is byte-identical to a direct RenderDocumentJSON
+// call. Pins the wrapper as a no-op shim, mirroring the markdown/html
+// wrapper-equivalence tests.
+func TestJSONFromTraceWrapperEquivalence(t *testing.T) {
+	d, trace := fixtureDemoForJSON()
+
+	viaWrapper := JSONFromTrace(d, trace)
+	viaContext := RenderDocumentJSON(RenderContext{Demo: d, Trace: trace})
+
+	if viaWrapper != viaContext {
+		t.Errorf("wrapper output differs from RenderContext output\n--- wrapper ---\n%s\n--- context ---\n%s",
+			viaWrapper, viaContext)
+	}
+}
+
+// TestDemoJSONStaticEntryPoint verifies Demo.JSON() — the static-mode
+// counterpart to Demo.Markdown() — produces the same envelope as
+// RenderDocumentJSON with no trace.
+func TestDemoJSONStaticEntryPoint(t *testing.T) {
+	d, _ := fixtureDemoForJSON()
+
+	got := d.JSON()
+	want := RenderDocumentJSON(RenderContext{Demo: d})
+
+	if got != want {
+		t.Errorf("Demo.JSON() differs from RenderDocumentJSON(static)\n--- got ---\n%s\n--- want ---\n%s",
+			got, want)
+	}
+}

--- a/render_test.go
+++ b/render_test.go
@@ -1,0 +1,273 @@
+package demokit
+
+import (
+	"strings"
+	"testing"
+)
+
+// fixtureDemoForRender builds a small demo with notes and refs so that
+// per-entry and document renders have something to look up. Returns the
+// demo plus a two-step trace covering both step and section entries.
+func fixtureDemoForRender() (*Demo, []TraceEntry) {
+	d := New("Branchy").Description("test render gen")
+	d.Step("first").ID("a").
+		Note("explanation of A").
+		Ref(Ref{Name: "RFC X", URL: "https://rfc.example/X"})
+	d.Step("second").ID("b")
+
+	trace := []TraceEntry{
+		{Kind: KindStep, Title: "first", StepID: "a", Visit: 1,
+			Inputs: map[string]any{"name": "alice"},
+			Output: "hello\nworld",
+			Next:   "b"},
+		{Kind: KindStep, Title: "second", StepID: "b", Visit: 1,
+			Status: StatusInfo, Message: "fyi"},
+	}
+	return d, trace
+}
+
+// TestMarkdownFromTraceWrapperEquivalence verifies that the legacy
+// MarkdownFromTrace function produces byte-identical output to a direct
+// RenderDocumentMD call. The wrapper exists for backwards compatibility
+// and must remain a no-op shim — any drift here is a contract break.
+func TestMarkdownFromTraceWrapperEquivalence(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+
+	viaWrapper := MarkdownFromTrace(d, trace)
+	viaContext := RenderDocumentMD(RenderContext{Demo: d, Trace: trace})
+
+	if viaWrapper != viaContext {
+		t.Errorf("wrapper output differs from RenderContext output\n--- wrapper ---\n%s\n--- context ---\n%s",
+			viaWrapper, viaContext)
+	}
+}
+
+// TestHTMLFromTraceWrapperEquivalence is the HTML mirror of the markdown
+// wrapper-equivalence test.
+func TestHTMLFromTraceWrapperEquivalence(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+
+	viaWrapper := HTMLFromTrace(d, trace)
+	viaContext := RenderDocumentHTML(RenderContext{Demo: d, Trace: trace})
+
+	if viaWrapper != viaContext {
+		t.Errorf("wrapper output differs from RenderContext output\n--- wrapper ---\n%s\n--- context ---\n%s",
+			viaWrapper, viaContext)
+	}
+}
+
+// TestRenderEntryMDIsSelfContained verifies a per-entry markdown render
+// is a fragment with no document-level chrome: it must not include the
+// "## Walkthrough" header, the deduplicated "## References" section, or
+// the title preamble. Layering enforcement — incremental renderers (WS
+// embeds) depend on per-entry being a self-contained piece.
+func TestRenderEntryMDIsSelfContained(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+	ctx := RenderContext{Demo: d, Trace: trace}
+
+	out := RenderEntryMD(ctx, trace[0], EntryOpts{StepNumber: 1})
+
+	mustNotContain := []string{
+		"# Branchy",
+		"## Walkthrough",
+		"## References",
+	}
+	for _, s := range mustNotContain {
+		if strings.Contains(out, s) {
+			t.Errorf("per-entry render should not contain %q, got:\n%s", s, out)
+		}
+	}
+
+	// Step content must still be present (heading, note, inline refs,
+	// inputs, output, jump arrow).
+	mustContain := []string{
+		"### 1. first",
+		"explanation of A",
+		"RFC X",
+		"`name` = `alice`",
+		"hello\nworld",
+		"jumped to `b`",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("per-entry render missing %q, got:\n%s", s, out)
+		}
+	}
+}
+
+// TestRenderEntryMDStepNumberIsHonored verifies that EntryOpts.StepNumber
+// controls the heading prefix. Caller-supplied numbering is the contract
+// for incremental render — without it, WS embeds couldn't display the
+// correct absolute step index when pushing one fragment at a time.
+func TestRenderEntryMDStepNumberIsHonored(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+	ctx := RenderContext{Demo: d, Trace: trace}
+
+	out42 := RenderEntryMD(ctx, trace[0], EntryOpts{StepNumber: 42})
+	if !strings.Contains(out42, "### 42. first") {
+		t.Errorf("StepNumber=42 not honored, got:\n%s", out42)
+	}
+
+	out1 := RenderEntryMD(ctx, trace[0], EntryOpts{StepNumber: 1})
+	if !strings.Contains(out1, "### 1. first") {
+		t.Errorf("StepNumber=1 not honored, got:\n%s", out1)
+	}
+
+	// Zero is the documented "no number" sentinel — heading falls back
+	// to bare title without the "N. " prefix.
+	out0 := RenderEntryMD(ctx, trace[0], EntryOpts{StepNumber: 0})
+	if !strings.Contains(out0, "### first") {
+		t.Errorf("StepNumber=0 should produce bare title heading, got:\n%s", out0)
+	}
+	if strings.Contains(out0, "### 0. first") {
+		t.Errorf("StepNumber=0 should not render the literal 0, got:\n%s", out0)
+	}
+}
+
+// TestRenderDocumentMDComposition verifies the document render is exactly
+// the concatenation of preamble + per-entry calls + refs footer. This
+// locks the layering: any future formatter divergence between
+// RenderDocumentMD and a hand-rolled composition would break this test
+// and signal that the document path has acquired logic that the per-
+// entry path can't reproduce.
+func TestRenderDocumentMDComposition(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+	ctx := RenderContext{Demo: d, Trace: trace}
+
+	got := RenderDocumentMD(ctx)
+
+	var want strings.Builder
+	want.WriteString("# Branchy\n\n")
+	want.WriteString("test render gen\n\n")
+	want.WriteString("## Walkthrough\n\n")
+	stepIdx := 0
+	for _, e := range trace {
+		opts := EntryOpts{}
+		if e.Kind == KindStep {
+			stepIdx++
+			opts.StepNumber = stepIdx
+		}
+		want.WriteString(RenderEntryMD(ctx, e, opts))
+	}
+	want.WriteString("## References\n\n")
+	want.WriteString("- [RFC X](https://rfc.example/X)\n\n")
+
+	if got != want.String() {
+		t.Errorf("document render diverges from composed entries\n--- got ---\n%s\n--- want ---\n%s",
+			got, want.String())
+	}
+}
+
+// TestRenderDocumentMDEmptyTrace verifies the empty-trace marker is
+// preserved — preserves prior MarkdownFromTrace behavior so that doc
+// generation against an empty recording produces a recognizable stub
+// rather than an empty file.
+func TestRenderDocumentMDEmptyTrace(t *testing.T) {
+	d := New("Empty")
+	got := RenderDocumentMD(RenderContext{Demo: d, Trace: nil})
+	if !strings.Contains(got, "_(empty trace)_") {
+		t.Errorf("empty-trace marker missing:\n%s", got)
+	}
+}
+
+// TestRenderEntryMDSection verifies section entries render heading and
+// body without the step-numbering scheme. Sections must work in
+// incremental render too, not only in the document loop.
+func TestRenderEntryMDSection(t *testing.T) {
+	ctx := RenderContext{}
+	entry := TraceEntry{Kind: KindSection, Title: "Setup", Body: "do this first"}
+
+	out := RenderEntryMD(ctx, entry, EntryOpts{StepNumber: 1})
+
+	if !strings.Contains(out, "### Setup") {
+		t.Errorf("section heading missing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "do this first") {
+		t.Errorf("section body missing, got:\n%s", out)
+	}
+	// Sections never get a numeric prefix — the StepNumber argument is
+	// for steps only.
+	if strings.Contains(out, "### 1. Setup") {
+		t.Errorf("section should not be numbered, got:\n%s", out)
+	}
+}
+
+// TestRenderEntryHTMLIsSelfContained verifies the HTML per-entry render
+// emits no doctype, head, body, or closing tags. Mirror of the markdown
+// layering check.
+func TestRenderEntryHTMLIsSelfContained(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+	ctx := RenderContext{Demo: d, Trace: trace}
+
+	out := RenderEntryHTML(ctx, trace[0], EntryOpts{StepNumber: 1})
+
+	mustNotContain := []string{
+		"<!doctype",
+		"<html",
+		"<head",
+		"<body",
+		"</body",
+		"</html",
+		"<style",
+	}
+	for _, s := range mustNotContain {
+		if strings.Contains(strings.ToLower(out), s) {
+			t.Errorf("per-entry HTML should not contain %q, got:\n%s", s, out)
+		}
+	}
+
+	// The fragment must still carry the step content.
+	if !strings.Contains(out, "<h2>1. first") {
+		t.Errorf("HTML per-entry missing numbered heading, got:\n%s", out)
+	}
+}
+
+// TestRenderDocumentHTMLComposition verifies the HTML document is
+// preamble + per-entry fragments + closing tags. Same layering
+// guarantee as the markdown side.
+func TestRenderDocumentHTMLComposition(t *testing.T) {
+	d, trace := fixtureDemoForRender()
+	ctx := RenderContext{Demo: d, Trace: trace}
+
+	got := RenderDocumentHTML(ctx)
+
+	// Locate the body opening — everything between it and </body> must
+	// be exactly the concatenation of per-entry fragments.
+	bodyStart := strings.Index(got, "<body>\n")
+	if bodyStart < 0 {
+		t.Fatalf("RenderDocumentHTML missing <body>: %s", got)
+	}
+	bodyContent := got[bodyStart+len("<body>\n"):]
+	bodyEnd := strings.Index(bodyContent, "</body>")
+	if bodyEnd < 0 {
+		t.Fatalf("RenderDocumentHTML missing </body>: %s", got)
+	}
+	bodyContent = bodyContent[:bodyEnd]
+
+	// Strip the h1 + description preamble that lives inside <body>.
+	h1End := strings.Index(bodyContent, "</h1>\n")
+	if h1End < 0 {
+		t.Fatalf("missing </h1> in body content: %s", bodyContent)
+	}
+	afterH1 := bodyContent[h1End+len("</h1>\n"):]
+	pEnd := strings.Index(afterH1, "</p>\n")
+	if pEnd >= 0 {
+		afterH1 = afterH1[pEnd+len("</p>\n"):]
+	}
+
+	var entries strings.Builder
+	stepIdx := 0
+	for _, e := range trace {
+		opts := EntryOpts{}
+		if e.Kind == KindStep {
+			stepIdx++
+			opts.StepNumber = stepIdx
+		}
+		entries.WriteString(RenderEntryHTML(ctx, e, opts))
+	}
+
+	if afterH1 != entries.String() {
+		t.Errorf("HTML document body diverges from composed entries\n--- doc body ---\n%s\n--- composed ---\n%s",
+			afterH1, entries.String())
+	}
+}

--- a/render_trace.go
+++ b/render_trace.go
@@ -7,113 +7,117 @@ import (
 	"strings"
 )
 
-// MarkdownFromTrace renders a recorded trace as markdown documentation.
-// Unlike Demo.Markdown (which describes the demo's static declaration),
-// this captures the actual path that was visited — useful for branching
-// graph-mode demos where one document = one playthrough.
-//
-// Pass d for title/description/refs context. Pass nil to render the
-// trace alone with no header.
-func MarkdownFromTrace(d *Demo, entries []TraceEntry) string {
+// RenderEntryMD renders a single TraceEntry as a self-contained markdown
+// fragment. No preamble, no walkthrough header, no global references
+// list — those are document-level concerns. Inline references for the
+// step are emitted in place; deduplicated aggregation happens only in
+// RenderDocumentMD.
+func RenderEntryMD(ctx RenderContext, entry TraceEntry, opts EntryOpts) string {
+	var b strings.Builder
+	switch entry.Kind {
+	case KindStep:
+		title := entry.Title
+		if title == "" {
+			title = entry.StepID
+		}
+		if opts.StepNumber > 0 {
+			fmt.Fprintf(&b, "### %d. %s", opts.StepNumber, title)
+		} else {
+			fmt.Fprintf(&b, "### %s", title)
+		}
+		if entry.Visit > 1 {
+			fmt.Fprintf(&b, " _(visit %d)_", entry.Visit)
+		}
+		b.WriteString("\n\n")
+
+		s := lookupStep(ctx.Demo, entry.StepID)
+		if s != nil && s.note != "" {
+			fmt.Fprintf(&b, "%s\n\n", s.note)
+		}
+		if s != nil && len(s.refs) > 0 {
+			b.WriteString("> **References:** ")
+			for i, ref := range s.refs {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				fmt.Fprintf(&b, "[%s](%s)", ref.Name, ref.URL)
+			}
+			b.WriteString("\n\n")
+		}
+
+		if len(entry.Inputs) > 0 {
+			b.WriteString("**Inputs:**\n\n")
+			for _, k := range sortedKeys(entry.Inputs) {
+				fmt.Fprintf(&b, "- `%s` = `%v`\n", k, entry.Inputs[k])
+			}
+			b.WriteString("\n")
+		}
+
+		if entry.Output != "" {
+			b.WriteString("```\n")
+			b.WriteString(strings.TrimRight(entry.Output, "\n"))
+			b.WriteString("\n```\n\n")
+		}
+
+		if entry.Status != StatusSuccess && (entry.Message != "" || entry.Label != "") {
+			label := entry.Label
+			if label == "" {
+				label = entry.Status.DefaultLabel()
+			}
+			fmt.Fprintf(&b, "> **%s:** %s\n\n", label, entry.Message)
+		}
+
+		if entry.Next != "" {
+			fmt.Fprintf(&b, "→ jumped to `%s`\n\n", entry.Next)
+		}
+
+	case KindSection:
+		fmt.Fprintf(&b, "### %s\n\n", entry.Title)
+		if entry.Body != "" {
+			fmt.Fprintf(&b, "%s\n\n", entry.Body)
+		}
+	}
+	return b.String()
+}
+
+// RenderDocumentMD renders the full markdown document: title +
+// description preamble, "Walkthrough" header, per-entry fragments in
+// order, and a deduplicated references footer.
+func RenderDocumentMD(ctx RenderContext) string {
 	var b strings.Builder
 
-	if d != nil {
-		fmt.Fprintf(&b, "# %s\n\n", d.title)
-		if d.description != "" {
-			fmt.Fprintf(&b, "%s\n\n", d.description)
+	if ctx.Demo != nil {
+		fmt.Fprintf(&b, "# %s\n\n", ctx.Demo.title)
+		if ctx.Demo.description != "" {
+			fmt.Fprintf(&b, "%s\n\n", ctx.Demo.description)
 		}
 	}
 
-	if len(entries) == 0 {
+	if len(ctx.Trace) == 0 {
 		b.WriteString("_(empty trace)_\n")
 		return b.String()
 	}
 
-	stepIdx := 0
-	allRefs := map[string]Ref{} // url → ref, dedup
-	stepByID := map[string]*StepDef{}
-	if d != nil {
-		for _, it := range d.items {
-			if s, ok := it.(*StepDef); ok {
-				stepByID[s.id] = s
-			}
-		}
-	}
-
 	b.WriteString("## Walkthrough\n\n")
-	for _, e := range entries {
-		switch e.Kind {
-		case KindStep:
+	stepIdx := 0
+	for _, e := range ctx.Trace {
+		opts := EntryOpts{}
+		if e.Kind == KindStep {
 			stepIdx++
-			title := e.Title
-			if title == "" {
-				title = e.StepID
-			}
-			fmt.Fprintf(&b, "### %d. %s", stepIdx, title)
-			if e.Visit > 1 {
-				fmt.Fprintf(&b, " _(visit %d)_", e.Visit)
-			}
-			b.WriteString("\n\n")
-
-			if s, ok := stepByID[e.StepID]; ok && s.note != "" {
-				fmt.Fprintf(&b, "%s\n\n", s.note)
-			}
-
-			if s, ok := stepByID[e.StepID]; ok && len(s.refs) > 0 {
-				b.WriteString("> **References:** ")
-				for i, ref := range s.refs {
-					if i > 0 {
-						b.WriteString(", ")
-					}
-					fmt.Fprintf(&b, "[%s](%s)", ref.Name, ref.URL)
-					allRefs[ref.URL] = ref
-				}
-				b.WriteString("\n\n")
-			}
-
-			if len(e.Inputs) > 0 {
-				b.WriteString("**Inputs:**\n\n")
-				for _, k := range sortedKeys(e.Inputs) {
-					fmt.Fprintf(&b, "- `%s` = `%v`\n", k, e.Inputs[k])
-				}
-				b.WriteString("\n")
-			}
-
-			if e.Output != "" {
-				b.WriteString("```\n")
-				b.WriteString(strings.TrimRight(e.Output, "\n"))
-				b.WriteString("\n```\n\n")
-			}
-
-			if e.Status != StatusSuccess && (e.Message != "" || e.Label != "") {
-				label := e.Label
-				if label == "" {
-					label = e.Status.DefaultLabel()
-				}
-				fmt.Fprintf(&b, "> **%s:** %s\n\n", label, e.Message)
-			}
-
-			if e.Next != "" {
-				fmt.Fprintf(&b, "→ jumped to `%s`\n\n", e.Next)
-			}
-
-		case KindSection:
-			fmt.Fprintf(&b, "### %s\n\n", e.Title)
-			if e.Body != "" {
-				fmt.Fprintf(&b, "%s\n\n", e.Body)
-			}
+			opts.StepNumber = stepIdx
 		}
+		b.WriteString(RenderEntryMD(ctx, e, opts))
 	}
 
-	if len(allRefs) > 0 {
+	if refs := collectRefsFromTrace(ctx); len(refs) > 0 {
 		b.WriteString("## References\n\n")
-		urls := make([]string, 0, len(allRefs))
-		for u := range allRefs {
+		urls := make([]string, 0, len(refs))
+		for u := range refs {
 			urls = append(urls, u)
 		}
 		sort.Strings(urls)
 		for _, u := range urls {
-			r := allRefs[u]
+			r := refs[u]
 			fmt.Fprintf(&b, "- [%s](%s)\n", r.Name, r.URL)
 		}
 		b.WriteString("\n")
@@ -122,14 +126,81 @@ func MarkdownFromTrace(d *Demo, entries []TraceEntry) string {
 	return b.String()
 }
 
-// HTMLFromTrace renders a recorded trace as a minimal standalone HTML
-// document. Markup is intentionally plain — callers can apply their own
-// stylesheet by post-processing or by wrapping the output.
-func HTMLFromTrace(d *Demo, entries []TraceEntry) string {
+// MarkdownFromTrace is a thin compatibility wrapper around
+// RenderDocumentMD. Prefer RenderDocumentMD in new code.
+func MarkdownFromTrace(d *Demo, entries []TraceEntry) string {
+	return RenderDocumentMD(RenderContext{Demo: d, Trace: entries})
+}
+
+// RenderEntryHTML renders a single TraceEntry as a self-contained HTML
+// fragment. No doctype, no <head>, no surrounding document chrome —
+// callers compose those in RenderDocumentHTML.
+func RenderEntryHTML(ctx RenderContext, entry TraceEntry, opts EntryOpts) string {
+	var b strings.Builder
+	switch entry.Kind {
+	case KindStep:
+		title := entry.Title
+		if title == "" {
+			title = entry.StepID
+		}
+		if opts.StepNumber > 0 {
+			fmt.Fprintf(&b, "<h2>%d. %s", opts.StepNumber, html.EscapeString(title))
+		} else {
+			fmt.Fprintf(&b, "<h2>%s", html.EscapeString(title))
+		}
+		if entry.Visit > 1 {
+			fmt.Fprintf(&b, " <small>(visit %d)</small>", entry.Visit)
+		}
+		b.WriteString("</h2>\n")
+
+		s := lookupStep(ctx.Demo, entry.StepID)
+		if s != nil && s.note != "" {
+			fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(s.note))
+		}
+
+		if len(entry.Inputs) > 0 {
+			b.WriteString("<p><strong>Inputs:</strong></p>\n<ul>\n")
+			for _, k := range sortedKeys(entry.Inputs) {
+				fmt.Fprintf(&b, "  <li><code>%s</code> = <code>%v</code></li>\n",
+					html.EscapeString(k), entry.Inputs[k])
+			}
+			b.WriteString("</ul>\n")
+		}
+
+		if entry.Output != "" {
+			fmt.Fprintf(&b, "<pre>%s</pre>\n", html.EscapeString(strings.TrimRight(entry.Output, "\n")))
+		}
+
+		if entry.Status != StatusSuccess && entry.Message != "" {
+			class := statusCSSClass(entry.Status)
+			label := entry.Label
+			if label == "" {
+				label = entry.Status.DefaultLabel()
+			}
+			fmt.Fprintf(&b, "<blockquote class=\"%s\"><strong>%s:</strong> %s</blockquote>\n",
+				class, html.EscapeString(label), html.EscapeString(entry.Message))
+		}
+
+		if entry.Next != "" {
+			fmt.Fprintf(&b, "<p class=\"jump\">→ jumped to <code>%s</code></p>\n", html.EscapeString(entry.Next))
+		}
+
+	case KindSection:
+		fmt.Fprintf(&b, "<h2>%s</h2>\n", html.EscapeString(entry.Title))
+		if entry.Body != "" {
+			fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(entry.Body))
+		}
+	}
+	return b.String()
+}
+
+// RenderDocumentHTML renders a minimal standalone HTML document built
+// from the same per-entry fragments.
+func RenderDocumentHTML(ctx RenderContext) string {
 	var b strings.Builder
 	title := "Demo"
-	if d != nil && d.title != "" {
-		title = d.title
+	if ctx.Demo != nil && ctx.Demo.title != "" {
+		title = ctx.Demo.title
 	}
 	fmt.Fprintf(&b, "<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<title>%s</title>\n",
 		html.EscapeString(title))
@@ -144,75 +215,64 @@ func HTMLFromTrace(d *Demo, entries []TraceEntry) string {
 		"</style>\n</head>\n<body>\n")
 
 	fmt.Fprintf(&b, "<h1>%s</h1>\n", html.EscapeString(title))
-	if d != nil && d.description != "" {
-		fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(d.description))
-	}
-
-	stepByID := map[string]*StepDef{}
-	if d != nil {
-		for _, it := range d.items {
-			if s, ok := it.(*StepDef); ok {
-				stepByID[s.id] = s
-			}
-		}
+	if ctx.Demo != nil && ctx.Demo.description != "" {
+		fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(ctx.Demo.description))
 	}
 
 	stepIdx := 0
-	for _, e := range entries {
-		switch e.Kind {
-		case KindStep:
+	for _, e := range ctx.Trace {
+		opts := EntryOpts{}
+		if e.Kind == KindStep {
 			stepIdx++
-			title := e.Title
-			if title == "" {
-				title = e.StepID
-			}
-			fmt.Fprintf(&b, "<h2>%d. %s", stepIdx, html.EscapeString(title))
-			if e.Visit > 1 {
-				fmt.Fprintf(&b, " <small>(visit %d)</small>", e.Visit)
-			}
-			b.WriteString("</h2>\n")
-
-			if s, ok := stepByID[e.StepID]; ok && s.note != "" {
-				fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(s.note))
-			}
-
-			if len(e.Inputs) > 0 {
-				b.WriteString("<p><strong>Inputs:</strong></p>\n<ul>\n")
-				for _, k := range sortedKeys(e.Inputs) {
-					fmt.Fprintf(&b, "  <li><code>%s</code> = <code>%v</code></li>\n",
-						html.EscapeString(k), e.Inputs[k])
-				}
-				b.WriteString("</ul>\n")
-			}
-
-			if e.Output != "" {
-				fmt.Fprintf(&b, "<pre>%s</pre>\n", html.EscapeString(strings.TrimRight(e.Output, "\n")))
-			}
-
-			if e.Status != StatusSuccess && e.Message != "" {
-				class := statusCSSClass(e.Status)
-				label := e.Label
-				if label == "" {
-					label = e.Status.DefaultLabel()
-				}
-				fmt.Fprintf(&b, "<blockquote class=\"%s\"><strong>%s:</strong> %s</blockquote>\n",
-					class, html.EscapeString(label), html.EscapeString(e.Message))
-			}
-
-			if e.Next != "" {
-				fmt.Fprintf(&b, "<p class=\"jump\">→ jumped to <code>%s</code></p>\n", html.EscapeString(e.Next))
-			}
-
-		case KindSection:
-			fmt.Fprintf(&b, "<h2>%s</h2>\n", html.EscapeString(e.Title))
-			if e.Body != "" {
-				fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(e.Body))
-			}
+			opts.StepNumber = stepIdx
 		}
+		b.WriteString(RenderEntryHTML(ctx, e, opts))
 	}
 
 	b.WriteString("</body>\n</html>\n")
 	return b.String()
+}
+
+// HTMLFromTrace is a thin compatibility wrapper around RenderDocumentHTML.
+// Prefer RenderDocumentHTML in new code.
+func HTMLFromTrace(d *Demo, entries []TraceEntry) string {
+	return RenderDocumentHTML(RenderContext{Demo: d, Trace: entries})
+}
+
+// lookupStep finds a step by ID in the demo's items list, or nil if the
+// demo is nil or the step isn't found.
+func lookupStep(d *Demo, id string) *StepDef {
+	if d == nil {
+		return nil
+	}
+	for _, it := range d.items {
+		if s, ok := it.(*StepDef); ok && s.id == id {
+			return s
+		}
+	}
+	return nil
+}
+
+// collectRefsFromTrace walks the trace and gathers every step's refs,
+// keyed by URL for deduplication.
+func collectRefsFromTrace(ctx RenderContext) map[string]Ref {
+	out := map[string]Ref{}
+	if ctx.Demo == nil {
+		return out
+	}
+	for _, e := range ctx.Trace {
+		if e.Kind != KindStep {
+			continue
+		}
+		s := lookupStep(ctx.Demo, e.StepID)
+		if s == nil {
+			continue
+		}
+		for _, ref := range s.refs {
+			out[ref.URL] = ref
+		}
+	}
+	return out
 }
 
 func statusCSSClass(s ResultStatus) string {

--- a/step.go
+++ b/step.go
@@ -2,8 +2,8 @@ package demokit
 
 // ActorDef defines a participant in the sequence diagram.
 type ActorDef struct {
-	ID    string // Short identifier used in arrows (e.g., "AS")
-	Label string // Display label (e.g., "Auth Server")
+	ID    string `json:"id"`    // Short identifier used in arrows (e.g., "AS")
+	Label string `json:"label"` // Display label (e.g., "Auth Server")
 }
 
 // Actor creates an ActorDef.
@@ -13,8 +13,8 @@ func Actor(id, label string) ActorDef {
 
 // Ref is a named reference (RFC, CVE, blog post, spec section, etc.).
 type Ref struct {
-	Name string // e.g., "RFC 7519 (JWT)" or "CVE-2015-9235"
-	URL  string // e.g., "https://www.rfc-editor.org/rfc/rfc7519"
+	Name string `json:"name"` // e.g., "RFC 7519 (JWT)" or "CVE-2015-9235"
+	URL  string `json:"url"`  // e.g., "https://www.rfc-editor.org/rfc/rfc7519"
 }
 
 // item is a union type for the ordered sequence of steps and sections.
@@ -41,8 +41,10 @@ type arrowDef struct {
 
 // ArrowView is a read-only view of an arrow for use by renderers.
 type ArrowView struct {
-	From, To, Label string
-	Dashed          bool
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Label  string `json:"label,omitempty"`
+	Dashed bool   `json:"dashed,omitempty"`
 }
 
 func (s *StepDef) isItem() {}


### PR DESCRIPTION
## Summary

Phases 1 and 2 of issue 1 (sidecar markdown + render contract). Establishes the rendering contract and the new `--doc <format>` CLI; lays the foundation that Phases 3–4 (sidecar md loader, example migration) will plug into. Also folds in a small drive-by fix for issue 6 surfaced while building this PR's tests.

### Phase 1 — render contract refactor

- Introduces `RenderContext{Demo, Trace, State}` as the canonical input to every doc renderer. Renderers are pure of these three values and never invoke `Run`. Three modes share the contract:
  - **Static** (`Trace == nil`): walks `Demo` definition only.
  - **Trace** (`Trace == loaded entries`): post-hoc record from `--record`.
  - **Live** (future): partial trace + state snapshot for WebSocket embeds. `State` is reserved with a doc comment; not consumed yet.
- Splits `MarkdownFromTrace` / `HTMLFromTrace` into:
  - `RenderEntryMD/HTML(ctx, entry, opts)` — self-contained per-entry fragments. Caller controls absolute step numbering via `EntryOpts.StepNumber`.
  - `RenderDocumentMD/HTML(ctx)` — whole-document shells that loop over per-entry calls and add document-level chrome.
- Legacy `MarkdownFromTrace` / `HTMLFromTrace` retained as one-line compat wrappers.

### Phase 2 — `--doc <format>` CLI + JSON renderer

- New flag surface: `--doc <md|html|json> [--from <trace>]`. Static and trace modes route on a clear dispatch table:

  | `--doc` | `--from`? | Renderer |
  |---|---|---|
  | `md` | no | `Demo.Markdown()` (rich static visitor) |
  | `md` | yes | `RenderDocumentMD(ctx)` (per-entry layered) |
  | `html` | no | `RenderDocumentHTML(ctx)` (minimal: title + description) |
  | `html` | yes | `RenderDocumentHTML(ctx)` |
  | `json` | no | `RenderDocumentJSON(ctx)` (definition only) |
  | `json` | yes | `RenderDocumentJSON(ctx)` (definition + trace) |
- Static-md and trace-md route to **different renderers** because they walk fundamentally different sources (declarations vs. recorded entries) — the static visitor includes a "What you'll learn" notes summary, mermaid sequence diagram, and run-it footer that don't make sense for a single recorded path.
- Legacy `--readme`, `--readme-from`, `--readme-html-from` print a one-line deprecation warning to stderr but still produce output. Slated for removal in a follow-up PR.
- New `render_json.go` — `RenderDocumentJSON`, `JSONFromTrace`, `Demo.JSON()` plus projection view structs that omit `InputDef.Parse` from the wire format.
- `ActorDef`, `Ref`, `ArrowView` gain lowercase JSON tags. Pre-1.0 module so soft-compat; flagging for downstream consumers who might've been marshaling these directly.
- Example Makefiles gain `doc-md`, `doc-html`, `doc-json` targets demonstrating the new flag. `gen-readme` switches from `--readme*` to `--doc md` — produces byte-identical READMEs (verified zero git diff).

### Drive-by fix — issue 6

`Demo.Markdown()` panicked on demos with steps but no actors (indexed `d.actors[0]` unconditionally). Fixed by skipping the entire `## Flow` section when no actors are declared — mermaid renders empty `sequenceDiagram` as a broken figure, so omission is the right behavior. Surfaced while building Phase 2's format-matrix test fixture.

### Documentation reorg

- New `ARCHITECTURE.md` absorbs the file map, render contract, doc-emit dispatch table, and gotchas.
- `CLAUDE.md` shrinks to a router: links to README/ARCHITECTURE plus a handful of "must-know" facts.
- `README.md` advertises the new `--doc <format>` flag in the run-examples block and replaces the trace-driven docs paragraph.

## Why the layering matters

The split into per-entry + whole-document is the architectural seam that lets future incremental consumers (a WebSocket embed pushing one fragment at a time) reuse the exact same renderers as the bulk doc-gen path. Without it, an embed would either need to re-implement per-entry rendering or post-process whole-document output. The composition test locks the relationship.

## Tradeoffs

- **`--doc md` static dispatches to the existing rich `Demo.Markdown()` rather than `RenderDocumentMD`.** Forcing static markdown through the trace renderer would produce `_(empty trace)_` instead of the rich mermaid + notes summary output users expect from `--readme` today. Issue 1 documents the rationale; not unifying these is deliberate.
- **JSON is single-document, not layered.** Per-entry JSON is just `json.Marshal(entry)`. No demokit wrapper buys anything; embed hosts will call `encoding/json` directly when streaming.
- **Static HTML stays minimal.** `--doc html` without `--from` produces title + description only. Adding a rich `Demo.HTML()` is deferred — the embed direction wants structured data (`--doc json`), not pre-rendered markup.
- **`InputDef` JSON shape ships only Name/Prompt/Default** in this PR. Type metadata (`type: choice, options: [...]`) lands with Phase 3 when the inputs registry is built.
- **Compat wrappers retained** (`MarkdownFromTrace`, `HTMLFromTrace`, `--readme*`). Cost is a few one-liners; cleanup PR after Phase 3.
- **`State any` reserved on `RenderContext` even though no renderer reads it.** Adding the field later would be a breaking change for renderer plugins. One field today vs. one breaking change later.

## Test plan

All tests added; no existing assertions weakened or removed.

**Phase 1 (`render_test.go`, 9 cases):**
- [x] Wrapper equivalence (md + html): `MarkdownFromTrace(d, entries)` byte-identical to `RenderDocumentMD(RenderContext{...})`
- [x] Per-entry isolation (md + html): no `## Walkthrough`, no `## References`, no preamble — must still carry step content
- [x] `EntryOpts.StepNumber` honored (42, 1, 0 = "no number" sentinel)
- [x] Composition (md + html): `RenderDocumentMD/HTML(ctx)` equals manual concatenation of preamble + per-entry calls + footer
- [x] Empty trace marker preserved
- [x] Section entries: heading + body, no numeric prefix

**Phase 2 (`render_json_test.go`, 5 cases):**
- [x] Static JSON shape: lowercase tags on actors/refs, `omitempty` on `trace`, `kind` discriminator on items
- [x] `InputDef.Parse` closure not exposed in JSON (would panic the encoder otherwise)
- [x] Trace round-trips through `RenderDocumentJSON` → `json.Unmarshal`
- [x] `JSONFromTrace` wrapper byte-equivalent to `RenderDocumentJSON`
- [x] `Demo.JSON()` matches static `RenderDocumentJSON`

**Phase 2 CLI (`cli_test.go`, 8 cases):**
- [x] `--doc md` static dispatches to `Demo.Markdown()` (asserts `sequenceDiagram`)
- [x] `--doc md --from` dispatches to `RenderDocumentMD` (asserts `## Walkthrough`)
- [x] Format×mode matrix: every `(md, html, json) × (static, trace)` produces non-empty, format-recognizable output
- [x] Unknown `--doc xyz` writes stderr error, no stdout
- [x] Missing `--from` path writes stderr error
- [x] `--readme` deprecation warning fires; output still produced
- [x] `--readme-from` deprecation warning fires
- [x] End-to-end `--doc json` via `Execute` (covers `scanOwnArgs` glue)

**Issue 6 fix (`demokit_test.go`):**
- [x] `TestMarkdownGenerationWithoutActors`: actor-less demo produces useful output, no panic, no empty `sequenceDiagram`

## Manual verification

- `go test ./...` ✓
- `go vet ./...` ✓
- `cd examples/basic && make gen-readme` produces zero diff vs main (now via `--doc md`).
- `cd examples/graph && make gen-readme` produces zero diff vs main (now via `--doc md --from`).
- `examples/graph/ --doc json --from <trace>` produces parseable JSON with both `demo` and `trace` keys.
- `examples/graph/ --readme` still works and prints the deprecation warning.

## Phases that follow

- **Phase 3**: sidecar markdown loader (`FromMarkdown` + `Bind`). Picks up the typed-input metadata work this PR deferred.
- **Phase 4**: convert `examples/graph` to sidecar form as the canary.
- **Cleanup PR**: remove `MarkdownFromTrace` / `HTMLFromTrace` wrappers and the `--readme*` flags after Phase 3 stabilizes.
