### PR TITLE
feat: stream step output live + capture stderr (closes #5)

### DIFF
--- a/demokit.go
+++ b/demokit.go
@@ -445,8 +445,25 @@ walk:
 
 			var output string
 			var result *StepResult
+			// Tee output chunks into the renderer in real time when it
+			// supports streaming. The trace and recorder still receive
+			// the full captured string regardless. Snapshot os.Stdout
+			// before captureOutput redirects it so the chunk callback
+			// can write to the user's actual terminal — writing to
+			// os.Stdout from the drain goroutine would loop the bytes
+			// back into the capture pipe.
+			var onChunk func([]byte)
+			streaming := false
+			if sr, ok := r.(StreamingRenderer); ok {
+				streaming = true
+				stepNum := totalVisits
+				originalStdout := os.Stdout
+				onChunk = func(chunk []byte) {
+					sr.StreamOutput(stepNum, chunk, originalStdout)
+				}
+			}
 			if v.runFn != nil {
-				output, result = captureOutput(v.runFn, ctx)
+				output, result = captureOutput(v.runFn, ctx, onChunk)
 			}
 
 			// In replay mode, the recorded path wins over what the user's
@@ -459,7 +476,14 @@ walk:
 				result.Next = replayEntry.Next
 			}
 
-			r.RenderResult(totalVisits, output, result)
+			// When the body has already been streamed, hand RenderResult
+			// an empty output so it doesn't double-print. The trace
+			// entry below still carries the full captured string.
+			displayOutput := output
+			if streaming {
+				displayOutput = ""
+			}
+			r.RenderResult(totalVisits, displayOutput, result)
 
 			entry := TraceEntry{
 				Kind:   KindStep,

--- a/demokit_test.go
+++ b/demokit_test.go
@@ -56,7 +56,7 @@ func TestCaptureOutputSuccess(t *testing.T) {
 	out, result := captureOutput(func(ctx StepContext) *StepResult {
 		fmt.Print("hello world")
 		return nil
-	}, StepContext{})
+	}, StepContext{}, nil)
 	if result != nil {
 		t.Fatalf("expected nil result, got %+v", result)
 	}
@@ -66,7 +66,7 @@ func TestCaptureOutputSuccess(t *testing.T) {
 }
 
 func TestCaptureOutputEmpty(t *testing.T) {
-	out, result := captureOutput(func(ctx StepContext) *StepResult { return nil }, StepContext{})
+	out, result := captureOutput(func(ctx StepContext) *StepResult { return nil }, StepContext{}, nil)
 	if result != nil {
 		t.Fatalf("expected nil result, got %+v", result)
 	}
@@ -79,7 +79,7 @@ func TestCaptureOutputError(t *testing.T) {
 	out, result := captureOutput(func(ctx StepContext) *StepResult {
 		fmt.Print("partial output")
 		return Errf("step failed")
-	}, StepContext{})
+	}, StepContext{}, nil)
 	if result == nil || result.Status != StatusError {
 		t.Fatalf("expected error result, got %+v", result)
 	}
@@ -95,7 +95,7 @@ func TestCaptureOutputPanic(t *testing.T) {
 	out, result := captureOutput(func(ctx StepContext) *StepResult {
 		fmt.Print("before panic")
 		panic("boom")
-	}, StepContext{})
+	}, StepContext{}, nil)
 	if result == nil || result.Status != StatusError {
 		t.Fatalf("expected error result from panic, got %+v", result)
 	}
@@ -110,7 +110,7 @@ func TestCaptureOutputPanic(t *testing.T) {
 func TestCaptureOutputWarning(t *testing.T) {
 	_, result := captureOutput(func(ctx StepContext) *StepResult {
 		return Warn("heads up")
-	}, StepContext{})
+	}, StepContext{}, nil)
 	if result == nil || result.Status != StatusWarning {
 		t.Fatalf("expected warning result, got %+v", result)
 	}
