### PR TITLE
chore: remove deprecated --readme* flags and trace-wrapper functions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ This document describes how demokit is wired together internally — the files, 
 | `renderer.go` | `Renderer` interface + `PlainRenderer` (default zero-dep stdout renderer) |
 | `markdown.go` | `Demo.Markdown()` — the static-visitor markdown emitter (used by `--doc md` without `--from`) |
 | `render.go` | `RenderContext{Demo, Trace, State}` + `EntryOpts{StepNumber}` — the contract every doc renderer consumes |
-| `render_trace.go` | `RenderEntryMD/HTML`, `RenderDocumentMD/HTML`, legacy `MarkdownFromTrace`/`HTMLFromTrace` wrappers |
+| `render_trace.go` | `RenderEntryMD/HTML`, `RenderDocumentMD/HTML` |
 | `render_json.go` | `RenderDocumentJSON`, `JSONFromTrace`, `Demo.JSON()` + projection view structs |
 | `markdown_load.go` | `Demo.FromMarkdown(path)` + `Demo.FromMarkdownBytes` + `Demo.Bind(id)` — sidecar markdown loader |
 | `term.go` | Terminal width detection with stdout/stderr fallback |
@@ -172,7 +172,6 @@ Load warnings (unsupported mermaid syntax, content before the first heading) pri
 
 Static-md and trace-md route to **different renderers** because they walk fundamentally different sources (declarations vs. recorded entries) and produce intentionally different shapes. The static visitor includes a "What you'll learn" notes summary, a consolidated mermaid sequence diagram, and a Run-it footer; the trace renderer produces a per-step walkthrough with captured outputs and inputs.
 
-Legacy flags `--readme`, `--readme-from`, `--readme-html-from` still work but print a one-line deprecation warning to stderr.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ go run ./examples/graph/ --doc json --from /tmp/run.json  # JSON for embed hosts
 
 **Trace-driven docs.** `--doc md --from trace.json` renders the *actual visited path* as markdown — useful when one demo has many paths and you want to document each. `--doc html --from` does the same for HTML. `--doc json --from` produces structured data for embed hosts that want to render their own DOM. Without `--from`, `--doc md` falls back to a rich static walkthrough of the demo definition (mermaid diagram, notes summary, run-it commands).
 
-The legacy flags `--readme`, `--readme-from`, `--readme-html-from` still work but print a deprecation warning; new code should use `--doc <format>`.
-
 **Auto-advance with countdown.** `Demo.AutoAcceptAfter(5 * time.Second).ShowCountdown(true)` makes `WaitForStep` advance after a timer with a visible burn-down bar, while still letting Enter accept early. Useful for kiosks and timed demos.
 
 **Sidecar markdown (optional).** Demos with a lot of prose can move content into a companion `demo.md` file. See [`examples/dungeon/`](examples/dungeon/) for a CYOA showcase that exercises cycles, the `MaxVisits` guard, an `int` input, and Go-side state in 50 lines of markdown + 80 lines of Go. Frontmatter holds the title/description/actors; `## Heading {#id}` blocks become steps or sections; blockquotes become step notes; reserved fenced blocks (`mermaid`, `inputs`, `refs`) declare arrows, typed inputs, and references. Behavior (Run, Coalesce, custom parsers) stays in Go and attaches via `Demo.Bind(id)`:

--- a/cli_test.go
+++ b/cli_test.go
@@ -167,60 +167,6 @@ func TestEmitDocFromMissingFileErrors(t *testing.T) {
 	}
 }
 