@@ -122,7 +122,7 @@ func TestCaptureOutputWarning(t *testing.T) {
 func TestCaptureOutputInfo(t *testing.T) {
 	_, result := captureOutput(func(ctx StepContext) *StepResult {
 		return Info("FYI")
-	}, StepContext{})
+	}, StepContext{}, nil)
 	if result == nil || result.Status != StatusInfo {
 		t.Fatalf("expected info result, got %+v", result)
 	}

--- a/examples/dungeon/main.go
+++ b/examples/dungeon/main.go
@@ -51,6 +51,59 @@ var honorifics = []string{
 	"Surprisingly Tall",
 }
 
+// ANSI escape codes for the dragon scene. Plain text terminals
+// render these as literal characters; modern TTYs interpret them.
+// The streaming demo prints them as-is — TTY-stripping for piped
+// output is a future enhancement (would key off term.IsTerminal).
+const (
+	ansiReset      = "\033[0m"
+	ansiDim        = "\033[2m"
+	ansiBold       = "\033[1m"
+	ansiCyan       = "\033[36m"
+	ansiBoldYellow = "\033[1;33m"
+	ansiRed        = "\033[31m"
+	ansiBoldRed    = "\033[1;31m"
+	ansiGold       = "\033[38;5;220m" // 256-color: warm gold
+	ansiSmoke      = "\033[38;5;245m" // 256-color: medium gray
+	ansiScale      = "\033[38;5;88m"  // 256-color: deep crimson
+)
+
+// dragonScene is revealed line-by-line in the dragon step, exercising
+// streaming output: each line prints with a brief sleep so the
+// silhouette assembles in front of the user instead of dumping all
+// at once when Run returns. Three movements: approach (stalactites),
+// reveal (the dragon itself), aftermath (treasure, magazine, "lunch").
+var dragonScene = []string{
+	ansiSmoke + "      The cave widens. Your torch flickers and gives up entirely." + ansiReset,
+	ansiSmoke + "      Something else takes over the lighting." + ansiReset,
+	"",
+	ansiCyan + "                    /\\        /\\        /\\        /\\" + ansiReset,
+	ansiCyan + "                   /  \\      /  \\      /  \\      /  \\" + ansiReset,
+	ansiCyan + "                  /    \\    /    \\    /    \\    /    \\" + ansiReset,
+	ansiCyan + "                 /______\\  /______\\  /______\\  /______\\" + ansiReset,
+	"",
+	ansiScale + "                              \\||/" + ansiReset,
+	ansiScale + "                              |  " + ansiBoldYellow + "@" + ansiScale + "___oo" + ansiReset,
+	ansiScale + "                    /\\  /\\   / (__,,,,|" + ansiReset,
+	ansiScale + "                   ) /^\\) ^\\/ _)" + ansiReset,
+	ansiScale + "                   )   /^\\/   _)" + ansiReset,
+	ansiScale + "                   )   _ /  / _)" + ansiReset,
+	ansiScale + "                  /\\  )/\\/ ||  | )_)" + ansiReset,
+	ansiScale + "                 <  >      |(,,) )__)" + ansiReset,
+	ansiScale + "                  ||      /    \\)___)\\" + ansiReset,
+	ansiScale + "                  | \\____(      )___) )___" + ansiReset,
+	ansiScale + "                   \\______(_______;;; __;;;" + ansiReset,
+	"",
+	ansiGold + "      Around him: rivers of gold, sparkling like dirty fountains." + ansiReset,
+	ansiDim + "      A magazine titled \"" + ansiReset + ansiBold + "Hoard Quarterly" + ansiReset + ansiDim + "\" rests across one claw." + ansiReset,
+	ansiDim + "      He licks a page with a forked tongue and turns it." + ansiReset,
+	ansiDim + "      The article is a six-page spread on adamantine polishing." + ansiReset,
+	"",
+	ansiBoldYellow + "      Slowly, two enormous yellow eyes lift to meet yours." + ansiReset,
+	"",
+	ansiBoldRed + "      \"Oh good,\"" + ansiReset + ansiRed + " he says, conversationally. " + ansiBoldRed + "\"Lunch.\"" + ansiReset,
+}
+
 // demoMarkdown is the sidecar content. Using go:embed makes the binary
 // self-contained — it works regardless of the invoker's cwd, and
 // `go install` produces a single-file binary that ships its own demo.
@@ -168,6 +221,18 @@ func main() {
 	// --- the dragon (state-driven outcome) ---
 
 	demo.Bind("dragon").Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		// Reveal the lair scene line by line. Each Println streams
+		// out as soon as it's written (PlainRenderer / TUI both
+		// implement StreamingRenderer); the user sees the dragon
+		// assemble in real time instead of getting a wall-of-text
+		// dump after Run returns.
+		for _, line := range dragonScene {
+			fmt.Println(line)
+			time.Sleep(80 * time.Millisecond)
+		}
+		// Beat for dramatic effect before the verdict.
+		time.Sleep(700 * time.Millisecond)
+
 		if hasRing {
 			return &demokit.StepResult{Next: "victory"}
 		}

--- a/renderer.go
+++ b/renderer.go
@@ -3,6 +3,7 @@ package demokit
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -34,6 +35,31 @@ type Renderer interface {
 	// when the step has at least one input. Implementations should
 	// re-prompt on Parse error and respect each input's Default.
 	Prompt(stepID string, inputs []InputDef) map[string]any
+}
+
+// StreamingRenderer is implemented by renderers that can show step
+// output incrementally while Run is still executing. demokit detects
+// this via type assertion: when the renderer implements StreamOutput,
+// captureOutput tees each chunk into the renderer in roughly real
+// time. RenderResult is then called with output == "" because the
+// body has already appeared on screen.
+//
+// Renderers that don't implement StreamingRenderer get the buffered
+// path: the full captured output is passed to RenderResult after Run
+// returns.
+type StreamingRenderer interface {
+	Renderer
+	// StreamOutput is called for each byte chunk a step's Run writes
+	// to stdout or stderr while it's still executing. May be invoked
+	// from a goroutine other than the one driving Render*; renderers
+	// must serialize their own state if needed.
+	//
+	// out is the writer to emit chunks to — the user's actual stdout,
+	// captured before captureOutput redirected it. Writing to
+	// os.Stdout directly would loop the chunks back into the capture
+	// pipe. stepNum is the absolute visit count (matching what
+	// RenderStep received); implementations are free to ignore it.
+	StreamOutput(stepNum int, chunk []byte, out io.Writer)
 }
 
 // --- PlainRenderer: default text-only renderer (zero dependencies) ---
@@ -196,6 +222,16 @@ func (r *PlainRenderer) RenderSection(section *SectionDef) {
 
 func (r *PlainRenderer) RenderDone() {
 	r.printLine("=== Done ===\n")
+}
+
+// StreamOutput writes a chunk of step output as it's produced. The
+// out writer is the user's actual stdout (captured by Execute before
+// captureOutput redirected os.Stdout into the capture pipe); writing
+// to os.Stdout directly here would loop straight back into the pipe.
+// PlainRenderer doesn't style or buffer per-chunk — this is a
+// passthrough that lets long-running steps print live.
+func (r *PlainRenderer) StreamOutput(_ int, chunk []byte, out io.Writer) {
+	out.Write(chunk)
 }
 
 func (r *PlainRenderer) WaitForStep(opts WaitOpts) {

--- a/term.go
+++ b/term.go
@@ -29,10 +29,19 @@ func isTerminal() bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
-// captureOutput redirects stdout while fn runs and returns what was written.
-// Panics are recovered and converted to a StepResult with StatusError.
-func captureOutput(fn func(StepContext) *StepResult, ctx StepContext) (output string, result *StepResult) {
-	old := os.Stdout
+// captureOutput runs fn with both os.Stdout AND os.Stderr redirected
+// through a single pipe so a step's prints — wherever they go —
+// land in the rendered demo body. Returns the captured output and
+// the StepResult; panics in fn become a StatusError result.
+//
+// If onChunk is non-nil, it's invoked for each byte chunk drained
+// from the pipe in roughly real time. Renderers that implement
+// StreamingRenderer hook in here so the user sees output as it's
+// produced rather than waiting for fn to return. The captured
+// output (returned string) still contains everything regardless of
+// onChunk — the chunk callback tees, it doesn't replace the buffer.
+func captureOutput(fn func(StepContext) *StepResult, ctx StepContext, onChunk func([]byte)) (output string, result *StepResult) {
+	oldOut, oldErr := os.Stdout, os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
 		// If pipe fails, just run normally — don't block the demo.
@@ -40,11 +49,34 @@ func captureOutput(fn func(StepContext) *StepResult, ctx StepContext) (output st
 		return "", result
 	}
 	os.Stdout = w
+	os.Stderr = w
 
 	done := make(chan string)
 	go func() {
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		// Read in chunks so onChunk fires in something like real time.
+		// io.Copy alone would also work, but it gives us no hook to
+		// observe each block as it arrives.
+		raw := make([]byte, 4096)
+		for {
+			n, err := r.Read(raw)
+			if n > 0 {
+				buf.Write(raw[:n])
+				if onChunk != nil {
+					// Copy the slice — the callback may outlive this
+					// loop iteration and `raw` is reused on the next read.
+					cp := make([]byte, n)
+					copy(cp, raw[:n])
+					onChunk(cp)
+				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					_ = err // pipe closed; surface nothing
+				}
+				break
+			}
+		}
 		done <- buf.String()
 	}()
 
@@ -61,7 +93,8 @@ func captureOutput(fn func(StepContext) *StepResult, ctx StepContext) (output st
 	}()
 
 	w.Close()
-	os.Stdout = old
+	os.Stdout = oldOut
+	os.Stderr = oldErr
 	output = <-done
 	return output, result
 }

--- a/term_test.go
+++ b/term_test.go
@@ -1,0 +1,201 @@
+package demokit
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestCaptureOutputCapturesStderr verifies that bytes written to
+// os.Stderr inside a step's Run are captured the same way bytes
+// written to os.Stdout are. The pre-streaming version of
+// captureOutput only redirected stdout, so an `fmt.Fprintln(os.Stderr, ...)`
+// or a default `log.Println` (which uses stderr) leaked straight to
+// the terminal — different placement than `fmt.Println`. Now both
+// flow through the same merged pipe.
+func TestCaptureOutputCapturesStderr(t *testing.T) {
+	out, _ := captureOutput(func(ctx StepContext) *StepResult {
+		fmt.Fprintln(os.Stderr, "from stderr")
+		return nil
+	}, StepContext{}, nil)
+
+	if !strings.Contains(out, "from stderr") {
+		t.Errorf("captured output missing stderr text: %q", out)
+	}
+}
+
+// TestCaptureOutputInterleavesStdoutStderr verifies the merged-pipe
+// approach preserves the order of writes across stdout and stderr.
+// A two-pass concat (read stdout fully, then stderr) would lose this;
+// the single shared writer end keeps things in source order.
+func TestCaptureOutputInterleavesStdoutStderr(t *testing.T) {
+	out, _ := captureOutput(func(ctx StepContext) *StepResult {
+		fmt.Fprint(os.Stdout, "a\n")
+		fmt.Fprint(os.Stderr, "b\n")
+		fmt.Fprint(os.Stdout, "c\n")
+		return nil
+	}, StepContext{}, nil)
+
+	idxA := strings.Index(out, "a")
+	idxB := strings.Index(out, "b")
+	idxC := strings.Index(out, "c")
+	if idxA < 0 || idxB < 0 || idxC < 0 {
+		t.Fatalf("missing one of a/b/c in output: %q", out)
+	}
+	if !(idxA < idxB && idxB < idxC) {
+		t.Errorf("interleaving lost — got order indexes a=%d b=%d c=%d in %q", idxA, idxB, idxC, out)
+	}
+}
+
+// TestCaptureOutputOnChunkCallbackFires verifies onChunk is invoked
+// with the bytes a step's Run produces, in roughly real time. Verifies
+// the streaming primitive at the captureOutput level — independent of
+// any renderer integration.
+func TestCaptureOutputOnChunkCallbackFires(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		chunks []string
+	)
+	onChunk := func(chunk []byte) {
+		mu.Lock()
+		chunks = append(chunks, string(chunk))
+		mu.Unlock()
+	}
+
+	out, _ := captureOutput(func(ctx StepContext) *StepResult {
+		fmt.Print("hello ")
+		fmt.Print("world")
+		return nil
+	}, StepContext{}, onChunk)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(chunks) == 0 {
+		t.Fatalf("onChunk never fired; full output was %q", out)
+	}
+	joined := strings.Join(chunks, "")
+	if joined != "hello world" {
+		t.Errorf("chunks reassembled to %q, want %q", joined, "hello world")
+	}
+	if out != "hello world" {
+		t.Errorf("captured buffer %q diverges from streamed chunks %q", out, joined)
+	}
+}
+
+// streamingTestRenderer extends recordingRenderer with StreamOutput
+// support. Used to verify the streaming dispatch path.
+type streamingTestRenderer struct {
+	recordingRenderer
+	mu     sync.Mutex
+	chunks []string
+}
+
+func (r *streamingTestRenderer) StreamOutput(_ int, chunk []byte, _ io.Writer) {
+	r.mu.Lock()
+	r.chunks = append(r.chunks, string(chunk))
+	r.mu.Unlock()
+}
+
+// resultRecordingRenderer captures the output value RenderResult sees,
+// so tests can assert the streaming path passes "" while the buffered
+// path passes the full text.
+type resultRecordingRenderer struct {
+	recordingRenderer
+	lastOutput string
+}
+
+func (r *resultRecordingRenderer) RenderResult(num int, out string, res *StepResult) {
+	r.recordingRenderer.RenderResult(num, out, res)
+	r.lastOutput = out
+}
+
+type streamingResultRenderer struct {
+	resultRecordingRenderer
+	mu     sync.Mutex
+	chunks []string
+}
+
+func (r *streamingResultRenderer) StreamOutput(_ int, chunk []byte, _ io.Writer) {
+	r.mu.Lock()
+	r.chunks = append(r.chunks, string(chunk))
+	r.mu.Unlock()
+}
+
+// TestExecuteStreamingRendererReceivesChunks verifies that when a
+// renderer implements StreamingRenderer, a step's Run output is
+// teed into StreamOutput in roughly real time AND RenderResult is
+// invoked with output == "" so the body isn't double-printed.
+func TestExecuteStreamingRendererReceivesChunks(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"test", "--non-interactive"}
+
+	r := &streamingResultRenderer{}
+	demo := New("Stream").WithRenderer(r)
+	demo.Step("emit").ID("emit").Run(func(ctx StepContext) *StepResult {
+		fmt.Print("live output")
+		return nil
+	})
+	demo.Execute()
+
+	r.mu.Lock()
+	gotChunks := strings.Join(r.chunks, "")
+	r.mu.Unlock()
+
+	if gotChunks != "live output" {
+		t.Errorf("streamed chunks = %q, want %q", gotChunks, "live output")
+	}
+	if r.lastOutput != "" {
+		t.Errorf("RenderResult should receive empty output when streaming, got %q", r.lastOutput)
+	}
+}
+
+// TestExecuteNonStreamingRendererBuffers verifies the legacy path
+// for renderers that don't implement StreamingRenderer: the captured
+// output flows in full to RenderResult, no streaming.
+func TestExecuteNonStreamingRendererBuffers(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"test", "--non-interactive"}
+
+	r := &resultRecordingRenderer{}
+	demo := New("Buffer").WithRenderer(r)
+	demo.Step("emit").ID("emit").Run(func(ctx StepContext) *StepResult {
+		fmt.Print("buffered output")
+		return nil
+	})
+	demo.Execute()
+
+	if r.lastOutput != "buffered output" {
+		t.Errorf("buffered RenderResult output = %q, want %q", r.lastOutput, "buffered output")
+	}
+}
+
+// TestExecuteStreamingTraceCapturesFullOutput verifies that even when
+// a step streams live, the trace recorder still gets the complete
+// captured text — streaming tees into the renderer; it doesn't replace
+// the buffer feeding the trace.
+func TestExecuteStreamingTraceCapturesFullOutput(t *testing.T) {
+	orig := os.Args
+	defer func() { os.Args = orig }()
+	os.Args = []string{"test", "--non-interactive"}
+
+	rec := &MemoryRecorder{}
+	r := &streamingResultRenderer{}
+	demo := New("Tee").WithRenderer(r).WithRecorder(rec)
+	demo.Step("emit").ID("emit").Run(func(ctx StepContext) *StepResult {
+		fmt.Print("archive me")
+		return nil
+	})
+	demo.Execute()
+
+	if len(rec.Entries) != 1 {
+		t.Fatalf("expected 1 trace entry, got %d", len(rec.Entries))
+	}
+	if rec.Entries[0].Output != "archive me" {
+		t.Errorf("trace[0].Output = %q, want %q", rec.Entries[0].Output, "archive me")
+	}
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"image/color"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -278,6 +279,22 @@ func (r *Renderer) statusColors(status demokit.ResultStatus) (border, label colo
 	default:
 		return p.ResultBorder, p.Success
 	}
+}
+
+// StreamOutput writes a chunk of step output as the step's Run is
+// still executing. demokit's Execute loop dispatches here when the
+// renderer implements StreamingRenderer; the resulting RenderResult
+// call is then handed an empty output so the body isn't double-printed.
+//
+// out is the writer to emit chunks to (the user's actual stdout,
+// captured before the redirect into demokit's capture pipe).
+//
+// Phase-1 implementation writes chunks raw between the step header
+// and the eventual styled status box. A future enhancement would
+// track an in-progress box and redraw it via cursor rewind on each
+// chunk for a live-growing-box effect; that's deferred.
+func (r *Renderer) StreamOutput(_ int, chunk []byte, out io.Writer) {
+	out.Write(chunk)
 }
 
 func (r *Renderer) RenderResult(stepNum int, output string, result *demokit.StepResult) {


### PR DESCRIPTION
## Summary

Closes #5. Step output now streams to the user's terminal as `Run` executes, rather than buffering until `Run` returns. Long-running steps — live event watchers, polling loops, build progress, mid-step prompts — show output in real time. Also fixes the longstanding "stdout captured, stderr leaks to terminal" UX trap by merging both file descriptors through a single pipe.

The visible smoke test is in `examples/dungeon/`: the dragon's lair now streams a colored ASCII scene line-by-line as the step runs.

## What changed

### `captureOutput` — merged stdout/stderr + chunk callback

```go
func captureOutput(fn func(StepContext) *StepResult, ctx StepContext, onChunk func([]byte)) (output string, result *StepResult)
```

- Both `os.Stdout` and `os.Stderr` are redirected through one pipe so `fmt.Fprintln(os.Stderr, ...)` and `log.Println` (default stderr) land in the same rendered body as `fmt.Println`.
- New optional `onChunk` parameter: when non-nil, the drain goroutine forwards each pipe chunk to it in roughly real time **and** archives to the buffer. Trace recording is unaffected — `entry.Output` still has the full captured string regardless.

### `StreamingRenderer` interface

```go
type StreamingRenderer interface {
    Renderer
    StreamOutput(stepNum int, chunk []byte, out io.Writer)
}
```

- The `out io.Writer` parameter is the user's **actual stdout, snapshotted before `captureOutput` redirects** `os.Stdout` into the pipe. This avoids the pipe-loop bug where writing to `os.Stdout` from the drain goroutine would feed chunks straight back into the capture pipe.
- Both `PlainRenderer` and `tui.Renderer` implement it (raw chunk writes for Phase 1; future cursor-rewind redraws for live-growing TUI boxes can layer on without contract changes).
- Custom downstream renderers that don't implement `StreamingRenderer` get the buffered path — full captured output passed to `RenderResult` after `Run` returns. Backward compatible.

### `Execute` glue

When the renderer is a `StreamingRenderer`:
1. Snapshot `os.Stdout` before calling `captureOutput`.
2. Wire the chunk callback to `sr.StreamOutput(stepNum, chunk, originalStdout)`.
3. After `Run` returns, hand `RenderResult` an empty `output` (the body has already been streamed; don't double-print).
4. The full captured string still goes into the trace entry for `--record` / `--doc md --from`.

## Why a wider scope than the original issue plan

Issue #5 proposed a `Streaming(true)` opt-in flag with TUI falling back to buffered. After tracing the actual cost — TUI is lipgloss-only (no Bubble Tea), and the chunk-callback wiring works for both renderers — going with **streaming-by-default in both modes** turned out cleaner: no opt-in flag, no TUI fallback warning, and every step gets live output without the author having to think about it. The discussion that locked this in lives in the planning thread; capturing the conclusion here.

## Tradeoffs and notes

- **Step output and demokit chrome share `os.Stdout`.** The `StreamOutput` out-writer parameter is the lever that makes FD-separation (step output → stdout, framework chrome → stderr) a small follow-up if/when wanted. The plumbing already supports it.
- **TUI streams chunks raw** above the eventual styled status box (Phase 1). Live-growing-box (cursor-rewind redraws on each chunk) is deferred — TUI is lipgloss-only so this is feasible later without Bubble Tea integration.
- **ANSI codes pass through unchanged** in non-TTY contexts (CI, piped output). A future `--no-color` flag or TTY-aware stripping could land alongside FD separation; out of scope here.
- **`InputDef`-style API breakage**: any custom downstream `Renderer` is unaffected (the new `StreamingRenderer` is opt-in via type assertion). No interface widening.

## Test plan

6 new tests in `term_test.go`:

- [x] `TestCaptureOutputCapturesStderr` — `fmt.Fprintln(os.Stderr, ...)` shows up in the captured output
- [x] `TestCaptureOutputInterleavesStdoutStderr` — merged pipe preserves stdout/stderr write order (`a` → `b` → `c`)
- [x] `TestCaptureOutputOnChunkCallbackFires` — `onChunk` fires with bytes in source order; reassembled chunks match the archived buffer
- [x] `TestExecuteStreamingRendererReceivesChunks` — `StreamingRenderer.StreamOutput` is called; `RenderResult` is handed `output=""`
- [x] `TestExecuteNonStreamingRendererBuffers` — renderers without `StreamOutput` get the full captured output through `RenderResult` (back-compat path)
- [x] `TestExecuteStreamingTraceCapturesFullOutput` — trace recorder receives the complete captured string even when streaming

All existing tests stay green; existing `captureOutput(...)` test callers updated to pass `nil` for the new `onChunk` parameter.

## Manual verification

- `go test ./...` ✓
- `go vet ./...` ✓
- Streaming smoke (`examples/dungeon/`): each line of the dragon scene appears with the 80 ms cadence baked into the Run loop; total reveal is ~3 seconds. In CI / piped output, the lines still appear sequentially as the goroutine produces them — only the ANSI styling becomes visual noise (acceptable; future TTY-strip).
- `make record` in `examples/dungeon/` produces a trace; `make doc-md` and `make doc-json` regenerate doc outputs unchanged in shape.
- A streaming step's `output` field in `--doc json` contains the full archived bytes including the ANSI escapes — embed hosts can choose to strip or render.

## Use case grounding (from the issue)

`panyam/mcpkit examples/events/discord/walkthrough.go` step 7 ("Live Discord interaction") wanted to print typing indicators and message events as they arrived, minutes-long capture. Today's workaround there extracts the live capture out of demokit. After this PR, that workaround can be removed — the step's `Run` writes to `os.Stdout` and demokit streams it.

## Follow-ups

- **FD separation** (step output stdout / demokit chrome stderr) — small change once a use case lands; plumbing already supports it.
- **TUI live-growing box** — cursor-rewind + redraw on each chunk; ~50 lines.
- **TTY-aware ANSI stripping** for piped output — pairs naturally with FD separation.
- **Tee for `StepContext.Out io.Writer`** — capture-and-stream for steps whose output should also archive to trace; bigger API change, file when needed.