-// TestExecuteDeprecatedReadmeWarns verifies invoking the legacy --readme
-// flag prints a deprecation warning to stderr while still producing
-// the expected static markdown on stdout. Same shape applies to
-// --readme-from and --readme-html-from.
-func TestExecuteDeprecatedReadmeWarns(t *testing.T) {
-	orig := os.Args
-	defer func() { os.Args = orig }()
-	os.Args = []string{"test", "--readme"}
-
-	d := New("Legacy").Description("d").Actors(Actor("A", "A"))
-	d.Step("only").Arrow("A", "A", "self")
-
-	out, errOut := captureStdoutStderr(t, func() { d.Execute() })
-
-	if !strings.Contains(out, "# Legacy") {
-		t.Errorf("--readme should still produce static markdown:\n%s", out)
-	}
-	if !strings.Contains(errOut, "deprecated") || !strings.Contains(errOut, "--doc md") {
-		t.Errorf("expected deprecation warning pointing at --doc md, got stderr:\n%s", errOut)
-	}
-}
-
-// TestExecuteDeprecatedReadmeFromWarns is the trace-md variant of the
-// deprecation-warning test.
-func TestExecuteDeprecatedReadmeFromWarns(t *testing.T) {
-	orig := os.Args
-	defer func() { os.Args = orig }()
-
-	tmp, err := os.CreateTemp("", "demokit-trace-*.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmp.Close()
-	defer os.Remove(tmp.Name())
-	rec := NewJSONFileRecorder(tmp.Name())
-	rec.Record(TraceEntry{Kind: KindStep, Title: "x", StepID: "x", Visit: 1})
-	if err := rec.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	os.Args = []string{"test", "--readme-from", tmp.Name()}
-	d := New("Legacy")
-	d.Step("x").ID("x")
-
-	out, errOut := captureStdoutStderr(t, func() { d.Execute() })
-
-	if !strings.Contains(out, "## Walkthrough") {
-		t.Errorf("--readme-from should still emit trace markdown:\n%s", out)
-	}
-	if !strings.Contains(errOut, "deprecated") || !strings.Contains(errOut, "--doc md --from") {
-		t.Errorf("expected deprecation warning pointing at --doc md --from, got stderr:\n%s", errOut)
-	}
-}
-
 // TestExecuteDocFlagDispatch verifies the new --doc md flag plumbing
 // works end-to-end through Execute (covers scanOwnArgs + Execute
 // dispatch glue, not just emitDoc).

--- a/demokit.go
+++ b/demokit.go
@@ -54,15 +54,12 @@ type Demo struct {
 	// CLI flag state. Populated either by RegisterFlags + the user's own
 	// FlagSet.Parse, or — if RegisterFlags is never called — by Execute's
 	// internal os.Args scan.
-	flagsRegistered     bool
-	flagNonInteractive  bool
-	flagReadme          bool
-	flagReadmeFromPath  string
-	flagReadmeHTMLPath  string
-	flagRecordPath      string
-	flagReplayPath      string
-	flagDoc             string // md|html|json (empty = not requested)
-	flagFrom            string // optional trace path used with --doc
+	flagsRegistered    bool
+	flagNonInteractive bool
+	flagRecordPath     string
+	flagReplayPath     string
+	flagDoc            string // md|html|json (empty = not requested)
+	flagFrom           string // optional trace path used with --doc
 
 	// Sidecar-markdown loader state. Errors are stored rather than
 	// returned so FromMarkdown stays chainable; surfaced at Execute.
@@ -230,12 +227,6 @@ func (d *Demo) RegisterFlags(fs *flag.FlagSet) {
 	d.flagsRegistered = true
 	fs.BoolVar(&d.flagNonInteractive, "non-interactive", false,
 		"skip pauses between steps")
-	fs.BoolVar(&d.flagReadme, "readme", false,
-		"emit static markdown for the demo to stdout and exit")
-	fs.StringVar(&d.flagReadmeFromPath, "readme-from", "",
-		"emit markdown rendered from the given trace file and exit")
-	fs.StringVar(&d.flagReadmeHTMLPath, "readme-html-from", "",
-		"emit HTML rendered from the given trace file and exit")
 	fs.StringVar(&d.flagRecordPath, "record", "",
 		"record this run to the given trace file")
 	fs.StringVar(&d.flagReplayPath, "replay", "",
@@ -256,18 +247,6 @@ func (d *Demo) scanOwnArgs(args []string) {
 		switch {
 		case arg == "--non-interactive":
 			d.flagNonInteractive = true
-		case arg == "--readme":
-			d.flagReadme = true
-		case arg == "--readme-from" && i+1 < len(args):
-			d.flagReadmeFromPath = args[i+1]
-			i++
-		case strings.HasPrefix(arg, "--readme-from="):
-			d.flagReadmeFromPath = strings.TrimPrefix(arg, "--readme-from=")
-		case arg == "--readme-html-from" && i+1 < len(args):
-			d.flagReadmeHTMLPath = args[i+1]
-			i++
-		case strings.HasPrefix(arg, "--readme-html-from="):
-			d.flagReadmeHTMLPath = strings.TrimPrefix(arg, "--readme-html-from=")
 		case arg == "--record" && i+1 < len(args):
 			d.flagRecordPath = args[i+1]
 			i++
@@ -320,26 +299,10 @@ func (d *Demo) Execute() {
 		fmt.Fprintf(os.Stderr, "demokit: %s\n", w)
 	}
 
-	// Doc-emit shortcuts exit before doing anything else. The new
-	// --doc <format> [--from <trace>] surface dispatches first; the
-	// legacy --readme* flags fall through with a deprecation warning.
+	// --doc <format> [--from <trace>] short-circuits before any
+	// run-mode setup so document generation never executes Run.
 	if d.flagDoc != "" {
 		d.emitDoc(d.flagDoc, d.flagFrom)
-		return
-	}
-	if d.flagReadme {
-		fmt.Fprintln(os.Stderr, "demokit: --readme is deprecated; use --doc md")
-		d.emitDoc("md", "")
-		return
-	}
-	if d.flagReadmeFromPath != "" {
-		fmt.Fprintln(os.Stderr, "demokit: --readme-from is deprecated; use --doc md --from <path>")
-		d.emitDoc("md", d.flagReadmeFromPath)
-		return
-	}
-	if d.flagReadmeHTMLPath != "" {
-		fmt.Fprintln(os.Stderr, "demokit: --readme-html-from is deprecated; use --doc html --from <path>")
-		d.emitDoc("html", d.flagReadmeHTMLPath)
 		return
 	}
 

--- a/demokit_test.go
+++ b/demokit_test.go
@@ -637,10 +637,12 @@ func TestReplayFlag(t *testing.T) {
 	}
 }
 
-// TestMarkdownFromTrace verifies trace-driven markdown captures the
-// visited step path (including jumps) and reaches into the demo for
-// notes and refs.
-func TestMarkdownFromTrace(t *testing.T) {
+// TestRenderDocumentMDSubstrings verifies trace-driven markdown
+// captures the visited step path (including jumps) and reaches into
+// the demo for notes and refs. The assertions are substring-based
+// because exact byte equality is covered by render_test.go's
+// composition tests; this test pins user-visible content survival.
+func TestRenderDocumentMDSubstrings(t *testing.T) {
 	demo := New("Branchy").Description("test trace doc gen")
 	demo.Step("first").ID("a").
 		Note("explanation of A").
@@ -656,7 +658,7 @@ func TestMarkdownFromTrace(t *testing.T) {
 			Status: StatusInfo, Message: "fyi"},
 	}
 
-	md := MarkdownFromTrace(demo, trace)
+	md := RenderDocumentMD(RenderContext{Demo: demo, Trace: trace})
 	checks := []string{
 		"# Branchy",
 		"test trace doc gen",
@@ -673,13 +675,16 @@ func TestMarkdownFromTrace(t *testing.T) {
 	}
 	for _, c := range checks {
 		if !strings.Contains(md, c) {
-			t.Errorf("MarkdownFromTrace missing %q", c)
+			t.Errorf("RenderDocumentMD missing %q", c)
 		}
 	}
 }
 
-// TestHTMLFromTrace verifies HTML output structure and escaping.
-func TestHTMLFromTrace(t *testing.T) {
+// TestRenderDocumentHTMLEscaping verifies HTML output structure and
+// that user-supplied content (description, output) is escaped before
+// being written into the document body. A regression here is a
+// genuine XSS-shaped vulnerability, so this stays as a focused test.
+func TestRenderDocumentHTMLEscaping(t *testing.T) {
 	demo := New("HTML Demo").Description("a <script>alert(1)</script>")
 	demo.Step("step").ID("s")
 
@@ -687,12 +692,11 @@ func TestHTMLFromTrace(t *testing.T) {
 		{Kind: KindStep, Title: "step", StepID: "s", Visit: 1,
 			Inputs: map[string]any{"x": "<b>"}, Output: "<not html>"},
 	}
-	out := HTMLFromTrace(demo, trace)
+	out := RenderDocumentHTML(RenderContext{Demo: demo, Trace: trace})
 
 	if !strings.Contains(out, "<!doctype html>") {
 		t.Error("missing doctype")
 	}
-	// Description must be escaped, not raw.
 	if strings.Contains(out, "<script>alert(1)</script>") {
 		t.Error("description not escaped")
 	}

--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run demo runsmooth runquiet demo-quiet readme record replay readme-from readme-html-from gen-readme doc-md doc-html doc-json
+.PHONY: run demo runsmooth runquiet demo-quiet record replay gen-readme doc-md doc-html doc-json
 
 TRACE := /tmp/demokit-basic-trace.json
 
@@ -22,10 +22,6 @@ runquiet:
 demo-quiet:
 	go run . --tui --non-interactive
 
-# Generate README from demo definitions (linear, mermaid)
-readme:
-	go run . --readme
-
 # Record a non-interactive run to $(TRACE)
 record:
 	go run . --non-interactive --record $(TRACE)
@@ -35,22 +31,12 @@ record:
 replay: record
 	go run . --replay $(TRACE)
 
-# Render markdown of the recorded path (captures actual visited steps,
-# inputs, and outputs — different from --readme which is static)
-readme-from: record
-	go run . --readme-from $(TRACE)
-
-# Same, but as standalone HTML
-readme-html-from: record
-	go run . --readme-html-from $(TRACE)
-
-# Regenerate this example's README.md from the demo definition
+# Regenerate this example's README.md from the static demo definition.
 gen-readme:
 	go run . --doc md > README.md
 	@echo "Wrote README.md"
 
-# New --doc <format> surface (replaces --readme*; old flags still work
-# but warn on stderr).
+# Documentation outputs.
 doc-md:
 	go run . --doc md
 
@@ -61,3 +47,13 @@ doc-html:
 # only (no trace).
 doc-json:
 	go run . --doc json
+
+# Trace-driven documentation outputs.
+doc-md-from: record
+	go run . --doc md --from $(TRACE)
+
+doc-html-from: record
+	go run . --doc html --from $(TRACE)
+
+doc-json-from: record
+	go run . --doc json --from $(TRACE)

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -6,16 +6,16 @@
 //   - Sections for narration
 //   - Sequence-diagram arrows between named actors
 //   - Recording, replay, and trace-driven docs (--record / --replay /
-//     --readme-from)
+//     --doc md --from)
 //
 // Run modes:
 //
-//	go run ./examples/basic/                     # interactive
-//	go run ./examples/basic/ --tui               # styled boxes
-//	go run ./examples/basic/ --smooth            # plain w/ smooth scroll
-//	go run ./examples/basic/ --non-interactive   # default-input run
+//	go run ./examples/basic/                              # interactive
+//	go run ./examples/basic/ --tui                        # styled boxes
+//	go run ./examples/basic/ --smooth                     # plain w/ smooth scroll
+//	go run ./examples/basic/ --non-interactive            # default-input run
 //	go run ./examples/basic/ --record /tmp/r.json
-//	go run ./examples/basic/ --readme-from /tmp/r.json
+//	go run ./examples/basic/ --doc md --from /tmp/r.json
 package main
 
 import (

--- a/examples/graph/Makefile
+++ b/examples/graph/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run demo runquiet record replay readme-from readme-html-from gen-readme doc-md doc-html doc-json
+.PHONY: run demo runquiet record replay gen-readme doc-md doc-html doc-json
 
 TRACE := /tmp/demokit-graph-trace.json
 
@@ -25,23 +25,13 @@ record:
 replay: record
 	go run . --replay $(TRACE)
 
-# Render markdown of the recorded path. This is the canonical way to
-# document a branching demo — one trace = one story.
-readme-from: record
-	go run . --readme-from $(TRACE)
-
-# Same, but as standalone HTML.
-readme-html-from: record
-	go run . --readme-html-from $(TRACE)
-
 # Regenerate this example's README.md from a recorded trace.
 # The default-input run captures the "expired token → refresh" branch.
 gen-readme: record
 	go run . --doc md --from $(TRACE) > README.md
 	@echo "Wrote README.md"
 
-# New --doc <format> surface (replaces --readme*; old flags still work
-# but warn on stderr).
+# Trace-driven documentation outputs.
 doc-md: record
 	go run . --doc md --from $(TRACE)
 

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -5,16 +5,16 @@
 //   - Declarative inputs with Choice() and sticky-on-retry defaults
 //   - AutoAcceptAfter countdown for time-based advancement
 //   - Recording (--record path.json) and replay (--replay path.json)
-//   - Trace-driven docs (--readme-from path.json, --readme-html-from path.json)
+//   - Trace-driven docs (--doc md --from path.json, --doc html --from path.json)
 //
 // Try:
 //
-//	go run ./examples/graph/                                  # interactive
-//	go run ./examples/graph/ --tui                            # TUI box style
-//	go run ./examples/graph/ --record /tmp/run.json           # save a trace
-//	go run ./examples/graph/ --replay /tmp/run.json           # replay it
-//	go run ./examples/graph/ --readme-from /tmp/run.json      # markdown doc
-//	go run ./examples/graph/ --readme-html-from /tmp/run.json # html doc
+//	go run ./examples/graph/                                    # interactive
+//	go run ./examples/graph/ --tui                              # TUI box style
+//	go run ./examples/graph/ --record /tmp/run.json             # save a trace
+//	go run ./examples/graph/ --replay /tmp/run.json             # replay it
+//	go run ./examples/graph/ --doc md --from /tmp/run.json      # markdown doc
+//	go run ./examples/graph/ --doc html --from /tmp/run.json    # html doc
 package main
 
 import (

--- a/markdown.go
+++ b/markdown.go
@@ -7,8 +7,9 @@ import (
 
 // Markdown generates static linear documentation from the demo
 // definition. This is the canonical output for non-branching demos
-// (run with --readme to regenerate). For branching demos, prefer
-// MarkdownFromTrace which captures the actual visited path.
+// (run with --doc md to regenerate). For branching demos, prefer
+// RenderDocumentMD which captures the actual visited path from a
+// recorded trace (--doc md --from <trace>).
 func (d *Demo) Markdown() string {
 	var b strings.Builder
 

--- a/render_json.go
+++ b/render_json.go
@@ -77,8 +77,8 @@ func RenderDocumentJSON(ctx RenderContext) string {
 	return buf.String()
 }
 
-// JSONFromTrace is the trace-mode wrapper, mirroring MarkdownFromTrace
-// and HTMLFromTrace.
+// JSONFromTrace is the trace-mode wrapper, mirroring RenderDocumentJSON
+// for callers that prefer the (demo, entries) shape.
 func JSONFromTrace(d *Demo, entries []TraceEntry) string {
 	return RenderDocumentJSON(RenderContext{Demo: d, Trace: entries})
 }

--- a/render_test.go
+++ b/render_test.go
@@ -26,36 +26,6 @@ func fixtureDemoForRender() (*Demo, []TraceEntry) {
 	return d, trace
 }
 
-// TestMarkdownFromTraceWrapperEquivalence verifies that the legacy
-// MarkdownFromTrace function produces byte-identical output to a direct
-// RenderDocumentMD call. The wrapper exists for backwards compatibility
-// and must remain a no-op shim — any drift here is a contract break.
-func TestMarkdownFromTraceWrapperEquivalence(t *testing.T) {
-	d, trace := fixtureDemoForRender()
-
-	viaWrapper := MarkdownFromTrace(d, trace)
-	viaContext := RenderDocumentMD(RenderContext{Demo: d, Trace: trace})
-
-	if viaWrapper != viaContext {
-		t.Errorf("wrapper output differs from RenderContext output\n--- wrapper ---\n%s\n--- context ---\n%s",
-			viaWrapper, viaContext)
-	}
-}
-
-// TestHTMLFromTraceWrapperEquivalence is the HTML mirror of the markdown
-// wrapper-equivalence test.
-func TestHTMLFromTraceWrapperEquivalence(t *testing.T) {
-	d, trace := fixtureDemoForRender()
-
-	viaWrapper := HTMLFromTrace(d, trace)
-	viaContext := RenderDocumentHTML(RenderContext{Demo: d, Trace: trace})
-
-	if viaWrapper != viaContext {
-		t.Errorf("wrapper output differs from RenderContext output\n--- wrapper ---\n%s\n--- context ---\n%s",
-			viaWrapper, viaContext)
-	}
-}
-
 // TestRenderEntryMDIsSelfContained verifies a per-entry markdown render
 // is a fragment with no document-level chrome: it must not include the
 // "## Walkthrough" header, the deduplicated "## References" section, or
@@ -159,9 +129,8 @@ func TestRenderDocumentMDComposition(t *testing.T) {
 }
 
 // TestRenderDocumentMDEmptyTrace verifies the empty-trace marker is
-// preserved — preserves prior MarkdownFromTrace behavior so that doc
-// generation against an empty recording produces a recognizable stub
-// rather than an empty file.
+// preserved so that doc generation against an empty recording produces
+// a recognizable stub rather than an empty file.
 func TestRenderDocumentMDEmptyTrace(t *testing.T) {
 	d := New("Empty")
 	got := RenderDocumentMD(RenderContext{Demo: d, Trace: nil})

--- a/render_trace.go
+++ b/render_trace.go
@@ -126,12 +126,6 @@ func RenderDocumentMD(ctx RenderContext) string {
 	return b.String()
 }
 
-// MarkdownFromTrace is a thin compatibility wrapper around
-// RenderDocumentMD. Prefer RenderDocumentMD in new code.
-func MarkdownFromTrace(d *Demo, entries []TraceEntry) string {
-	return RenderDocumentMD(RenderContext{Demo: d, Trace: entries})
-}
-
 // RenderEntryHTML renders a single TraceEntry as a self-contained HTML
 // fragment. No doctype, no <head>, no surrounding document chrome —
 // callers compose those in RenderDocumentHTML.
@@ -231,12 +225,6 @@ func RenderDocumentHTML(ctx RenderContext) string {
 
 	b.WriteString("</body>\n</html>\n")
 	return b.String()
-}
-
-// HTMLFromTrace is a thin compatibility wrapper around RenderDocumentHTML.
-// Prefer RenderDocumentHTML in new code.
-func HTMLFromTrace(d *Demo, entries []TraceEntry) string {
-	return RenderDocumentHTML(RenderContext{Demo: d, Trace: entries})
 }
 
 // lookupStep finds a step by ID in the demo's items list, or nil if the


### PR DESCRIPTION
## Summary

Cleanup of the deprecation paths introduced in PR #4 and superseded by the `--doc <format>` surface. Issue #1 closed; this PR is the housekeeping that follows.

## What's removed

| Surface | Replacement |
|---|---|
| `--readme` flag | `--doc md` |
| `--readme-from <path>` flag | `--doc md --from <path>` |
| `--readme-html-from <path>` flag | `--doc html --from <path>` |
| `MarkdownFromTrace(d, entries)` function | `RenderDocumentMD(RenderContext{Demo: d, Trace: entries})` |
| `HTMLFromTrace(d, entries)` function | `RenderDocumentHTML(RenderContext{Demo: d, Trace: entries})` |
| Stderr deprecation warnings on the legacy flags | (no longer needed) |

Also dropped: the wrapper-equivalence tests (no wrappers to assert against), the deprecation-warning tests, the legacy `readme*` Makefile targets in `examples/basic/` and `examples/graph/`, and the doc lines that mentioned the legacy flags.

## What's preserved

- `TestMarkdownFromTrace` migrated → `TestRenderDocumentMDSubstrings` — same substring-presence assertions, calls `RenderDocumentMD` directly.
- `TestHTMLFromTrace` migrated → `TestRenderDocumentHTMLEscaping` — same XSS-shaped escape check, calls `RenderDocumentHTML` directly. (The escape behavior matters and deserved a focused test.)

## Verification

- `go test ./...` clean (40 insertions, 187 deletions; full suite green)
- `go vet ./...` clean
- `cd examples/basic && make gen-readme` and `cd examples/graph && make gen-readme` both regenerate the existing READMEs byte-identically — confirms no rendering behavior changed
- `--doc md` / `--doc md --from` / `--doc html --from` / `--doc json` all still work end-to-end

## Follow-ups (not in this PR)

- Per-step declarative metadata (`meta` fenced block) — file when there's a concrete need
- Issue #5 (streaming output) — next chunk of work
