### PR TITLE
feat: verbatim variants + clipboard copy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,365 @@
+# PLAN: Verbatim variants + copy
+
+## Goal
+
+Two related additions to demokit's verbatim block:
+
+1. **Variants** — a single labeled snippet ("Fetch a user") can carry N alternative
+   forms (curl / gcloud CLI / Python). Renderers pick what to show; in TUI, the user
+   tabs between them.
+2. **Copy** — a clipboard primitive (`demokit.Copy(s)`) that combines OSC 52 with
+   OS shell fallbacks (`pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip.exe`). When a
+   step's verbatim block is rendered "boxed" in TUI, the user can copy the focused
+   variant via the `c` key.
+
+Both are opt-in at the **demo level**, not per-block. Today's single-variant unboxed
+verbatim — the existing surface — keeps working unchanged. A new demo flag
+(`Demo.BoxedVerbatim()`) flips all verbatim into the boxed + interactive form in
+TUI. Multi-variant blocks auto-box regardless of the flag (tabs need a frame).
+
+## Surface
+
+### Variant data model
+
+```go
+// Variant is one labeled form of a verbatim snippet.
+type Variant struct {
+    Label   string  // "curl", "gcloud", "Python" — empty on single-variant blocks
+    Lang    string  // fenced-code hint
+    Content string
+    Default bool    // marks the preferred form for non-interactive / doc default
+}
+
+// Constructor + fluent default marker.
+func Variant(label, lang, content string) Variant
+func (v Variant) Default() Variant
+```
+
+### Multi-variant constructor on StepDef
+
+```go
+// VerbatimVariants attaches a multi-variant snippet to the step. The first
+// variant is the implicit default if no .Default() marker is set.
+func (s *StepDef) VerbatimVariants(label string, variants ...Variant) *StepDef
+```
+
+Existing single-variant setters (`Verbatim`, `VerbatimLang`, `Shell`) keep their
+current signatures and return type (`*StepDef`) — no API change, no new public
+type, chained step setters continue to work identically.
+
+Usage:
+
+```go
+demo.Step("Fetch the user").
+    Note("Same API, three idioms.").
+    VerbatimVariants("Fetch user 123",
+        demokit.Variant("curl",   "bash",   `curl -X GET https://api/users/123`).Default(),
+        demokit.Variant("gcloud", "bash",   `gcloud users describe 123`),
+        demokit.Variant("Python", "python", `import requests; r = requests.get(...)`),
+    ).
+    Run(...)
+```
+
+### Demo-level boxing — `Demo.BoxedVerbatim()`
+
+```go
+// BoxedVerbatim enables the boxed + interactive rendering of verbatim
+// blocks in TUI mode. When unset (default), single-variant blocks render
+// outside the TUI box (mouse-select-friendly) as today. Multi-variant
+// blocks always render boxed regardless of this flag — tabs require a
+// frame.
+//
+// Plain renderer, markdown, HTML, and JSON output are unaffected by
+// this flag (no "box" concept outside the TUI).
+func (d *Demo) BoxedVerbatim() *Demo
+```
+
+Effective per-block boxing at render time:
+
+| Block type | `BoxedVerbatim()` unset | `BoxedVerbatim()` set |
+|---|---|---|
+| Single variant | unboxed (today's behavior) | boxed + `c`-to-copy |
+| Multi variant  | boxed + tabs + `c`-to-copy | boxed + tabs + `c`-to-copy |
+
+The rationale for auto-boxing multi-variant regardless of the flag: calling
+`VerbatimVariants(...)` is itself an opt-in to interactivity (tabs require a
+frame). Forcing authors to also set `BoxedVerbatim()` would be a second knob for
+no extra signal.
+
+### `verbatimBlock` updated
+
+```go
+type verbatimBlock struct {
+    Label    string
+    Variants []Variant
+    // No explicit `Boxed` field — derived at render time from
+    // (demo.BoxedVerbatim flag) OR (len(Variants) > 1).
+}
+```
+
+Single-variant constructors fill `Variants` with a one-element slice keyed by the
+existing Lang/Content. The legacy `Lang`/`Content` fields on `verbatimBlock` are
+removed — `Variants[0]` carries them.
+
+`VerbatimView` (the read-only projection) grows a `Variants []VariantView` field;
+existing `Lang`/`Content` accessors are sugar over `Variants[0]` for callers that
+ignore variants.
+
+### Demo flag — `--variant`
+
+Added to `RegisterFlags`, `scanOwnArgs`, and `FilterArgs`'s value-flag strip set.
+
+| `--variant` value | Effect on plain / `--non-interactive` / `--doc md|html|json` |
+|---|---|
+| _omitted_ | If a variant is `.Default()`-marked, render only that one. Else render all. |
+| `--variant=all` | Render all variants. |
+| `--variant=default` | Render the default-marked variant; error if none marked. |
+| `--variant=<label>` | Render the named variant; error (stderr, exit) if no block has it. |
+
+**TUI ignores `--variant`** — the user picks interactively. Documenting this in
+the flag help text avoids surprise.
+
+## TUI interaction
+
+A verbatim block is "boxed" if `Demo.BoxedVerbatim()` is set OR the block has
+multiple variants (auto-box).
+
+### v1: line-based copy
+
+The interactive key dispatch (Tab cycling, single-keystroke `c`, numeric jump,
+`[`/`]` block focus) requires raw terminal mode + cursor-positioned redraws.
+Those land in a follow-up PR. v1 ships a line-based copy UX that delivers the
+core value (variants visible + keyboard copy via OSC 52 / pbcopy) without
+adding a raw-mode dependency:
+
+- **Single-variant boxed** (e.g. `BoxedVerbatim()` set on a step with one
+  snippet): block renders in a styled box. Pause prompt:
+  ```
+  Press Enter to continue · type `c` to copy
+  ```
+  Reading: `bufio.NewReader(os.Stdin).ReadString('\n')`. On `c`, the clipboard
+  primitive copies the block's only variant; status line shows the strategy
+  (`(copied via osc52)`); prompt re-displays. On empty Enter, continue.
+
+- **Multi-variant** (always boxed): block renders inside a single box with
+  every variant printed stacked, each prefixed by its `**label**`. Pause
+  prompt:
+  ```
+  Press Enter to continue · type `c` to copy default · `c <label>` for a named variant
+  ```
+  `c` alone copies the default-marked variant (or the first if none marked).
+  `c curl` copies the variant labeled `curl`; case-insensitive match. Unknown
+  label re-prompts with an error line.
+
+- **Unboxed verbatim** (single-variant, `BoxedVerbatim()` unset): unchanged
+  from today — rendered outside the box, mouse-select copies. No `c` key in
+  the prompt.
+
+### v1.1 (follow-up): raw-mode interactivity
+
+Will replace the line-based UX with the bindings already designed:
+
+| Key | Scope | Effect |
+|---|---|---|
+| `Tab` / `Shift+Tab` | block (focused) | cycle variants forward / back |
+| `1`–`9` | block (focused) | jump to variant N of focused block |
+| `[` / `]` | step | cycle which block is focused |
+| `c` | block (focused) | copy focused variant |
+| `↑` / `↓` | **reserved** | future history mode |
+| `Enter` | step | continue (unchanged) |
+
+Reserved tab strip render (`[1] curl  <2> gcloud  [3] Python`) lands then.
+
+### Block ID scheme
+
+Independent of v1 vs v1.1: `<step-id>:verbatim:<index-within-step>`. Reserved
+in v1 for future focus addressing.
+
+## Clipboard primitive — new `clipboard.go`
+
+```go
+// Copy writes s to the system clipboard. Strategy order:
+//   1. OSC 52 escape sequence (terminal-side; works over SSH if the
+//      terminal allows it; tmux 3.3+ honors it with set-clipboard on).
+//   2. pbcopy   (darwin)
+//   3. wl-copy  (Wayland)
+//   4. xclip    (X11)
+//   5. xsel     (X11 fallback)
+//   6. clip.exe (Windows / WSL)
+//
+// Returns the strategy that worked and ok=true, or ("", false) if all
+// failed. Missing tools are silent skips, not errors.
+func Copy(s string) (strategy string, ok bool)
+```
+
+OSC 52 implementation writes `\x1b]52;c;<base64(s)>\x07` to a writer chosen at
+package init (`os.Stderr` default — stdout is captured during step Run). We expose
+a small `clipboardWriter` seam for tests to assert the sequence without actually
+shelling out.
+
+Shell fallbacks use `exec.LookPath` first; only execute if the binary exists.
+Each invocation pipes `s` to stdin with a short context timeout (2s) so a hung
+clipboard daemon never blocks the TUI.
+
+No third-party dependency.
+
+## Markdown rendering
+
+Sub-headings per variant (your preference):
+
+```markdown
+#### Fetch user 123
+
+**curl**
+
+​```bash
+curl -X GET https://api/users/123
+​```
+
+**gcloud**
+
+​```bash
+gcloud users describe 123
+​```
+
+**Python**
+
+​```python
+import requests; r = requests.get(...)
+​```
+```
+
+Same shape in both `markdown.go` (the rich static visitor) and `render_trace.go`
+(per-entry trace renderer). `writeVerbatimMD` is updated to emit either:
+
+- One variant — current single block format (no `**label**` line); or
+- N variants — `**label**` line above each fenced block, in declaration order.
+
+`--variant=<label>` filters to that one in markdown output; default behavior is
+"default-marked if set, else all."
+
+## HTML rendering
+
+The minimal standalone HTML (`render_trace.go::RenderDocumentHTML`) uses
+`<h4>` for the outer label and bolded `<strong>` lines for each variant label
+plus `<pre><code class="language-X">` per snippet. No JS, no tabs — same model
+as the markdown render.
+
+**Web player tabbed UI (the `<demokit-demo>` custom element + bundle) is
+deferred to a follow-up PR.** The JSON projection lands now so embed hosts have
+the data; the player's vanilla-JS UI for tabs is its own work.
+
+## JSON projection
+
+```go
+type VariantView struct {
+    Label   string `json:"label,omitempty"`
+    Lang    string `json:"lang,omitempty"`
+    Content string `json:"content"`
+    Default bool   `json:"default,omitempty"`
+}
+
+type VerbatimView struct {
+    Label    string        `json:"label,omitempty"`
+    Variants []VariantView `json:"variants"`
+}
+```
+
+A single-variant block emits a one-element `variants` array — embed hosts read
+the same shape unconditionally. No `lang`/`content` on the outer view; everything
+lives in variants for symmetry. No `Boxed` field — boxing is a TUI rendering
+concern, derived at render time from the demo flag + variant count, not a per-
+block property worth wire-projecting.
+
+## Block identity for future history nav
+
+Each rendered verbatim block gets an addressable ID:
+
+```
+<step-id>:verbatim:<index-within-step>
+```
+
+E.g. `triage:verbatim:0`, `triage:verbatim:1`. The ID is computed in the renderer
+and stored on the in-memory block state. v1 doesn't read these IDs (no history
+nav yet), but reserving the scheme avoids retrofitting when history mode lands.
+
+## What stays out of the trace
+
+Variants are static (author-time). The trace does NOT record which variant the
+user copied (or "viewed") — variants don't affect demo flow. `TraceEntry` is
+unchanged. Replays don't need to know about variants.
+
+## File-level changes
+
+| File | Change |
+|---|---|
+| `step.go` | `Variant` type + `.Default()`; `verbatimBlock` rewritten with `Variants []Variant` (no Boxed field); `VerbatimVariants` constructor returning `*StepDef`; existing single-variant constructors unchanged in signature; `VerbatimView` updated. |
+| `clipboard.go` (new) | `Copy(s string) (strategy string, ok bool)`; OSC 52 emitter; shell-fallback dispatch. |
+| `clipboard_test.go` (new) | Asserts OSC 52 byte sequence via a fake writer; asserts LookPath-miss falls through; asserts no exec when all tools missing. |
+| `args.go` | Add `--variant` to FilterArgs value-flag strip set. |
+| `demokit.go` | `flagVariant string` + `boxedVerbatim bool` fields; `Demo.BoxedVerbatim() *Demo` setter; `RegisterFlags` / `scanOwnArgs` updates for `--variant`; expose `Demo.VariantSelection() VariantSelection` helper used by renderers to pick variants for non-interactive output; expose `Demo.IsBoxedVerbatim() bool` for TUI to consult at render time. |
+| `markdown.go` | `writeVerbatimMD` rewritten to emit one-or-many variants with sub-headings; applies `VariantSelection` filter. |
+| `render_trace.go` | `writeVerbatimMD/HTML` reuse; same selection filter; HTML output uses `<strong>` per variant. |
+| `render_json.go` | `VariantView`; `VerbatimView` reshaped; `inputView` untouched. |
+| `tui/` | Render single-variant inside the box when `Demo.IsBoxedVerbatim()` is true. Multi-variant always boxed with stacked-with-labels rendering. After step render, the TUI's pause loop reads a line: empty = continue, `c` = copy default/single variant, `c <label>` = copy named variant. `clipboard.Copy()` integration, status-line "(copied via X)" feedback. **Raw-mode key dispatch (Tab, single-key c, 1-9, [/], focus model) deferred to follow-up PR.** |
+| `renderer.go` | `PlainRenderer.RenderStep` applies the `--variant` selection (no interactivity). |
+| `examples/graph/` | Demo calls `.BoxedVerbatim()`; the "Refresh succeeds" step's `.Shell(...)` is converted to `.VerbatimVariants("Refresh the token", curl.Default(), python, go)` — three client forms; curl is the default. The "Retry succeeds" step keeps its single-variant `.VerbatimLang(...)` so it exercises the demo-flag-driven boxing path. |
+| `examples/dungeon/` | Spot-check that sidecar-md path still loads (no markdown variant syntax in v1). |
+
+## Sidecar markdown
+
+Out of scope for v1. Sidecar-loaded verbatim blocks stay single-variant; the
+goldmark fenced-code parser doesn't get a `variants` block type in this PR.
+Authors who need variants in a sidecar demo declare them via `Demo.Bind(id)` and
+call `VerbatimVariants(...)` from Go (mirrors how `Run` / `Coalesce` are
+Go-only). Follow-up can add a `variants` reserved fence info-string.
+
+## Tests
+
+- `TestVariantConstruction` — `Variant("curl", "bash", "...").Default()` sets Default; `Variant(...)` without it leaves Default false.
+- `TestSingleVariantBackcompat` — `Verbatim("l", "c")`, `VerbatimLang("l", "py", "c")`, `Shell("c")` each produce one-element `Variants` slices preserving label / lang / content; rendered markdown / JSON / HTML byte-equal pre-change reference output. Existing chain shape (`step.Verbatim(...).Shell(...).Run(...)`) compiles unchanged.
+- `TestBoxedVerbatimFlag` — `Demo.BoxedVerbatim()` toggles the flag; `Demo.IsBoxedVerbatim()` reads it; default is false.
+- `TestMultiVariantAutoBoxed` — TUI render of a step with a multi-variant block produces the boxed/tabbed layout even when `BoxedVerbatim()` is unset.
+- `TestSingleVariantUnboxedByDefault` — TUI render of a step with a single-variant block produces today's unboxed output when `BoxedVerbatim()` is unset; the same step produces boxed output when `BoxedVerbatim()` is set.
+- `TestRenderMarkdownVariants` — multi-variant block emits `#### <label>` + `**variant-label**` + fenced block per variant; single-variant block emits the legacy shape unchanged.
+- `TestRenderJSONVariants` — multi-variant block produces a `variants` array; single-variant block produces a one-element array.
+- `TestRenderHTMLVariants` — same shape via `<strong>` labels.
+- `TestVariantFlagDefault` — `--variant` unset + one variant marked Default → render only Default. Unset + no Default → render all.
+- `TestVariantFlagExplicit` — `--variant=all` renders all; `--variant=curl` renders only curl; `--variant=does-not-exist` exits with stderr error.
+- `TestFilterArgsStripsVariant` — both `--variant foo` and `--variant=foo` are removed from caller-side args.
+- `TestClipboardOSC52` — `Copy("hello")` with a fake writer emits `\x1b]52;c;aGVsbG8=\x07`.
+- `TestClipboardShellFallback` — when `exec.LookPath("pbcopy")` is stubbed to fail, the next strategy is tried; when all fail, `Copy` returns `("", false)`.
+- `TestClipboardTimeout` — a hanging stub binary is killed after the 2s context deadline; `Copy` returns `("", false)`.
+
+TUI interaction (line-based `c` / `c <label>` copy command parsing) is
+exercised by feeding lines into the renderer's pause loop through a stdin pipe
+— same pattern as the existing `cancel_test.go` cancellable-stdin tests. The
+raw-mode key dispatch tests land in the v1.1 follow-up PR.
+
+## Build sequence
+
+1. PLAN.md (this file) — review.
+2. `step.go` — data model + `Variant` type + `VerbatimVariants` constructor; `verbatimBlock` rewritten around `Variants []Variant`; existing single-variant constructors keep signature/return type. Existing tests adjusted for internal shape change only.
+3. `clipboard.go` + `clipboard_test.go` — standalone primitive, no other code depends on it yet.
+4. `markdown.go`, `render_trace.go`, `render_json.go` — variant-aware renderers; `--variant` flag wired in.
+5. `args.go` + `demokit.go` — `--variant` flag registration + strip set; `BoxedVerbatim()` / `IsBoxedVerbatim()`; `VariantSelection` helper.
+6. `tui/` — interactive variant tabs, focus model, clipboard integration.
+7. `examples/graph/` smoke; manual TUI exercise of Tab/`c`/`[`/`]`.
+8. `ARCHITECTURE.md` + `README.md` short additions describing the surface.
+
+## Open questions resolved
+
+- **Box opt-in**: **demo-level only** via `Demo.BoxedVerbatim()`. Multi-variant blocks auto-box regardless of the flag (tabs need a frame); single-variant blocks honor the flag (default unboxed = today's behavior). No per-block `.Boxed()` API, no `VerbatimRef` type — keeps the chain shape and API surface unchanged.
+- **`.Default()` placement**: marker on `Variant` (local; one source of truth per option).
+- **Numeric quick-jump**: `1-9` acts on focused block's variants. `[` / `]` switches block focus. Preserves `↑` / `↓` for future history mode.
+- **`--variant` scope**: applies to plain / non-interactive / `--doc`. TUI ignores it (interactive selection).
+- **Block ID**: `<step-id>:verbatim:<index>` scheme reserved now; unused in v1.
+- **Trace impact**: none. Variants are static.
+
+## Out of scope (explicit)
+
+- Sidecar-markdown `variants` fenced-block syntax.
+- Web player (`<demokit-demo>` custom element) tabbed UI — JSON projection lands; player JS is a follow-up.
+- Cross-step history navigation (`↑` / `↓` mode). Reserved bindings only.
+- Per-block boxing override (e.g. "this demo is mostly boxed but THIS block should be mouse-select"). YAGNI until a real demo asks for it.
+- Per-variant copy in non-TUI contexts (e.g. a "copy" button in the static HTML render). HTML stays static; web player gets the dynamic UX.

--- a/args.go
+++ b/args.go
@@ -11,12 +11,13 @@ import (
 // that layer their own flags (`-addr`, `--url`, `--file`, ...) on top
 // of the demokit-recognized ones.
 //
-// Built-in strip set — the four flags demokit's dispatcher consumes:
+// Built-in strip set — the flags demokit's dispatcher consumes:
 //
 //   - --tui                   (bare; selects the TUI renderer)
 //   - --non-interactive       (bare; skips between-step pauses)
 //   - --doc <format>          (value; routes to doc emission)
 //   - --from <trace-path>     (value; trace input for --doc)
+//   - --variant <name>        (value; filters verbatim variant output)
 //
 // Both `--flag value` and `--flag=value` forms are stripped for the
 // value flags. Anything else passes through untouched.
@@ -34,8 +35,9 @@ func FilterArgs(args []string, extra ...ExtraFlag) []string {
 		"--non-interactive": true,
 	}
 	value := map[string]bool{
-		"--doc":  true,
-		"--from": true,
+		"--doc":     true,
+		"--from":    true,
+		"--variant": true,
 	}
 	for _, e := range extra {
 		if e.TakesValue {

--- a/args_test.go
+++ b/args_test.go
@@ -6,22 +6,38 @@ import (
 	"testing"
 )
 
-// TestFilterArgsBuiltInStripsOnly verifies the four built-in flags are
+// TestFilterArgsBuiltInStripsOnly verifies the built-in flags are
 // stripped (with both spaced and = forms for value flags) and nothing
 // else is touched. This is the load-bearing case — examples rely on
-// these four being inverted from demokit's own scanner.
+// these being inverted from demokit's own scanner.
 func TestFilterArgsBuiltInStripsOnly(t *testing.T) {
 	got := FilterArgs([]string{
 		"--tui",
 		"--non-interactive",
 		"--doc", "md",
 		"--from=trace.json",
+		"--variant", "curl",
 		"-addr", ":8081", // unrelated, must pass through
 		"positional",     // positional, must pass through
 	})
 	want := []string{"-addr", ":8081", "positional"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("FilterArgs built-in:\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// TestFilterArgsStripsVariantEqForm verifies --variant=<value> is
+// stripped alongside the spaced form. Examples that layer their own
+// flags rely on this so demokit's dispatcher flags never leak into
+// their flag.Parse.
+func TestFilterArgsStripsVariantEqForm(t *testing.T) {
+	got := FilterArgs([]string{
+		"--variant=python",
+		"-addr", ":8081",
+	})
+	want := []string{"-addr", ":8081"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FilterArgs --variant=...:\n got:  %v\n want: %v", got, want)
 	}
 }
 

--- a/clipboard.go
+++ b/clipboard.go
@@ -1,0 +1,176 @@
+package demokit
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Copy writes s to the system clipboard, trying terminal-side OSC 52
+// first and falling back to OS-specific shell tools. Returns the
+// strategy name that succeeded ("osc52", "pbcopy", "wl-copy", "xclip",
+// "xsel", "clip") and ok=true, or ("", false) if every strategy failed
+// (missing tools, OSC 52 disabled, hung daemons, etc.).
+//
+// Strategy order (first success wins):
+//
+//  1. OSC 52 escape sequence. Works over SSH and inside tmux (≥3.3 with
+//     set-clipboard on) without a binary on the host. Some corporate
+//     environments disable it.
+//  2. pbcopy   (darwin)
+//  3. wl-copy  (Wayland — typical on modern Linux laptops)
+//  4. xclip    (X11)
+//  5. xsel     (X11 fallback)
+//  6. clip.exe (Windows; works in WSL where /mnt/c/Windows/System32 is
+//     on PATH)
+//
+// Each shell-out is given a 2-second context deadline so a hung
+// clipboard daemon never blocks demokit's caller. Missing tools (no
+// exec.LookPath hit) are silent skips, not errors.
+//
+// Callers may swap the writer used by the OSC 52 strategy via the
+// SetClipboardWriter package function — primarily for tests; default
+// is os.Stderr (writing to stdout would be captured by demokit's step
+// output redirect during Run).
+func Copy(s string) (strategy string, ok bool) {
+	if writeOSC52(s) {
+		return "osc52", true
+	}
+	for _, c := range shellCopyCandidates() {
+		if runShellCopy(c, s) {
+			return c.name, true
+		}
+	}
+	return "", false
+}
+
+// clipboardOut is the writer the OSC 52 strategy targets. Defaults to
+// os.Stderr because stdout is captured during step execution; writing
+// the escape sequence to stdout would loop into demokit's capture pipe
+// and never reach the terminal.
+var clipboardOut io.Writer = os.Stderr
+
+// SetClipboardWriter overrides the writer used by the OSC 52 strategy.
+// Pass nil to restore the default (os.Stderr). Tests use this to
+// capture the emitted escape sequence without touching the real
+// terminal.
+func SetClipboardWriter(w io.Writer) {
+	if w == nil {
+		clipboardOut = os.Stderr
+		return
+	}
+	clipboardOut = w
+}
+
+// shellCopyEnabled controls whether Copy attempts the shell-out
+// fallback strategies. Tests set this to false to assert OSC 52 is the
+// only path exercised. Default true.
+var shellCopyEnabled = true
+
+// EnableShellClipboardFallback toggles whether Copy attempts shell-out
+// strategies (pbcopy / wl-copy / xclip / xsel / clip.exe) after OSC 52.
+// Primarily for tests; production callers leave this on.
+func EnableShellClipboardFallback(enabled bool) {
+	shellCopyEnabled = enabled
+}
+
+// writeOSC52 emits the OSC 52 clipboard-write escape sequence to
+// clipboardOut. Returns true if the write succeeded — note that
+// success here means "the bytes left the process," not "the terminal
+// honored the request." There is no in-band acknowledgement from the
+// terminal for OSC 52; demokit treats a successful Write as good
+// enough and presents the strategy as "osc52" to the user.
+//
+// Format: ESC ]52;c;<base64(payload)> BEL
+func writeOSC52(s string) bool {
+	enc := base64.StdEncoding.EncodeToString([]byte(s))
+	seq := "\x1b]52;c;" + enc + "\x07"
+	_, err := fmt.Fprint(clipboardOut, seq)
+	return err == nil
+}
+
+// shellCopyCandidate describes one shell-fallback clipboard strategy.
+type shellCopyCandidate struct {
+	name string   // strategy label returned from Copy on success
+	cmd  string   // binary to look up via exec.LookPath
+	args []string // arguments to pass to the binary
+}
+
+// shellCopyCandidates returns the platform-appropriate shell fallback
+// strategies in priority order. Filtered to candidates whose binary
+// is actually present on PATH so a Copy call only spends a context
+// timeout on tools that exist.
+func shellCopyCandidates() []shellCopyCandidate {
+	if !shellCopyEnabled {
+		return nil
+	}
+	var all []shellCopyCandidate
+	switch runtime.GOOS {
+	case "darwin":
+		all = []shellCopyCandidate{
+			{name: "pbcopy", cmd: "pbcopy"},
+		}
+	case "linux", "freebsd", "openbsd", "netbsd":
+		all = []shellCopyCandidate{
+			{name: "wl-copy", cmd: "wl-copy"},
+			{name: "xclip", cmd: "xclip", args: []string{"-selection", "clipboard"}},
+			{name: "xsel", cmd: "xsel", args: []string{"--clipboard", "--input"}},
+		}
+	case "windows":
+		all = []shellCopyCandidate{
+			{name: "clip", cmd: "clip"},
+		}
+	default:
+		return nil
+	}
+	// On Linux under WSL, clip.exe is reachable and is the only path
+	// to the host Windows clipboard. Try it after the native tools.
+	if runtime.GOOS == "linux" && isWSL() {
+		all = append(all, shellCopyCandidate{name: "clip", cmd: "clip.exe"})
+	}
+
+	out := all[:0]
+	for _, c := range all {
+		if _, err := exec.LookPath(c.cmd); err == nil {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// runShellCopy invokes the given candidate with a 2-second deadline.
+// Returns true if the command exited 0. False covers every failure
+// shape (LookPath miss already filtered, timeout, non-zero exit, IO
+// error). A failure is silent — the caller proceeds to the next
+// candidate.
+func runShellCopy(c shellCopyCandidate, s string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, c.cmd, c.args...)
+	cmd.Stdin = strings.NewReader(s)
+	// Discard stdout/stderr — the tool's output isn't useful here and
+	// would otherwise leak into the caller's terminal.
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}
+
+// isWSL returns true when running inside Windows Subsystem for Linux.
+// Used to opportunistically try clip.exe alongside the native Linux
+// clipboard tools. Cheap to compute; called at most once per Copy
+// failure path.
+func isWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" || os.Getenv("WSL_INTEROP") != "" {
+		return true
+	}
+	if b, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+		return strings.Contains(strings.ToLower(string(b)), "microsoft")
+	}
+	return false
+}

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -1,0 +1,90 @@
+package demokit
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestCopyOSC52SequenceShape(t *testing.T) {
+	var buf bytes.Buffer
+	SetClipboardWriter(&buf)
+	EnableShellClipboardFallback(false)
+	defer func() {
+		SetClipboardWriter(nil)
+		EnableShellClipboardFallback(true)
+	}()
+
+	strategy, ok := Copy("hello, clipboard")
+	if !ok {
+		t.Fatalf("Copy returned ok=false; OSC 52 should always succeed when writer is a *bytes.Buffer")
+	}
+	if strategy != "osc52" {
+		t.Errorf("strategy = %q, want %q", strategy, "osc52")
+	}
+
+	got := buf.String()
+	if !strings.HasPrefix(got, "\x1b]52;c;") {
+		t.Errorf("missing OSC 52 prefix: got %q", got)
+	}
+	if !strings.HasSuffix(got, "\x07") {
+		t.Errorf("missing BEL terminator: got %q", got)
+	}
+
+	wantPayload := base64.StdEncoding.EncodeToString([]byte("hello, clipboard"))
+	if !strings.Contains(got, wantPayload) {
+		t.Errorf("base64 payload missing or wrong: got %q, want substring %q", got, wantPayload)
+	}
+}
+
+func TestCopyWithoutTerminalFallsBackOrFails(t *testing.T) {
+	// With shell fallback disabled and the OSC 52 writer accepting any
+	// write, Copy succeeds via OSC 52 — confirming the strategy order
+	// (OSC 52 tried first).
+	var buf bytes.Buffer
+	SetClipboardWriter(&buf)
+	EnableShellClipboardFallback(false)
+	defer func() {
+		SetClipboardWriter(nil)
+		EnableShellClipboardFallback(true)
+	}()
+
+	strategy, ok := Copy("payload")
+	if !ok || strategy != "osc52" {
+		t.Errorf("expected OSC 52 success with shell fallback disabled, got (%q, %v)", strategy, ok)
+	}
+}
+
+// failingWriter always returns an error from Write — simulates a
+// terminal that doesn't accept the OSC 52 sequence (no stderr, etc.).
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errFailingWriter
+}
+
+var errFailingWriter = &errString{"forced write failure"}
+
+type errString struct{ s string }
+
+func (e *errString) Error() string { return e.s }
+
+func TestCopyOSC52WriteFailFallsThrough(t *testing.T) {
+	// When OSC 52 write fails AND shell fallbacks are disabled, Copy
+	// must return ("", false) without panicking.
+	SetClipboardWriter(failingWriter{})
+	EnableShellClipboardFallback(false)
+	defer func() {
+		SetClipboardWriter(nil)
+		EnableShellClipboardFallback(true)
+	}()
+
+	strategy, ok := Copy("payload")
+	if ok {
+		t.Errorf("expected Copy to fail when OSC 52 writer errors and shell fallback is disabled, got strategy=%q", strategy)
+	}
+	if strategy != "" {
+		t.Errorf("expected empty strategy on full failure, got %q", strategy)
+	}
+}

--- a/considered-rejected.md
+++ b/considered-rejected.md
@@ -1,0 +1,240 @@
+# Considered & rejected: Scenario-filtering primitives
+
+**Status:** Considered 2026-05, rejected in favor of consumer-side composition
+(shared helper package + N small `main.go` binaries per variant). See the closing
+section at the bottom of this file for the rationale.
+
+The plan below is preserved as a record of what was designed and why, in case the
+trade-off changes (e.g. a demokit consumer hits a case that composition cannot
+express cleanly).
+
+---
+
+## Goal
+
+Let a single `Demo` be sliced into named **scenarios** — overlapping subsets of steps that
+can be run, recorded, and rendered independently — without breaking demos that don't opt in.
+
+Driven by mcpkit's events demos (14 linear steps each, 5–7 minutes live). Same shape will
+hit any other demokit consumer that grows past comfortable single-narrative size.
+
+## Surface (additive, no breaking changes)
+
+### 1. Tag steps and sections — `.Scenario(name, more ...string)`
+
+```go
+demo.Step("Subscribe to webhook").ID("subscribe").
+    Scenario("webhook").
+    Run(...)
+
+demo.Step("Connect").ID("connect").
+    Scenario("basics", "webhook", "validation").    // belongs to all three
+    Run(...)
+
+demo.Section("Webhook overview").Scenario("webhook")
+```
+
+Variadic so authors can group a step into multiple scenarios in one call.
+Multiple `.Scenario()` calls on the same step are **additive** (set-union) — your design
+intuition is right; the alternative (last-call-wins) makes it impossible to grow tags
+across composition layers.
+
+A step / section with **zero `.Scenario()` calls is universal** — runs and renders in
+every scenario filter. This is what preserves existing-demo behavior for consumers that
+never opt in.
+
+### 2. Declare scenario metadata — `demo.Scenario(name)`
+
+```go
+demo.Scenario("webhook").
+    Description("Subscribe and receive deliveries via HTTP").
+    Next("validation", "Run make demo-validation to see spec validation in action.")
+```
+
+A `*ScenarioDef` chain. Properties:
+
+- `Description(string)` — used in the index doc.
+- `Next(toScenario, blurb string)` — pointer rendered after the last step of this
+  scenario (in TUI, in the per-scenario Markdown, and in the index).
+
+**Why on the scenario, not on the last step (push-back on item 3 of the proposal):**
+
+The "last step of scenario X" is something demokit can compute from the tagged step list
+in declaration order. If the pointer lives on a step, the author has to remember to put
+it on the right one — which moves any time another scenario is interleaved. And if the
+same step happens to be the last step of *two* scenarios (entirely possible with overlap),
+a step-bound pointer can't say what the next-of-X is vs. next-of-Y.
+
+A scenario-declared `Next("validation", ...)` is unambiguous: "when scenario X's render
+ends, point readers at scenario Y." The renderer does the bookkeeping.
+
+If a scenario name appears in `step.Scenario(...)` but is never declared via
+`demo.Scenario(name)`, demokit auto-declares it with no description (mirrors how step
+IDs auto-fill). This keeps the simplest case (`step.Scenario("foo")` only) one-liner.
+
+### 3. Runtime filter — `--scenario=<name>`
+
+Added to demokit's standard flag set in `RegisterFlags` and `scanOwnArgs` (and to
+`FilterArgs`'s strip set).
+
+| Flag value         | Effect                                                           |
+|--------------------|------------------------------------------------------------------|
+| _omitted_          | Run / render every item — current behavior.                      |
+| `--scenario=all`   | Same as omitted. Explicit form for Make targets.                 |
+| `--scenario=foo`   | Filter to items that match scenario `foo` (or are universal).    |
+| `--scenario=index` | Reserved sentinel — see (4).                                     |
+
+Unknown scenario name: stderr error, exit. (Same shape as unknown `--doc` format.)
+
+`index` is a reserved name; `demo.Scenario("index")` panics at registration time, so we
+never have to disambiguate the sentinel from a real scenario.
+
+The filter applies uniformly:
+
+- **Run mode:** the loop walks the filtered items list; jumps via `StepResult.Next` to
+  IDs outside the filter are an error (logged + recorded, run aborts cleanly). This is
+  the right loud failure — silent skip would mask broken demos.
+- **`--record` / `--replay`:** trace records only the filtered visited path. Replay is
+  agnostic of the filter — if the trace was recorded under a scenario, replaying without
+  `--scenario=…` just walks that recorded path; replaying with a *different* `--scenario`
+  is also fine (the trace drives, scenario filter doesn't reapply during replay).
+- **`--doc md|html|json`:** the renderer walks the filtered items list. The static
+  `Demo.Markdown()` path filters mermaid actors to those referenced by the filtered steps
+  (your second design call — agreed, only-actors-used).
+- **`--doc bundle` / `--serve`:** same filter in the items the bundle / live stream sees.
+
+### 4. Index document — `--scenario=index`
+
+`--doc=md --scenario=index` (and `html`/`json` analogues) produces a top-level index of
+all declared scenarios:
+
+- For each scenario in declaration order: name, description, step count, and a
+  `→ run with: --scenario=<name>` hint.
+- Optionally a one-line summary derived from the first step's note's first sentence
+  when the scenario has no `Description`.
+
+Filename / output path stays consumer-owned: demokit emits to stdout (or `--out` for
+formats that support it — bundle), consumer Makefiles route to `WALKTHROUGH-index.md` or
+wherever they want.
+
+`--scenario=index` without `--doc` (i.e. just running the demo) prints the index to
+stdout and exits — useful as `go run ./mydemo --scenario=index` for "what scenarios does
+this demo support?". This costs us little and avoids surprising "why does my CLI hang?"
+when someone forgets `--doc`.
+
+## Decisions on the open questions
+
+| Question                                          | Decision                                                                                                                |
+|---------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `.Scenario()` additive vs. exclusive on multi-call| **Additive** (set-union).                                                                                               |
+| Filtered mermaid: full actors or only-used        | **Only-used.** Walk filtered steps, collect referenced `from`/`to` IDs, emit only those `participant` lines.            |
+| `make demo` (no flag) behavior                    | **Consumer-owned.** demokit doesn't define this. README documents the canonical pattern — author chooses (a) sequential with banners, (b) print-index. |
+| Makefile generated vs. consumer-owned             | **Consumer-owned.** demokit only ships the runtime flag.                                                                |
+
+## File-level changes
+
+| File                  | Change                                                                                       |
+|-----------------------|----------------------------------------------------------------------------------------------|
+| `step.go`             | `StepDef.scenarios []string`, `StepDef.Scenario(name, more...) *StepDef`, `StepDef.Scenarios() []string`. Same on `SectionDef`. |
+| `demokit.go`          | `Demo.scenarios map[string]*ScenarioDef`, `Demo.scenarioOrder []string`, `Demo.Scenario(name) *ScenarioDef`, `Demo.flagScenario` (+ register/scan/Filter), `Demo.filteredItems(scenario) []item`, runtime filter wiring in `RunLoop`. `index` reserved-name panic. |
+| `scenario.go` (new)   | `ScenarioDef` type and its setter chain (`Description`, `Next`). Helper `Demo.MatchesScenario(it item, name string) bool` (universal + tagged check). |
+| `args.go`             | Add `--scenario` to `FilterArgs`'s built-in value-flag set.                                  |
+| `markdown.go`         | `Demo.Markdown()` accepts the active scenario filter; filters items + actors; appends `Next` pointer if scenario has one. |
+| `render_trace.go`     | `RenderDocumentMD/HTML` filter trace entries by scenario; `Next` pointer at end.             |
+| `render_json.go`      | Trace + items projected post-filter; `demoView.Scenarios` field for embed hosts.             |
+| `render_index.go` (new)| `RenderIndexMD/HTML/JSON(ctx)` for the index document.                                       |
+| `examples/graph/`     | Add a couple of `.Scenario(...)` tags + one `demo.Scenario(...).Description().Next(...)` so the test consumer exercises the path end-to-end. |
+
+## Tests (to land with the implementation)
+
+- `TestScenarioTagAdditive` — multiple `.Scenario("a")`, `.Scenario("b","c")` calls on
+  one step produces the union `{a,b,c}`.
+- `TestUntaggedStepsAreUniversal` — a step with no `.Scenario(...)` calls runs / renders
+  in every scenario filter.
+- `TestScenarioFilterRunLoop` — `flagScenario="foo"` runs only foo-tagged + universal
+  items; `--scenario=all` and "" both run everything.
+- `TestUnknownScenarioNamePanicsOrErrors` — `--scenario=does-not-exist` exits with the
+  expected stderr message; `demo.Scenario("index")` panics at registration.
+- `TestUndeclaredScenarioAutoCreated` — tagging steps with `Scenario("foo")` without
+  `demo.Scenario("foo")` works; the scenario shows up in the index with empty description.
+- `TestStaticMarkdownActorFiltering` — only actors referenced by the filtered scenario's
+  steps appear as `participant` lines.
+- `TestNextScenarioRenderedOnce` — when `Next("validation", blurb)` is set on scenario
+  "webhook", rendering scenario webhook ends with the blurb; rendering scenario foo
+  doesn't include it.
+- `TestRenderIndexMD` — index doc lists declared scenarios, descriptions, step counts,
+  and stable order.
+- `TestFilterArgsStripsScenario` — `--scenario foo`, `--scenario=foo`, and missing-value
+  forms all behave like other value flags.
+- `TestJumpAcrossScenarioBoundaryErrors` — a `StepResult{Next: "step-not-in-filter"}`
+  produces a clean error and trace abort entry.
+
+## Out of scope (for this PR)
+
+- **Sidecar markdown integration.** Authors that load content via `FromMarkdown` get no
+  scenario syntax in this PR. Once the Go-side primitives stabilize, frontmatter (or a
+  per-heading `[scenarios: a,b]` annotation) is a small follow-up.
+- **mcpkit consumer-side changes.** This branch only ships the framework primitives.
+  The events-demo split happens in a separate worktree against mcpkit, exercising what
+  this PR builds.
+- **Per-scenario `MaxSteps` / `MaxVisits`.** The existing demo-level guardrails apply
+  to the filtered run as-is. If real demos hit a need for per-scenario caps later, add
+  it on `ScenarioDef`.
+
+## Build sequence
+
+1. PLAN.md (this file) — review.
+2. `scenario.go` + `step.go` + `demokit.go` (data model + filtering helper, no rendering).
+3. `args.go` + flag wiring + run-loop filter; first set of tests pass.
+4. `markdown.go` (static md filter + actors + Next pointer); render tests pass.
+5. `render_trace.go` (trace md/html filter + Next pointer); render tests pass.
+6. `render_index.go` + index dispatch in `emitDoc`; index test passes.
+7. `render_json.go` projection update; JSON test passes.
+8. `examples/graph` tagging update + manual smoke (run, record/replay, all four
+   `--doc` formats).
+9. `ARCHITECTURE.md` and `README.md` short additions describing the surface.
+
+---
+
+## Why rejected (2026-05)
+
+The same problem — "this big demo has N narrative threads, run one at a time" — is
+solved cleanly by **consumer-side composition** without any demokit change:
+
+```
+examples/events/discord/
+  common/steps.go      # AddConnect(d), AddEventsList(d), AddPush(d), ...
+  basics/main.go       # composes the basics subset
+  webhook/main.go      # composes the webhook subset
+  full/main.go         # composes all helpers, in canonical order
+  README.md            # the "index" — plain prose
+  Makefile             # demo-basics → go run ./basics, etc.
+```
+
+Trade-offs that drove the decision:
+
+- **Wide blast radius.** Scenarios touch every renderer (`markdown.go`,
+  `render_trace.go`, `render_json.go`, plus index renderer), the run loop, the
+  flag parser, and `FilterArgs`. Cross-cutting filter axis vs. focused framework.
+- **Composition already idiomatic in mcpkit.** The pattern (helper package +
+  N `main.go`s) is how mcpkit organizes other examples — adding scenarios would
+  be a fifth pattern, not a unification.
+- **Overlap reality.** The driving demo (mcpkit events, 14 steps) has heavy
+  overlap (`connect` is in 4 of 5 scenarios). The cleanest tagging API for that
+  is "list step IDs in a scenario block" — but that's nearly the same source
+  shape as "call helpers in a main.go." Composition wins on cost.
+- **Per-variant flexibility.** Each binary can have its own description,
+  actors, renderer, `--serve` port, etc. without framework support for "these
+  fields are per-scenario."
+- **Reversibility.** If a real demokit consumer later hits a case composition
+  can't express, this plan can be picked up; no code commitment was made.
+
+What the consumer ends up writing instead:
+
+- Shared `common.NewDemo(title, description)` factory that pre-applies repeated
+  knobs (MaxSteps, MaxVisits, AutoAcceptAfter, Actors).
+- One `common.Add<StepName>(d)` per canonical step.
+- A `common.NextDemoPointer(d, "webhook", blurb)` that's just
+  `demo.Section("Next steps", "Run `make demo-webhook` to ...")`.
+
+No demokit-side primitive needed.

--- a/demokit.go
+++ b/demokit.go
@@ -48,6 +48,7 @@ type Demo struct {
 	showCountdown        bool
 	showStepDenominator  bool
 	inputTimeout         time.Duration // default per-prompt deadline; 0 = wait forever. Per-step override via StepDef.InputTimeout.
+	boxedVerbatim        bool          // render verbatim blocks inside the TUI bordered box (default: unboxed, today's behavior)
 	recorder        Recorder
 	replay          []TraceEntry
 	replayCursor    int
@@ -64,6 +65,7 @@ type Demo struct {
 	flagOut            string // output file for --doc bundle (else stdout)
 	flagServe          string // address (e.g. ":8765") to serve the live demo on
 	flagInputTimeout   time.Duration // demo-level prompt deadline; per-step .InputTimeout takes precedence
+	flagVariant        string        // --variant=<label>|all|default; filters multi-variant verbatim output in non-TUI contexts
 
 	// Sidecar-markdown loader state. Errors are stored rather than
 	// returned so FromMarkdown stays chainable; surfaced at Execute.
@@ -128,6 +130,51 @@ type ServeHandler func(d *Demo, addr string) error
 func (d *Demo) RegisterServeHandler(h ServeHandler) *Demo {
 	d.serveHandler = h
 	return d
+}
+
+// BoxedVerbatim opts this demo into the TUI's boxed + interactive
+// rendering of verbatim blocks. When set, single-variant verbatim
+// renders inside a styled box (today's behavior is outside the box
+// for mouse-select friendliness) and the pause prompt accepts a
+// `c` command to copy via the clipboard primitive.
+//
+// Multi-variant verbatim blocks (declared via VerbatimVariants) always
+// render boxed regardless of this flag — per-variant labels require a
+// frame to be readable.
+//
+// Has no effect on plain / markdown / HTML / JSON renderers — boxing
+// is a TUI rendering concern only.
+func (d *Demo) BoxedVerbatim() *Demo {
+	d.boxedVerbatim = true
+	return d
+}
+
+// IsBoxedVerbatim reports whether the demo opted into the boxed +
+// interactive verbatim rendering (set via BoxedVerbatim). Renderers
+// call this at RenderStep time to decide which path to take.
+func (d *Demo) IsBoxedVerbatim() bool {
+	return d.boxedVerbatim
+}
+
+// VariantSelection returns the current --variant selection. Used by
+// renderers (markdown, HTML, JSON, plain) to decide which verbatim
+// variants to emit when the user has set the flag.
+//
+// Mapping from --variant value:
+//   - "" or unset → VariantSelectionDefault (default-marked variants
+//     only, falling back to all when no Default is declared)
+//   - "all"       → VariantSelectionAll
+//   - "default"   → VariantSelectionDefault (explicit)
+//   - "<label>"   → VariantSelectionNamed("<label>")
+func (d *Demo) VariantSelection() VariantSelection {
+	switch d.flagVariant {
+	case "", "default":
+		return VariantSelectionDefault()
+	case "all":
+		return VariantSelectionAll()
+	default:
+		return VariantSelectionNamed(d.flagVariant)
+	}
 }
 
 // InputTimeout sets a default deadline for input prompts across the
@@ -274,7 +321,7 @@ func (d *Demo) Actors(actors ...ActorDef) *Demo {
 
 // Step adds an executable step to the demo. Returns the StepDef for chaining.
 func (d *Demo) Step(title string) *StepDef {
-	s := &StepDef{title: title}
+	s := &StepDef{demo: d, title: title}
 	d.items = append(d.items, s)
 	d.stepCount++
 	return s
@@ -346,6 +393,8 @@ func (d *Demo) RegisterFlags(fs *flag.FlagSet) {
 		"address to serve the live demo (e.g. :8765); requires importing demokit/web")
 	fs.DurationVar(&d.flagInputTimeout, "input-timeout", 0,
 		"default deadline for input prompts (e.g. 60s); per-step .InputTimeout overrides this. 0 = wait forever.")
+	fs.StringVar(&d.flagVariant, "variant", "",
+		"select which verbatim variants to render in non-TUI output: <label>|all|default. TUI ignores this flag.")
 }
 
 // scanOwnArgs is the default flag scanner used when RegisterFlags is
@@ -397,6 +446,11 @@ func (d *Demo) scanOwnArgs(args []string) {
 			if dur, err := time.ParseDuration(strings.TrimPrefix(arg, "--input-timeout=")); err == nil {
 				d.flagInputTimeout = dur
 			}
+		case arg == "--variant" && i+1 < len(args):
+			d.flagVariant = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "--variant="):
+			d.flagVariant = strings.TrimPrefix(arg, "--variant=")
 		}
 	}
 }

--- a/demokit_test.go
+++ b/demokit_test.go
@@ -87,15 +87,22 @@ func TestVerbatimAttachment(t *testing.T) {
 		t.Fatalf("VerbatimBlocks() len = %d, want 4", len(got))
 	}
 
-	want := []VerbatimView{
+	want := []struct {
+		Label, Lang, Content string
+	}{
 		{Label: "first", Lang: "", Content: "alpha"},
 		{Label: "second", Lang: "json", Content: `{"k":"v"}`},
 		{Label: "", Lang: "bash", Content: "echo hi"},
 		{Label: "", Lang: "", Content: "no-label content"},
 	}
 	for i, w := range want {
-		if got[i] != w {
-			t.Errorf("block[%d] = %+v, want %+v", i, got[i], w)
+		if len(got[i].Variants) != 1 {
+			t.Fatalf("block[%d] Variants len = %d, want 1 (single-variant backcompat)", i, len(got[i].Variants))
+		}
+		va := got[i].Variants[0]
+		if got[i].Label != w.Label || va.Lang != w.Lang || va.Content != w.Content {
+			t.Errorf("block[%d] = {label=%q variant={lang=%q content=%q}}, want {label=%q variant={lang=%q content=%q}}",
+				i, got[i].Label, va.Lang, va.Content, w.Label, w.Lang, w.Content)
 		}
 	}
 }
@@ -106,7 +113,7 @@ func TestVerbatimAttachment(t *testing.T) {
 func TestVerbatimContentByteExact(t *testing.T) {
 	raw := "  leading-space\n\ttabbed\nline\twith\ttabs\ntrailing-newline\n"
 	s := (&StepDef{}).Verbatim("", raw)
-	got := s.VerbatimBlocks()[0].Content
+	got := s.VerbatimBlocks()[0].Variants[0].Content
 	if got != raw {
 		t.Errorf("Verbatim content not preserved byte-exact:\n got:  %q\n want: %q", got, raw)
 	}

--- a/examples/graph/Makefile
+++ b/examples/graph/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run demo runquiet record replay gen-readme doc-md doc-html doc-json doc-bundle
+.PHONY: run demo runquiet record replay gen-readme doc-md doc-md-default doc-md-python doc-html doc-json doc-bundle
 
 TRACE := /tmp/demokit-graph-trace.json
 
@@ -35,8 +35,22 @@ gen-readme: record
 	@echo "Wrote README.md"
 
 # Trace-driven documentation outputs.
+# --variant flag demos:
+#   doc-md          renders every variant of every multi-variant block.
+#   doc-md-default  honors the Go-side Default() marker (curl only on
+#                   the refresh step) — matches what an unset --variant
+#                   produces when a Default is declared.
+#   doc-md-python   filters to just the variant labeled python; useful
+#                   for producing language-specific cheat-sheets from a
+#                   single demo definition.
 doc-md: record
 	go run . --doc md --from $(TRACE) --variant=all
+
+doc-md-default: record
+	go run . --doc md --from $(TRACE) --variant=default
+
+doc-md-python: record
+	go run . --doc md --from $(TRACE) --variant=python
 
 doc-html: record
 	go run . --doc html --from $(TRACE) --variant=all

--- a/examples/graph/Makefile
+++ b/examples/graph/Makefile
@@ -27,16 +27,19 @@ replay: record
 
 # Regenerate this example's README.md from a recorded trace.
 # The default-input run captures the "expired token → refresh" branch.
+# --variant=all so multi-variant verbatim blocks show every form in
+# the generated doc (e.g. curl/python/go for the refresh step); the
+# Go default marker on the curl variant still drives TUI keyboard copy.
 gen-readme: record
-	go run . --doc md --from $(TRACE) > README.md
+	go run . --doc md --from $(TRACE) --variant=all > README.md
 	@echo "Wrote README.md"
 
 # Trace-driven documentation outputs.
 doc-md: record
-	go run . --doc md --from $(TRACE)
+	go run . --doc md --from $(TRACE) --variant=all
 
 doc-html: record
-	go run . --doc html --from $(TRACE)
+	go run . --doc html --from $(TRACE) --variant=all
 
 # JSON for embed hosts. Includes both the static demo definition and
 # the recorded trace.

--- a/examples/graph/README.md
+++ b/examples/graph/README.md
@@ -12,7 +12,11 @@ try a different one.
 
 ### 1. Pick a symptom
 
-Most auth failures fall into a handful of buckets.
+Most auth failures fall into a handful of buckets:
+
+- **expired** — the access token's TTL has elapsed
+- **scope** — token is valid but lacks the required scope
+- **ratelimit** — auth server is shedding load
 
 **Inputs:**
 
@@ -43,6 +47,37 @@ API said: 401 token_expired
 → jumped to `refresh`
 
 ### 4. Refresh succeeds
+
+#### Refresh the token
+
+**curl**
+
+```bash
+curl -s -X POST https://auth.example/oauth2/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=refresh_token&refresh_token=eyJhbGci...'
+```
+
+**python**
+
+```python
+import requests
+r = requests.post(
+    "https://auth.example/oauth2/token",
+    data={"grant_type": "refresh_token", "refresh_token": "eyJhbGci..."},
+)
+token = r.json()["access_token"]
+```
+
+**go**
+
+```go
+resp, _ := http.PostForm("https://auth.example/oauth2/token", url.Values{
+    "grant_type":    {"refresh_token"},
+    "refresh_token": {"eyJhbGci..."},
+})
+defer resp.Body.Close()
+```
 
 ```
 New token: eyJhbGci...truncated

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -41,6 +41,7 @@ func main() {
 		MaxVisits(3).
 		AutoAcceptAfter(8 * time.Second).
 		ShowCountdown(true).
+		BoxedVerbatim().
 		Actors(
 			demokit.Actor("User", "User"),
 			demokit.Actor("App", "App"),
@@ -109,9 +110,22 @@ func main() {
 	demo.Step("Refresh succeeds").ID("refresh").
 		Arrow("App", "AS", "POST /token (refresh)").
 		DashedArrow("AS", "App", "{access_token, expires_in: 3600}").
-		Shell(`curl -s -X POST https://auth.example/oauth2/token \
+		VerbatimVariants("Refresh the token",
+			demokit.MakeVariant("curl", "bash", `curl -s -X POST https://auth.example/oauth2/token \
   -H 'Content-Type: application/x-www-form-urlencoded' \
-  -d 'grant_type=refresh_token&refresh_token=eyJhbGci...'`).
+  -d 'grant_type=refresh_token&refresh_token=eyJhbGci...'`).Default(),
+			demokit.MakeVariant("python", "python", `import requests
+r = requests.post(
+    "https://auth.example/oauth2/token",
+    data={"grant_type": "refresh_token", "refresh_token": "eyJhbGci..."},
+)
+token = r.json()["access_token"]`),
+			demokit.MakeVariant("go", "go", `resp, _ := http.PostForm("https://auth.example/oauth2/token", url.Values{
+    "grant_type":    {"refresh_token"},
+    "refresh_token": {"eyJhbGci..."},
+})
+defer resp.Body.Close()`),
+		).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			fmt.Println("New token: eyJhbGci...truncated")
 			return &demokit.StepResult{Next: "recovered"}

--- a/markdown.go
+++ b/markdown.go
@@ -107,7 +107,7 @@ func (d *Demo) Markdown() string {
 			if v.note != "" {
 				fmt.Fprintf(&b, "%s\n\n", v.note)
 			}
-			writeVerbatimMD(&b, v.verbatim)
+			writeVerbatimMD(&b, v.verbatim, d.VariantSelection())
 		case *SectionDef:
 			fmt.Fprintf(&b, "### %s\n\n%s\n\n", v.title, v.body)
 		}
@@ -145,13 +145,26 @@ func (d *Demo) Markdown() string {
 // Empty label skips the heading. Content is emitted byte-exact between
 // fences with a single trailing newline before the closing fence so we
 // don't leak the fence into adjacent paragraphs.
-func writeVerbatimMD(b *strings.Builder, blocks []verbatimBlock) {
+//
+// Multi-variant blocks emit each variant under a **bold-label** line in
+// declaration order; single-variant blocks emit the legacy shape (no
+// variant label). selection controls which variants are rendered when
+// the caller has set --variant; pass VariantSelectionAll to print every
+// variant.
+func writeVerbatimMD(b *strings.Builder, blocks []verbatimBlock, selection VariantSelection) {
 	for _, v := range blocks {
 		if v.Label != "" {
 			fmt.Fprintf(b, "#### %s\n\n", v.Label)
 		}
-		fmt.Fprintf(b, "```%s\n", v.Lang)
-		b.WriteString(strings.TrimRight(v.Content, "\n"))
-		b.WriteString("\n```\n\n")
+		chosen := selection.Apply(v.Variants)
+		multi := len(v.Variants) > 1 && len(chosen) > 1
+		for _, va := range chosen {
+			if multi && va.Label != "" {
+				fmt.Fprintf(b, "**%s**\n\n", va.Label)
+			}
+			fmt.Fprintf(b, "```%s\n", va.Lang)
+			b.WriteString(strings.TrimRight(va.Content, "\n"))
+			b.WriteString("\n```\n\n")
+		}
 	}
 }

--- a/markdown_load.go
+++ b/markdown_load.go
@@ -89,7 +89,9 @@ func (d *Demo) FromMarkdownBytes(src []byte) *Demo {
 
 	for _, li := range loaded {
 		if li.isStep() {
-			d.items = append(d.items, li.toStep())
+			s := li.toStep()
+			s.demo = d
+			d.items = append(d.items, s)
 			d.stepCount++
 		} else {
 			d.items = append(d.items, li.toSection())

--- a/render_json.go
+++ b/render_json.go
@@ -90,6 +90,30 @@ func (d *Demo) JSON() string {
 	return RenderDocumentJSON(RenderContext{Demo: d})
 }
 
+// filterVerbatimViews applies the selection to each block's variants
+// in a VerbatimView slice. Blocks whose variants are all filtered out
+// are dropped — embed hosts shouldn't see empty Variants arrays.
+func filterVerbatimViews(in []VerbatimView, selection VariantSelection) []VerbatimView {
+	var out []VerbatimView
+	for _, b := range in {
+		// Convert to Variant for the selection helper, then back.
+		vs := make([]Variant, len(b.Variants))
+		for i, v := range b.Variants {
+			vs[i] = Variant{Label: v.Label, Lang: v.Lang, Content: v.Content, IsDefault: v.IsDefault}
+		}
+		kept := selection.Apply(vs)
+		if len(kept) == 0 {
+			continue
+		}
+		filtered := make([]VariantView, len(kept))
+		for i, v := range kept {
+			filtered[i] = VariantView{Label: v.Label, Lang: v.Lang, Content: v.Content, IsDefault: v.IsDefault}
+		}
+		out = append(out, VerbatimView{Label: b.Label, Variants: filtered})
+	}
+	return out
+}
+
 // projectDemo builds the JSON-serializable view of a Demo.
 func projectDemo(d *Demo) *demoView {
 	v := &demoView{
@@ -107,7 +131,7 @@ func projectDemo(d *Demo) *demoView {
 				Note:     x.note,
 				Arrows:   x.Arrows(),
 				Refs:     x.refs,
-				Verbatim: x.VerbatimBlocks(),
+				Verbatim: filterVerbatimViews(x.VerbatimBlocks(), d.VariantSelection()),
 			}
 			for _, in := range x.inputs {
 				iv.Inputs = append(iv.Inputs, inputView{

--- a/render_json_test.go
+++ b/render_json_test.go
@@ -179,10 +179,11 @@ func TestJSONFromTraceWrapperEquivalence(t *testing.T) {
 }
 
 // TestRenderDocumentJSONVerbatimProjection verifies a step's verbatim
-// blocks project into the JSON envelope under "verbatim" with lowercase
-// label/lang/content tags. Web embeds — both static (data-src
-// trace.json) and live (WS step-start) — depend on this exact shape to
-// render copy-pasteable code blocks in the player.
+// blocks project into the JSON envelope under "verbatim" with a
+// "variants" array per block. Single-snippet blocks produce a
+// one-element variants array — embed hosts read the same shape
+// unconditionally regardless of whether the author used Verbatim()
+// or VerbatimVariants().
 func TestRenderDocumentJSONVerbatimProjection(t *testing.T) {
 	d := New("V").Description("d")
 	d.Step("only").ID("only").
@@ -201,20 +202,37 @@ func TestRenderDocumentJSONVerbatimProjection(t *testing.T) {
 	if !ok || len(verb) != 2 {
 		t.Fatalf("verbatim not a 2-element list: %v", step0["verbatim"])
 	}
+
 	v0 := verb[0].(map[string]any)
-	if v0["label"] != "the wire" || v0["lang"] != "bash" || v0["content"] != "curl -s http://x" {
-		t.Errorf("verbatim[0] = %v", v0)
+	if v0["label"] != "the wire" {
+		t.Errorf("verbatim[0].label = %v, want %q", v0["label"], "the wire")
 	}
+	vars0 := v0["variants"].([]any)
+	if len(vars0) != 1 {
+		t.Fatalf("verbatim[0].variants len = %d, want 1", len(vars0))
+	}
+	va0 := vars0[0].(map[string]any)
+	if va0["lang"] != "bash" || va0["content"] != "curl -s http://x" {
+		t.Errorf("verbatim[0].variants[0] = %v", va0)
+	}
+	if _, hasLabel := va0["label"]; hasLabel {
+		t.Errorf("variants[0].label should be omitted (omitempty) for single-variant block, got %v", va0)
+	}
+
 	v1 := verb[1].(map[string]any)
-	// Empty label/lang must be omitted (omitempty); only content survives.
 	if _, hasLabel := v1["label"]; hasLabel {
-		t.Errorf("verbatim[1] should omit empty label, got %v", v1)
+		t.Errorf("verbatim[1] should omit empty outer label, got %v", v1)
 	}
-	if _, hasLang := v1["lang"]; hasLang {
-		t.Errorf("verbatim[1] should omit empty lang, got %v", v1)
+	vars1 := v1["variants"].([]any)
+	if len(vars1) != 1 {
+		t.Fatalf("verbatim[1].variants len = %d, want 1", len(vars1))
 	}
-	if v1["content"] != "no-label content" {
-		t.Errorf("verbatim[1].content = %v", v1["content"])
+	va1 := vars1[0].(map[string]any)
+	if _, hasLang := va1["lang"]; hasLang {
+		t.Errorf("verbatim[1].variants[0] should omit empty lang, got %v", va1)
+	}
+	if va1["content"] != "no-label content" {
+		t.Errorf("verbatim[1].variants[0].content = %v", va1["content"])
 	}
 }
 

--- a/render_trace.go
+++ b/render_trace.go
@@ -35,7 +35,7 @@ func RenderEntryMD(ctx RenderContext, entry TraceEntry, opts EntryOpts) string {
 			fmt.Fprintf(&b, "%s\n\n", s.note)
 		}
 		if s != nil && len(s.verbatim) > 0 {
-			writeVerbatimMD(&b, s.verbatim)
+			writeVerbatimMD(&b, s.verbatim, demoVariantSelection(ctx.Demo))
 		}
 		if s != nil && len(s.refs) > 0 {
 			b.WriteString("> **References:** ")
@@ -155,7 +155,7 @@ func RenderEntryHTML(ctx RenderContext, entry TraceEntry, opts EntryOpts) string
 			fmt.Fprintf(&b, "<p>%s</p>\n", html.EscapeString(s.note))
 		}
 		if s != nil && len(s.verbatim) > 0 {
-			writeVerbatimHTML(&b, s.verbatim)
+			writeVerbatimHTML(&b, s.verbatim, demoVariantSelection(ctx.Demo))
 		}
 
 		if len(entry.Inputs) > 0 {
@@ -237,20 +237,38 @@ func RenderDocumentHTML(ctx RenderContext) string {
 // h4 heading + a <pre><code> with html-escaped content. Language hints
 // surface as the standard `language-X` class so a downstream highlighter
 // (Prism, highlight.js) can pick them up.
-func writeVerbatimHTML(b *strings.Builder, blocks []verbatimBlock) {
+func writeVerbatimHTML(b *strings.Builder, blocks []verbatimBlock, selection VariantSelection) {
 	for _, v := range blocks {
 		if v.Label != "" {
 			fmt.Fprintf(b, "<h4>%s</h4>\n", html.EscapeString(v.Label))
 		}
-		if v.Lang != "" {
-			fmt.Fprintf(b, "<pre><code class=\"language-%s\">%s</code></pre>\n",
-				html.EscapeString(v.Lang),
-				html.EscapeString(strings.TrimRight(v.Content, "\n")))
-		} else {
-			fmt.Fprintf(b, "<pre><code>%s</code></pre>\n",
-				html.EscapeString(strings.TrimRight(v.Content, "\n")))
+		chosen := selection.Apply(v.Variants)
+		multi := len(v.Variants) > 1 && len(chosen) > 1
+		for _, va := range chosen {
+			if multi && va.Label != "" {
+				fmt.Fprintf(b, "<p><strong>%s</strong></p>\n", html.EscapeString(va.Label))
+			}
+			if va.Lang != "" {
+				fmt.Fprintf(b, "<pre><code class=\"language-%s\">%s</code></pre>\n",
+					html.EscapeString(va.Lang),
+					html.EscapeString(strings.TrimRight(va.Content, "\n")))
+			} else {
+				fmt.Fprintf(b, "<pre><code>%s</code></pre>\n",
+					html.EscapeString(strings.TrimRight(va.Content, "\n")))
+			}
 		}
 	}
+}
+
+// demoVariantSelection is a nil-safe lookup for the demo's current
+// VariantSelection. Used by trace renderers where ctx.Demo may be nil
+// (e.g. raw-trace render without a demo definition); falls back to
+// VariantSelectionDefault.
+func demoVariantSelection(d *Demo) VariantSelection {
+	if d == nil {
+		return VariantSelectionDefault()
+	}
+	return d.VariantSelection()
 }
 
 // lookupStep finds a step by ID in the demo's items list, or nil if the

--- a/renderer.go
+++ b/renderer.go
@@ -259,46 +259,70 @@ func (r *PlainRenderer) WaitForStep(opts WaitOpts) {
 
 // WaitForEnterOrTimeout blocks until the user presses Enter on stdin or
 // the timeout elapses. Returns true if Enter was pressed, false if the
-// timer fired. Uses muesli/cancelreader to cancel the pending stdin
-// read when the timer wins, so the read goroutine never leaks across
-// successive calls — important because a leaked goroutine still
-// blocked on os.Stdin can race later prompt reads and steal input.
+// timer fired. Discards the line content — callers that need to inspect
+// what the user typed should use WaitForLineOrTimeout instead.
+//
+// Uses muesli/cancelreader to cancel the pending stdin read when the
+// timer wins, so the read goroutine never leaks across successive
+// calls — important because a leaked goroutine still blocked on
+// os.Stdin can race later prompt reads and steal input.
 //
 // onTick, if non-nil, is invoked roughly every 100ms with the time
 // remaining; renderers use it to redraw a countdown bar.
 //
 // On platforms where cancelreader is unavailable, the function
 // degrades gracefully: it sleeps for the timeout (no Enter shortcut)
-// and returns false. The pending-read leak is avoided either way.
+// and returns false.
 func WaitForEnterOrTimeout(timeout time.Duration, onTick func(remaining time.Duration)) bool {
+	_, ok := WaitForLineOrTimeout(timeout, onTick)
+	return ok
+}
+
+// WaitForLineOrTimeout is the line-returning sibling of
+// WaitForEnterOrTimeout. Reads one line from stdin racing against the
+// timer; returns ("", false) when the timer fires, (line, true) when
+// the user submitted a line (line excludes the trailing newline,
+// preserving any other whitespace the user typed).
+//
+// Used by renderers that combine an auto-advance countdown with an
+// interactive command prompt — the returned line lets the caller
+// dispatch (e.g. "c" → copy) when the input was non-empty, advance
+// when the input was empty, or auto-advance when the timer won.
+func WaitForLineOrTimeout(timeout time.Duration, onTick func(remaining time.Duration)) (string, bool) {
 	if timeout <= 0 {
-		bufio.NewReader(os.Stdin).ReadString('\n')
-		return true
+		line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		return strings.TrimRight(line, "\r\n"), true
 	}
 	cr, err := cancelreader.NewReader(os.Stdin)
 	if err != nil {
-		// Platform unsupported — sleep and give up the Enter shortcut
-		// rather than leak a goroutine.
 		time.Sleep(timeout)
-		return false
+		return "", false
 	}
 	defer cr.Close()
 
-	enter := make(chan struct{}, 1)
+	type lineMsg struct {
+		text string
+		ok   bool
+	}
+	got := make(chan lineMsg, 1)
 	go func() {
-		bufio.NewReader(cr).ReadString('\n')
-		enter <- struct{}{}
+		text, err := bufio.NewReader(cr).ReadString('\n')
+		if err != nil {
+			got <- lineMsg{ok: false}
+			return
+		}
+		got <- lineMsg{text: strings.TrimRight(text, "\r\n"), ok: true}
 	}()
 
 	deadline := time.Now().Add(timeout)
 	if onTick == nil {
 		select {
-		case <-enter:
-			return true
+		case msg := <-got:
+			return msg.text, msg.ok
 		case <-time.After(timeout):
 			cr.Cancel()
-			<-enter
-			return false
+			<-got
+			return "", false
 		}
 	}
 
@@ -308,13 +332,13 @@ func WaitForEnterOrTimeout(timeout time.Duration, onTick func(remaining time.Dur
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			cr.Cancel()
-			<-enter
-			return false
+			<-got
+			return "", false
 		}
 		onTick(remaining)
 		select {
-		case <-enter:
-			return true
+		case msg := <-got:
+			return msg.text, msg.ok
 		case <-tick.C:
 		}
 	}

--- a/renderer.go
+++ b/renderer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/term"
 	"github.com/muesli/cancelreader"
 )
 
@@ -276,6 +277,116 @@ func (r *PlainRenderer) WaitForStep(opts WaitOpts) {
 func WaitForEnterOrTimeout(timeout time.Duration, onTick func(remaining time.Duration)) bool {
 	_, ok := WaitForLineOrTimeout(timeout, onTick)
 	return ok
+}
+
+// KeyEnter is the byte returned by WaitForKeyOrTimeout when the user
+// presses Enter. On most terminals the literal byte read in raw mode
+// is '\r' (carriage return); the constant lets callers compare
+// against a stable name. Some terminals (rare) deliver '\n' — the
+// public callers should accept both.
+const KeyEnter = '\r'
+
+// WaitForKeyOrTimeout puts the terminal in raw mode and reads a single
+// byte from stdin racing against the timer. Used by interactive
+// countdown prompts that want any-key (not just Enter) to interrupt.
+// Returns:
+//
+//   - (key, true) on the first byte typed. Enter typically arrives as
+//     '\r' (KeyEnter); some terminals send '\n'. Callers wanting "any
+//     key but Enter" should match both.
+//   - (0, false) when the timer fires before any input.
+//
+// The terminal is restored to its prior cooked-mode state before the
+// function returns so a caller can drop into line-based input
+// immediately. On platforms where raw mode is unavailable (or stdin
+// is not a terminal), falls back to WaitForLineOrTimeout — the user
+// has to press Enter to interrupt, but the function still works.
+//
+// onTick, if non-nil, fires roughly every 100ms with remaining time
+// — renderers use it to redraw a countdown bar.
+func WaitForKeyOrTimeout(timeout time.Duration, onTick func(remaining time.Duration)) (byte, bool) {
+	fd := os.Stdin.Fd()
+	if !term.IsTerminal(fd) {
+		return fallbackToLineRead(timeout, onTick)
+	}
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return fallbackToLineRead(timeout, onTick)
+	}
+	defer term.Restore(fd, state)
+
+	if timeout <= 0 {
+		buf := make([]byte, 1)
+		n, err := os.Stdin.Read(buf)
+		if err != nil || n == 0 {
+			return 0, false
+		}
+		return buf[0], true
+	}
+
+	cr, err := cancelreader.NewReader(os.Stdin)
+	if err != nil {
+		return fallbackToLineRead(timeout, onTick)
+	}
+	defer cr.Close()
+
+	type keyMsg struct {
+		key byte
+		ok  bool
+	}
+	got := make(chan keyMsg, 1)
+	go func() {
+		buf := make([]byte, 1)
+		n, err := cr.Read(buf)
+		if err != nil || n == 0 {
+			got <- keyMsg{ok: false}
+			return
+		}
+		got <- keyMsg{key: buf[0], ok: true}
+	}()
+
+	deadline := time.Now().Add(timeout)
+	if onTick == nil {
+		select {
+		case msg := <-got:
+			return msg.key, msg.ok
+		case <-time.After(timeout):
+			cr.Cancel()
+			<-got
+			return 0, false
+		}
+	}
+
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			cr.Cancel()
+			<-got
+			return 0, false
+		}
+		onTick(remaining)
+		select {
+		case msg := <-got:
+			return msg.key, msg.ok
+		case <-tick.C:
+		}
+	}
+}
+
+// fallbackToLineRead is the cooked-mode degradation for
+// WaitForKeyOrTimeout on platforms where raw mode is unavailable.
+// User must press Enter to interrupt (but the function still works).
+func fallbackToLineRead(timeout time.Duration, onTick func(remaining time.Duration)) (byte, bool) {
+	line, ok := WaitForLineOrTimeout(timeout, onTick)
+	if !ok {
+		return 0, false
+	}
+	if line == "" {
+		return KeyEnter, true
+	}
+	return line[0], true
 }
 
 // WaitForLineOrTimeout is the line-returning sibling of

--- a/step.go
+++ b/step.go
@@ -29,6 +29,7 @@ type item interface {
 
 // StepDef defines one executable step in the demo.
 type StepDef struct {
+	demo        *Demo // back-pointer set by Demo.Step (and Demo.Bind) so renderers can query demo-wide flags (BoxedVerbatim, ...). Nil only for steps constructed standalone in tests.
 	id          string
 	title       string
 	arrows      []arrowDef
@@ -46,18 +47,127 @@ type StepDef struct {
 // verbatimBlock holds character-exact content for copy-paste-friendly
 // display. Stored author-time on StepDef; renderers look it up via
 // VerbatimBlocks(). Same lifecycle as note/refs — not part of TraceEntry.
+//
+// A block may carry multiple Variants when the author wants to show the
+// same task expressed several ways (curl / gcloud CLI / Python). Single-
+// snippet blocks are stored as a one-element Variants slice — renderers
+// don't branch on the count, they iterate uniformly.
 type verbatimBlock struct {
-	Label   string
-	Lang    string
-	Content string
+	Label    string
+	Variants []Variant
+}
+
+// Variant is one labeled form of a verbatim snippet. Multi-variant blocks
+// declare N variants and renderers pick which to show (or, in markdown,
+// emit all of them with sub-labels). IsDefault marks the form preferred
+// by non-interactive contexts and the demo-defined "copy this one"
+// target; it has no effect when only one variant is declared.
+//
+// Construct via MakeVariant("curl", "bash", "...").Default() for the
+// fluent form, or as a struct literal — both are supported.
+type Variant struct {
+	Label     string // "curl", "gcloud", "Python" — empty for single-variant blocks
+	Lang      string // fenced-code language hint
+	Content   string
+	IsDefault bool
+}
+
+// MakeVariant constructs a Variant. Use .Default() to mark the preferred
+// form for non-interactive output and the keyboard-copy target.
+//
+// Named MakeVariant (not Variant) because the type is already named
+// Variant — Go doesn't allow a function and a type to share a name.
+func MakeVariant(label, lang, content string) Variant {
+	return Variant{Label: label, Lang: lang, Content: content}
+}
+
+// Default marks this variant as the preferred form. At most one variant
+// per block is expected to carry IsDefault=true; if multiple are marked,
+// the first wins. If none is marked, "default" behaves as "first".
+func (v Variant) Default() Variant {
+	v.IsDefault = true
+	return v
+}
+
+// VariantView is the read-only projection of a Variant exposed to
+// renderers and JSON consumers. JSON field is named "default" for wire
+// stability — embed hosts read it as the marker for the preferred form.
+type VariantView struct {
+	Label     string `json:"label,omitempty"`
+	Lang      string `json:"lang,omitempty"`
+	Content   string `json:"content"`
+	IsDefault bool   `json:"default,omitempty"`
 }
 
 // VerbatimView is the read-only projection of a verbatim block exposed
-// to renderers and JSON consumers.
+// to renderers and JSON consumers. Single-variant blocks produce a
+// one-element Variants slice; renderers treat all blocks uniformly.
 type VerbatimView struct {
-	Label   string `json:"label,omitempty"`
-	Lang    string `json:"lang,omitempty"`
-	Content string `json:"content"`
+	Label    string        `json:"label,omitempty"`
+	Variants []VariantView `json:"variants"`
+}
+
+// VariantSelection encodes a renderer's filter over a block's variants.
+// Renderers consult it to decide which variants to emit when the user
+// has set --variant on the CLI.
+//
+// Use the constructors (VariantSelectionAll, VariantSelectionDefault,
+// VariantSelectionNamed) rather than the struct literal — internal
+// fields may shift.
+type VariantSelection struct {
+	all      bool
+	defOnly  bool   // strict: error if no Default-marked variant exists
+	name     string // empty = no name filter
+}
+
+// VariantSelectionAll renders every variant of every block.
+func VariantSelectionAll() VariantSelection {
+	return VariantSelection{all: true}
+}
+
+// VariantSelectionDefault renders only Default-marked variants. Blocks
+// with no Default-marked variant fall back to all variants. Use this
+// when "--variant" is unset and the demo wants the implicit-default
+// behavior.
+func VariantSelectionDefault() VariantSelection {
+	return VariantSelection{}
+}
+
+// VariantSelectionNamed renders only variants whose Label matches name
+// (case-insensitive). Blocks with no matching variant are dropped from
+// output. Used when the user passes --variant=<label>.
+func VariantSelectionNamed(name string) VariantSelection {
+	return VariantSelection{name: name}
+}
+
+// Apply filters block.Variants according to the selection rules. The
+// returned slice is always a fresh allocation so callers may mutate.
+func (s VariantSelection) Apply(in []Variant) []Variant {
+	if s.all || len(in) == 0 {
+		out := make([]Variant, len(in))
+		copy(out, in)
+		return out
+	}
+	if s.name != "" {
+		var out []Variant
+		for _, v := range in {
+			if strings.EqualFold(v.Label, s.name) {
+				out = append(out, v)
+			}
+		}
+		return out
+	}
+	// Default behavior.
+	for _, v := range in {
+		if v.IsDefault {
+			return []Variant{v}
+		}
+	}
+	// No Default marked — render everything so non-interactive output
+	// stays lossless when the author didn't specify a preference.
+	out := make([]Variant, len(in))
+	copy(out, in)
+	return out
 }
 
 type arrowDef struct {
@@ -142,22 +252,25 @@ func (s *StepDef) Input(d InputDef) *StepDef {
 }
 
 // Verbatim attaches a copy-paste-friendly content block to this step.
-// Content is preserved character-exact across all renderers; the TUI
-// renders it outside the bordered box so wrapping cannot inject border
-// chars into the middle of a line. Multiple calls render in declaration
-// order. Empty label is allowed (skips the heading in markdown, omits
-// the label line in the TUI). Use VerbatimLang to specify a fenced-code
-// language hint for markdown.
+// Content is preserved character-exact across all renderers. By default
+// the TUI renders it outside the bordered box so wrapping cannot inject
+// border chars into the middle of a line — call Demo.BoxedVerbatim() to
+// render every verbatim inside a styled box with keyboard copy instead.
+// Multiple calls render in declaration order. Empty label is allowed
+// (skips the heading in markdown, omits the label line in the TUI).
+// Use VerbatimLang to specify a fenced-code language hint for markdown.
 func (s *StepDef) Verbatim(label, content string) *StepDef {
-	s.verbatim = append(s.verbatim, verbatimBlock{Label: label, Content: content})
-	return s
+	return s.VerbatimLang(label, "", content)
 }
 
 // VerbatimLang is Verbatim with an explicit fenced-code language hint
-// (used by markdown renderers; ignored by the TUI). Pass an empty lang
-// for an unfenced default.
+// (used by markdown / HTML renderers). Pass an empty lang for an
+// unfenced default.
 func (s *StepDef) VerbatimLang(label, lang, content string) *StepDef {
-	s.verbatim = append(s.verbatim, verbatimBlock{Label: label, Lang: lang, Content: content})
+	s.verbatim = append(s.verbatim, verbatimBlock{
+		Label:    label,
+		Variants: []Variant{{Lang: lang, Content: content}},
+	})
 	return s
 }
 
@@ -168,12 +281,36 @@ func (s *StepDef) Shell(content string) *StepDef {
 	return s.VerbatimLang("", "bash", content)
 }
 
+// VerbatimVariants attaches a multi-variant verbatim block to this step
+// — one labeled snippet rendered N ways (curl / gcloud / Python ...).
+// At most one variant should carry Default=true (via .Default()); if
+// none does, the first declared is the implicit default for non-
+// interactive output and keyboard copy.
+//
+// Multi-variant blocks always render inside the TUI's bordered box
+// regardless of Demo.BoxedVerbatim() — the per-variant labels need a
+// frame to be readable.
+//
+// Markdown / HTML output emits every variant labeled in declaration
+// order; --variant=<label> at the CLI filters to a single one.
+func (s *StepDef) VerbatimVariants(label string, variants ...Variant) *StepDef {
+	s.verbatim = append(s.verbatim, verbatimBlock{
+		Label:    label,
+		Variants: append([]Variant(nil), variants...),
+	})
+	return s
+}
+
 // VerbatimBlocks returns a read-only view of this step's attached
 // verbatim blocks in declaration order.
 func (s *StepDef) VerbatimBlocks() []VerbatimView {
 	out := make([]VerbatimView, len(s.verbatim))
 	for i, v := range s.verbatim {
-		out[i] = VerbatimView{Label: v.Label, Lang: v.Lang, Content: v.Content}
+		vars := make([]VariantView, len(v.Variants))
+		for j, va := range v.Variants {
+			vars[j] = VariantView{Label: va.Label, Lang: va.Lang, Content: va.Content, IsDefault: va.IsDefault}
+		}
+		out[i] = VerbatimView{Label: v.Label, Variants: vars}
 	}
 	return out
 }
@@ -264,6 +401,12 @@ func (s *StepDef) Run(fn func(StepContext) *StepResult) *StepDef {
 
 // StepID returns the step's identifier (auto-assigned at Execute time if unset).
 func (s *StepDef) StepID() string { return s.id }
+
+// Demo returns the parent demo for this step, or nil if the step was
+// constructed standalone (e.g. in tests). Renderers use this to query
+// demo-wide flags like IsBoxedVerbatim that affect how this step
+// renders.
+func (s *StepDef) Demo() *Demo { return s.demo }
 
 // Title returns the step title.
 func (s *StepDef) Title() string { return s.title }

--- a/tui/copy.go
+++ b/tui/copy.go
@@ -1,0 +1,139 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/panyam/demokit"
+)
+
+// copyableBlock is a flat handle for the pause-loop copy parser. It
+// pairs a verbatim block with its index inside the step (used for
+// future addressability) so error messages can refer to the block
+// unambiguously.
+type copyableBlock struct {
+	index int
+	view  demokit.VerbatimView
+}
+
+// copyableBlocks returns the verbatim blocks on step that participate
+// in the line-based copy command — i.e. blocks rendered inside the
+// TUI's bordered box. Single-variant blocks are copyable only when the
+// demo set Demo.BoxedVerbatim(). Multi-variant blocks are always
+// copyable (they're auto-boxed regardless of the flag).
+func (r *Renderer) copyableBlocks(step *demokit.StepDef) []copyableBlock {
+	if step == nil {
+		return nil
+	}
+	demo := step.Demo()
+	boxedDefault := demo != nil && demo.IsBoxedVerbatim()
+	var out []copyableBlock
+	for i, v := range step.VerbatimBlocks() {
+		if len(v.Variants) == 0 {
+			continue
+		}
+		if !(boxedDefault || len(v.Variants) > 1) {
+			continue
+		}
+		out = append(out, copyableBlock{index: i, view: v})
+	}
+	return out
+}
+
+// copyPromptHint builds the one-line prompt shown at the pause. The
+// hint adapts to what's actually copyable on the step — no copy hint
+// when there's nothing to copy, a simple "c to copy" for single-
+// variant cases, and a labeled form when variants are present.
+func copyPromptHint(copyables []copyableBlock) string {
+	if len(copyables) == 0 {
+		return "  Press Enter to run this step..."
+	}
+	// Look for any multi-variant block to decide whether to expose the
+	// "c <label>" form in the hint.
+	hasVariants := false
+	for _, c := range copyables {
+		if len(c.view.Variants) > 1 {
+			hasVariants = true
+			break
+		}
+	}
+	if hasVariants {
+		return "  Press Enter to run · type `c` to copy default · `c <label>` for a named variant"
+	}
+	return "  Press Enter to run · type `c` to copy"
+}
+
+// handleCopyCommand parses one line typed at the pause and executes
+// the requested action against the available copyable blocks. Returns
+// a status line to display after the action ("(copied via osc52)",
+// error, etc.); the caller re-prompts after printing it.
+//
+// Recognized commands (case-insensitive):
+//
+//	c           → copy the first copyable block's default variant
+//	              (or first variant if none marked default)
+//	c <label>   → copy the variant whose Label matches <label> from the
+//	              first copyable block carrying that label. Useful when
+//	              the step has only one block; if multiple blocks share
+//	              a label, the earliest in declaration order wins.
+//
+// Anything else returns "(unknown command)" so the user sees the
+// prompt is interactive rather than waiting on raw input.
+func (r *Renderer) handleCopyCommand(cmd string, copyables []copyableBlock) string {
+	if len(copyables) == 0 {
+		return "(no copyable blocks on this step)"
+	}
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 || !strings.EqualFold(parts[0], "c") {
+		return fmt.Sprintf("(unknown command %q — type `c` to copy or press Enter to continue)", cmd)
+	}
+
+	// Bare "c" → first copyable block, default-or-first variant.
+	if len(parts) == 1 {
+		block := copyables[0]
+		va := pickDefaultVariant(block.view.Variants)
+		return performCopy(block.view.Label, va)
+	}
+
+	// "c <label>" → find first block with a matching variant label.
+	wanted := strings.Join(parts[1:], " ")
+	for _, c := range copyables {
+		for _, va := range c.view.Variants {
+			if strings.EqualFold(va.Label, wanted) {
+				return performCopy(c.view.Label, va)
+			}
+		}
+	}
+	return fmt.Sprintf("(no variant labeled %q on this step)", wanted)
+}
+
+// pickDefaultVariant returns the variant marked IsDefault, or the
+// first variant when none is marked. variants must be non-empty —
+// callers filter empty blocks out of copyables.
+func pickDefaultVariant(variants []demokit.VariantView) demokit.VariantView {
+	for _, v := range variants {
+		if v.IsDefault {
+			return v
+		}
+	}
+	return variants[0]
+}
+
+// performCopy invokes the clipboard primitive on va.Content and
+// returns the status line to display. Includes the variant's label
+// in the message when present so the user sees which form they
+// grabbed.
+func performCopy(blockLabel string, va demokit.VariantView) string {
+	strategy, ok := demokit.Copy(va.Content)
+	if !ok {
+		return "(copy failed — no clipboard provider available)"
+	}
+	what := va.Label
+	if what == "" {
+		what = blockLabel
+	}
+	if what == "" {
+		return fmt.Sprintf("(copied via %s)", strategy)
+	}
+	return fmt.Sprintf("(copied %q via %s)", what, strategy)
+}

--- a/tui/copy.go
+++ b/tui/copy.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/panyam/demokit"
@@ -43,13 +44,14 @@ func (r *Renderer) copyableBlocks(step *demokit.StepDef) []copyableBlock {
 // copyPromptHint builds the one-line prompt shown at the pause. The
 // hint adapts to what's actually copyable on the step — no copy hint
 // when there's nothing to copy, a simple "c to copy" for single-
-// variant cases, and a labeled form when variants are present.
+// variant cases, and the full switch/copy syntax when variants are
+// present.
 func copyPromptHint(copyables []copyableBlock) string {
 	if len(copyables) == 0 {
 		return "  Press Enter to run this step..."
 	}
 	// Look for any multi-variant block to decide whether to expose the
-	// "c <label>" form in the hint.
+	// switch/<label> forms in the hint.
 	hasVariants := false
 	for _, c := range copyables {
 		if len(c.view.Variants) > 1 {
@@ -58,7 +60,7 @@ func copyPromptHint(copyables []copyableBlock) string {
 		}
 	}
 	if hasVariants {
-		return "  Press Enter to run · type `c` to copy default · `c <label>` for a named variant"
+		return "  Press Enter to run · `<label>` or `<n>` to switch · `c` copy active · `c <label>` copy named"
 	}
 	return "  Press Enter to run · type `c` to copy"
 }
@@ -66,57 +68,101 @@ func copyPromptHint(copyables []copyableBlock) string {
 // handleCopyCommand parses one line typed at the pause and executes
 // the requested action against the available copyable blocks. Returns
 // a status line to display after the action ("(copied via osc52)",
-// error, etc.); the caller re-prompts after printing it.
+// "(switched to python)", error, etc.); the caller re-prompts after
+// printing it. The bool return is true when the caller should
+// re-render the active variant inline (switch happened) — the prompt
+// loop handles that.
 //
 // Recognized commands (case-insensitive):
 //
-//	c           → copy the first copyable block's default variant
-//	              (or first variant if none marked default)
-//	c <label>   → copy the variant whose Label matches <label> from the
-//	              first copyable block carrying that label. Useful when
-//	              the step has only one block; if multiple blocks share
-//	              a label, the earliest in declaration order wins.
+//	c             → copy the first copyable block's currently-active
+//	                variant. Active starts at the Default-marked
+//	                variant (or the first variant if none is marked).
+//	c <label>     → copy a variant by label without switching active.
+//	                Matches across all copyable blocks, earliest wins.
+//	<label>       → switch the first multi-variant block's active to
+//	                this label.
+//	<n>           → switch by 1-based index within the first
+//	                multi-variant block.
 //
 // Anything else returns "(unknown command)" so the user sees the
 // prompt is interactive rather than waiting on raw input.
-func (r *Renderer) handleCopyCommand(cmd string, copyables []copyableBlock) string {
+func (r *Renderer) handleCopyCommand(cmd string, copyables []copyableBlock) (msg string, switched bool) {
 	if len(copyables) == 0 {
-		return "(no copyable blocks on this step)"
+		return "(no copyable blocks on this step)", false
 	}
 	parts := strings.Fields(cmd)
-	if len(parts) == 0 || !strings.EqualFold(parts[0], "c") {
-		return fmt.Sprintf("(unknown command %q — type `c` to copy or press Enter to continue)", cmd)
+	if len(parts) == 0 {
+		return "", false
 	}
+	first := strings.ToLower(parts[0])
 
-	// Bare "c" → first copyable block, default-or-first variant.
-	if len(parts) == 1 {
-		block := copyables[0]
-		va := pickDefaultVariant(block.view.Variants)
-		return performCopy(block.view.Label, va)
-	}
-
-	// "c <label>" → find first block with a matching variant label.
-	wanted := strings.Join(parts[1:], " ")
-	for _, c := range copyables {
-		for _, va := range c.view.Variants {
-			if strings.EqualFold(va.Label, wanted) {
-				return performCopy(c.view.Label, va)
+	switch first {
+	case "c":
+		// Copy commands.
+		if len(parts) == 1 {
+			block := copyables[0]
+			va := block.view.Variants[r.activeIndex(block.index)]
+			return performCopy(block.view.Label, va), false
+		}
+		wanted := strings.Join(parts[1:], " ")
+		for _, c := range copyables {
+			for _, va := range c.view.Variants {
+				if strings.EqualFold(va.Label, wanted) {
+					return performCopy(c.view.Label, va), false
+				}
 			}
 		}
+		return fmt.Sprintf("(no variant labeled %q on this step)", wanted), false
 	}
-	return fmt.Sprintf("(no variant labeled %q on this step)", wanted)
+
+	// Switch commands — only meaningful for multi-variant blocks.
+	target := r.firstMultiVariantBlock(copyables)
+	if target == nil {
+		return fmt.Sprintf("(unknown command %q — type `c` to copy or press Enter to continue)", cmd), false
+	}
+	if idx, ok := matchVariant(cmd, target.view.Variants); ok {
+		if r.activeVariant == nil {
+			r.activeVariant = map[int]int{}
+		}
+		r.activeVariant[target.index] = idx
+		label := target.view.Variants[idx].Label
+		if label == "" {
+			label = fmt.Sprintf("variant %d", idx+1)
+		}
+		return fmt.Sprintf("(switched to %s)", label), true
+	}
+	return fmt.Sprintf("(unknown command %q — type `c` to copy, a variant label/number to switch, or press Enter to continue)", cmd), false
 }
 
-// pickDefaultVariant returns the variant marked IsDefault, or the
-// first variant when none is marked. variants must be non-empty —
-// callers filter empty blocks out of copyables.
-func pickDefaultVariant(variants []demokit.VariantView) demokit.VariantView {
-	for _, v := range variants {
-		if v.IsDefault {
-			return v
+// firstMultiVariantBlock returns the first copyable block that
+// actually has tabs (more than one variant); single-variant blocks
+// have no switch target.
+func (r *Renderer) firstMultiVariantBlock(copyables []copyableBlock) *copyableBlock {
+	for i := range copyables {
+		if len(copyables[i].view.Variants) > 1 {
+			return &copyables[i]
 		}
 	}
-	return variants[0]
+	return nil
+}
+
+// matchVariant resolves a switch token (`<label>` or 1-based number)
+// to a variant index. Returns the index and true on match.
+func matchVariant(token string, variants []demokit.VariantView) (int, bool) {
+	token = strings.TrimSpace(token)
+	if n, err := strconv.Atoi(token); err == nil {
+		if n >= 1 && n <= len(variants) {
+			return n - 1, true
+		}
+		return 0, false
+	}
+	for i, v := range variants {
+		if strings.EqualFold(v.Label, token) {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // performCopy invokes the clipboard primitive on va.Content and

--- a/tui/copy_test.go
+++ b/tui/copy_test.go
@@ -68,6 +68,17 @@ func TestCopyableBlocksNilStep(t *testing.T) {
 	}
 }
 
+// rendererWithStep returns a Renderer prepared as if RenderStep had
+// just been called on step — activeVariant map seeded from default
+// markers. Lets the tests skip the actual Render plumbing while still
+// exercising the active-variant logic.
+func rendererWithStep(step *demokit.StepDef) *Renderer {
+	r := New()
+	r.lastStep = step
+	r.activeVariant = initialActiveVariants(step)
+	return r
+}
+
 func TestHandleCopyCommandBareC(t *testing.T) {
 	// Route Copy() through a buffer so the OSC 52 path succeeds
 	// deterministically and the test doesn't depend on the host
@@ -80,18 +91,21 @@ func TestHandleCopyCommandBareC(t *testing.T) {
 		demokit.EnableShellClipboardFallback(true)
 	}()
 
-	r := New()
 	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
 	copyables := r.copyableBlocks(step)
 
-	msg := r.handleCopyCommand("c", copyables)
+	msg, switched := r.handleCopyCommand("c", copyables)
+	if switched {
+		t.Errorf("bare `c` should not be a switch; got switched=true")
+	}
 	if !strings.Contains(msg, "copied") || !strings.Contains(msg, "osc52") {
 		t.Errorf("bare `c` should report copy success, got %q", msg)
 	}
-	// Default-marked variant is curl — the OSC 52 sequence must encode
-	// that exact content. base64("curl -X GET ...") is the payload.
+	// Active starts at the Default-marked variant (curl). base64 of
+	// curl content is the OSC 52 payload.
 	if !strings.Contains(buf.String(), "Y3VybCAtWCBHRVQgLi4u") {
-		t.Errorf("bare `c` should have copied curl (default); buf=%q", buf.String())
+		t.Errorf("bare `c` should have copied the active (curl); buf=%q", buf.String())
 	}
 }
 
@@ -104,11 +118,14 @@ func TestHandleCopyCommandNamedVariant(t *testing.T) {
 		demokit.EnableShellClipboardFallback(true)
 	}()
 
-	r := New()
 	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
 	copyables := r.copyableBlocks(step)
 
-	msg := r.handleCopyCommand("c python", copyables)
+	msg, switched := r.handleCopyCommand("c python", copyables)
+	if switched {
+		t.Errorf("`c <label>` copies without switching; got switched=true")
+	}
 	if !strings.Contains(msg, "copied") {
 		t.Errorf("`c python` should copy, got %q", msg)
 	}
@@ -118,23 +135,88 @@ func TestHandleCopyCommandNamedVariant(t *testing.T) {
 	}
 }
 
-func TestHandleCopyCommandUnknownLabel(t *testing.T) {
-	r := New()
+func TestHandleCopyCommandSwitchByLabel(t *testing.T) {
 	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
 	copyables := r.copyableBlocks(step)
 
-	msg := r.handleCopyCommand("c ruby", copyables)
+	// Active starts at curl (Default). Switch to python.
+	msg, switched := r.handleCopyCommand("python", copyables)
+	if !switched {
+		t.Errorf("label switch should set switched=true, got false (msg=%q)", msg)
+	}
+	if !strings.Contains(msg, "switched to python") {
+		t.Errorf("expected status mentioning python; got %q", msg)
+	}
+	if r.activeVariant[copyables[0].index] != 1 {
+		t.Errorf("active variant index after switch = %d, want 1 (python)", r.activeVariant[copyables[0].index])
+	}
+}
+
+func TestHandleCopyCommandSwitchByNumber(t *testing.T) {
+	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
+	copyables := r.copyableBlocks(step)
+
+	// 1-based: "2" → python (index 1)
+	msg, switched := r.handleCopyCommand("2", copyables)
+	if !switched {
+		t.Errorf("numeric switch should set switched=true, got false (msg=%q)", msg)
+	}
+	if r.activeVariant[copyables[0].index] != 1 {
+		t.Errorf("`2` should switch to index 1, got %d", r.activeVariant[copyables[0].index])
+	}
+}
+
+func TestBareCCopiesActiveAfterSwitch(t *testing.T) {
+	var buf bytes.Buffer
+	demokit.SetClipboardWriter(&buf)
+	demokit.EnableShellClipboardFallback(false)
+	defer func() {
+		demokit.SetClipboardWriter(nil)
+		demokit.EnableShellClipboardFallback(true)
+	}()
+
+	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
+	copyables := r.copyableBlocks(step)
+
+	if _, switched := r.handleCopyCommand("python", copyables); !switched {
+		t.Fatalf("switch to python failed setup")
+	}
+	buf.Reset()
+	if _, _ = r.handleCopyCommand("c", copyables); buf.Len() == 0 {
+		t.Fatalf("bare c after switch should have written OSC 52")
+	}
+	// Now bare c should copy python content, not curl.
+	if !strings.Contains(buf.String(), "cmVxdWVzdHMuZ2V0KC4uLik=") {
+		t.Errorf("bare `c` after switch should copy python; buf=%q", buf.String())
+	}
+}
+
+func TestHandleCopyCommandUnknownLabel(t *testing.T) {
+	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
+	copyables := r.copyableBlocks(step)
+
+	msg, switched := r.handleCopyCommand("c ruby", copyables)
+	if switched {
+		t.Errorf("unknown label copy should not switch")
+	}
 	if !strings.Contains(msg, "no variant labeled") {
 		t.Errorf("unknown label should produce a clear error, got %q", msg)
 	}
 }
 
 func TestHandleCopyCommandUnknownVerb(t *testing.T) {
-	r := New()
 	step := stepWithVariants(t, false)
+	r := rendererWithStep(step)
 	copyables := r.copyableBlocks(step)
 
-	msg := r.handleCopyCommand("xyz", copyables)
+	msg, switched := r.handleCopyCommand("xyz", copyables)
+	if switched {
+		t.Errorf("unknown verb should not switch")
+	}
 	if !strings.Contains(msg, "unknown command") {
 		t.Errorf("unknown verb should produce a clear error, got %q", msg)
 	}

--- a/tui/copy_test.go
+++ b/tui/copy_test.go
@@ -1,0 +1,166 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/panyam/demokit"
+)
+
+// stepWithVariants builds a minimal *demokit.StepDef carrying a single
+// multi-variant verbatim block, hooked up to a demo so copyableBlocks
+// can see the parent for IsBoxedVerbatim. Used by the parser tests.
+func stepWithVariants(t *testing.T, boxed bool) *demokit.StepDef {
+	t.Helper()
+	d := demokit.New("t")
+	if boxed {
+		d.BoxedVerbatim()
+	}
+	return d.Step("S").ID("s").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET ...").Default(),
+		demokit.MakeVariant("python", "python", "requests.get(...)"),
+	)
+}
+
+// stepWithSingleVariant builds a step with a one-snippet block. Used
+// to assert single-variant blocks are copyable only when the demo
+// opts in via BoxedVerbatim.
+func stepWithSingleVariant(t *testing.T, boxed bool) *demokit.StepDef {
+	t.Helper()
+	d := demokit.New("t")
+	if boxed {
+		d.BoxedVerbatim()
+	}
+	return d.Step("S").ID("s").Shell("echo hi")
+}
+
+func TestCopyableBlocksMultiVariantAutoBoxed(t *testing.T) {
+	// Multi-variant is copyable regardless of the demo flag — tabs need
+	// a frame, so the box (and therefore copy affordance) is always on.
+	step := stepWithVariants(t, false)
+	r := New()
+	got := r.copyableBlocks(step)
+	if len(got) != 1 {
+		t.Fatalf("multi-variant should be copyable without BoxedVerbatim; got %d copyable blocks", len(got))
+	}
+}
+
+func TestCopyableBlocksSingleVariantHonorsFlag(t *testing.T) {
+	r := New()
+	t.Run("flag unset → not copyable (today's mouse-select behavior)", func(t *testing.T) {
+		got := r.copyableBlocks(stepWithSingleVariant(t, false))
+		if len(got) != 0 {
+			t.Errorf("single-variant without BoxedVerbatim should not be copyable, got %d", len(got))
+		}
+	})
+	t.Run("flag set → copyable", func(t *testing.T) {
+		got := r.copyableBlocks(stepWithSingleVariant(t, true))
+		if len(got) != 1 {
+			t.Errorf("single-variant with BoxedVerbatim should be copyable, got %d", len(got))
+		}
+	})
+}
+
+func TestCopyableBlocksNilStep(t *testing.T) {
+	if got := New().copyableBlocks(nil); got != nil {
+		t.Errorf("nil step should return nil, got %v", got)
+	}
+}
+
+func TestHandleCopyCommandBareC(t *testing.T) {
+	// Route Copy() through a buffer so the OSC 52 path succeeds
+	// deterministically and the test doesn't depend on the host
+	// terminal supporting clipboard escapes.
+	var buf bytes.Buffer
+	demokit.SetClipboardWriter(&buf)
+	demokit.EnableShellClipboardFallback(false)
+	defer func() {
+		demokit.SetClipboardWriter(nil)
+		demokit.EnableShellClipboardFallback(true)
+	}()
+
+	r := New()
+	step := stepWithVariants(t, false)
+	copyables := r.copyableBlocks(step)
+
+	msg := r.handleCopyCommand("c", copyables)
+	if !strings.Contains(msg, "copied") || !strings.Contains(msg, "osc52") {
+		t.Errorf("bare `c` should report copy success, got %q", msg)
+	}
+	// Default-marked variant is curl — the OSC 52 sequence must encode
+	// that exact content. base64("curl -X GET ...") is the payload.
+	if !strings.Contains(buf.String(), "Y3VybCAtWCBHRVQgLi4u") {
+		t.Errorf("bare `c` should have copied curl (default); buf=%q", buf.String())
+	}
+}
+
+func TestHandleCopyCommandNamedVariant(t *testing.T) {
+	var buf bytes.Buffer
+	demokit.SetClipboardWriter(&buf)
+	demokit.EnableShellClipboardFallback(false)
+	defer func() {
+		demokit.SetClipboardWriter(nil)
+		demokit.EnableShellClipboardFallback(true)
+	}()
+
+	r := New()
+	step := stepWithVariants(t, false)
+	copyables := r.copyableBlocks(step)
+
+	msg := r.handleCopyCommand("c python", copyables)
+	if !strings.Contains(msg, "copied") {
+		t.Errorf("`c python` should copy, got %q", msg)
+	}
+	// base64("requests.get(...)")
+	if !strings.Contains(buf.String(), "cmVxdWVzdHMuZ2V0KC4uLik=") {
+		t.Errorf("`c python` should have copied the python variant; buf=%q", buf.String())
+	}
+}
+
+func TestHandleCopyCommandUnknownLabel(t *testing.T) {
+	r := New()
+	step := stepWithVariants(t, false)
+	copyables := r.copyableBlocks(step)
+
+	msg := r.handleCopyCommand("c ruby", copyables)
+	if !strings.Contains(msg, "no variant labeled") {
+		t.Errorf("unknown label should produce a clear error, got %q", msg)
+	}
+}
+
+func TestHandleCopyCommandUnknownVerb(t *testing.T) {
+	r := New()
+	step := stepWithVariants(t, false)
+	copyables := r.copyableBlocks(step)
+
+	msg := r.handleCopyCommand("xyz", copyables)
+	if !strings.Contains(msg, "unknown command") {
+		t.Errorf("unknown verb should produce a clear error, got %q", msg)
+	}
+}
+
+func TestCopyPromptHintAdaptsToShape(t *testing.T) {
+	t.Run("no copyables → plain Enter prompt", func(t *testing.T) {
+		got := copyPromptHint(nil)
+		if !strings.Contains(got, "Press Enter") || strings.Contains(got, "copy") {
+			t.Errorf("expected plain Enter prompt without copy hint, got %q", got)
+		}
+	})
+	t.Run("single-variant copyable → simple `c` hint, no <label> form", func(t *testing.T) {
+		r := New()
+		copyables := r.copyableBlocks(stepWithSingleVariant(t, true))
+		got := copyPromptHint(copyables)
+		if !strings.Contains(got, "type `c` to copy") || strings.Contains(got, "<label>") {
+			t.Errorf("single-variant hint should not mention <label>, got %q", got)
+		}
+	})
+	t.Run("multi-variant copyable → exposes `c <label>` form", func(t *testing.T) {
+		r := New()
+		copyables := r.copyableBlocks(stepWithVariants(t, false))
+		got := copyPromptHint(copyables)
+		if !strings.Contains(got, "<label>") {
+			t.Errorf("multi-variant hint should mention <label>, got %q", got)
+		}
+	})
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -479,41 +479,93 @@ func (r *Renderer) WaitForStep(opts demokit.WaitOpts) {
 		Foreground(p.Prompt).
 		Italic(true)
 
-	// AutoAccept countdown owns its own input path (cancelreader-backed
-	// race against the timer). Wiring copy into it would require a
-	// raw-mode key dispatcher, which is deferred to v1.1. Steps that
-	// need copy must run without AutoAccept (the common case for
-	// interactive demos that show snippets).
+	copyables := r.copyableBlocks(r.lastStep)
+
+	// Countdown path. The user's escape hatch is "type anything to
+	// review" — empty Enter accepts and advances (today's behavior),
+	// any other input cancels the countdown and drops into the
+	// interactive hold (copy loop if the step has copyables; plain
+	// Enter wait otherwise). v1.1's raw mode will make Tab the
+	// literal trigger; the prompt wording reflects that v1 reality
+	// honestly.
 	if opts.AutoAcceptAfter > 0 {
-		if !opts.ShowCountdown {
-			fmt.Println(style.Render(fmt.Sprintf("  Press Enter to run (auto in %s)...",
-				opts.AutoAcceptAfter.Round(time.Second))))
-			demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, nil)
-			return
-		}
-		demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
-			bar := plainCountdownBar(remaining, opts.AutoAcceptAfter, 20)
-			line := fmt.Sprintf("  %s  %4.1fs  (Enter to accept)", bar, remaining.Seconds())
-			fmt.Print("\r" + style.Render(line))
-		})
-		fmt.Print("\r" + strings.Repeat(" ", 70) + "\r")
+		r.waitWithCountdown(opts, copyables, style)
 		return
 	}
 
-	// No countdown — line-based pause loop with optional copy command
-	// when the rendered step has boxed/multi-variant verbatim blocks
-	// the user can grab via the clipboard primitive.
-	copyables := r.copyableBlocks(r.lastStep)
+	// No countdown — line-based pause. Copy loop when the step has
+	// copyables, otherwise today's plain Enter pause.
+	if len(copyables) > 0 {
+		r.copyPromptLoop(copyables, style)
+		return
+	}
+	fmt.Println(style.Render("  Press Enter to run this step..."))
+	bufio.NewReader(os.Stdin).ReadString('\n')
+}
+
+// waitWithCountdown runs the auto-accept countdown with a universal
+// "type to review" escape. On user input, the countdown stops and the
+// caller drops into the interactive hold appropriate for the step.
+func (r *Renderer) waitWithCountdown(opts demokit.WaitOpts, copyables []copyableBlock, promptStyle lipgloss.Style) {
+	p := r.Palette
+	hint := "Enter to accept · type to review"
+
+	var line string
+	var gotInput bool
+	if !opts.ShowCountdown {
+		fmt.Println(promptStyle.Render(fmt.Sprintf("  Press Enter to run (auto in %s) · type to review",
+			opts.AutoAcceptAfter.Round(time.Second))))
+		line, gotInput = demokit.WaitForLineOrTimeout(opts.AutoAcceptAfter, nil)
+	} else {
+		line, gotInput = demokit.WaitForLineOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
+			bar := plainCountdownBar(remaining, opts.AutoAcceptAfter, 20)
+			row := fmt.Sprintf("  %s  %4.1fs  (%s)", bar, remaining.Seconds(), hint)
+			fmt.Print("\r" + promptStyle.Render(row))
+		})
+		fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
+	}
+
+	if !gotInput {
+		return // timer fired — auto-advance
+	}
+	cmd := strings.TrimSpace(line)
+	if cmd == "" {
+		return // empty Enter — accept and advance
+	}
+
+	// Non-empty input cancels the countdown. If we're on a copyable
+	// step and the input parses as a copy command, dispatch
+	// immediately so the experienced user doesn't have to re-type;
+	// then fall into the copy loop for further interaction. Steps
+	// without copyables get a plain hold (Enter to advance).
+	noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
+	if len(copyables) > 0 {
+		if msg := r.handleCopyCommand(cmd, copyables); msg != "" {
+			fmt.Println(noteStyle.Render("  " + msg))
+		}
+		r.copyPromptLoop(copyables, promptStyle)
+		return
+	}
+	fmt.Println(noteStyle.Render("  (countdown stopped — press Enter to continue)"))
+	bufio.NewReader(os.Stdin).ReadString('\n')
+}
+
+// copyPromptLoop runs the line-based pause for steps that have
+// copyable verbatim blocks. Empty input continues; `c` and `c <label>`
+// copy via the clipboard primitive and stay in the loop so the user
+// can grab several variants before advancing.
+func (r *Renderer) copyPromptLoop(copyables []copyableBlock, promptStyle lipgloss.Style) {
+	p := r.Palette
 	reader := bufio.NewReader(os.Stdin)
+	noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
 	for {
-		fmt.Println(style.Render(copyPromptHint(copyables)))
+		fmt.Println(promptStyle.Render(copyPromptHint(copyables)))
 		line, _ := reader.ReadString('\n')
 		cmd := strings.TrimSpace(line)
 		if cmd == "" {
 			return
 		}
 		if msg := r.handleCopyCommand(cmd, copyables); msg != "" {
-			noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
 			fmt.Println(noteStyle.Render("  " + msg))
 		}
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -338,11 +338,17 @@ func (r *Renderer) renderUnboxedVariant(v demokit.VerbatimView) {
 // the currently-active variant's content appears inside. blockIdx is
 // the block's index within the step; the renderer reads
 // r.activeVariant[blockIdx] to decide which variant is active.
+//
+// The outer block label is bold + Title color so it stands out from
+// the dim variant tabs (the previous italic Note color was too close
+// to the inactive-tab Dim color). A blank line after the label gives
+// the tab strip / box breathing room.
 func (r *Renderer) renderBoxedBlock(blockIdx int, v demokit.VerbatimView, multi bool) {
 	p := r.Palette
-	labelStyle := lipgloss.NewStyle().Italic(true).Foreground(p.Note)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Title)
 	if v.Label != "" {
 		fmt.Println(labelStyle.Render(v.Label))
+		fmt.Println()
 	}
 	if multi {
 		fmt.Println(r.renderTabStrip(v.Variants, r.activeIndex(blockIdx)))
@@ -578,20 +584,30 @@ func (r *Renderer) WaitForStep(opts demokit.WaitOpts) {
 }
 
 // waitWithCountdown runs the auto-accept countdown with a universal
-// "type to review" escape. On user input, the countdown stops and the
-// caller drops into the interactive hold appropriate for the step.
+// "any key to review" escape. The countdown read is in raw mode so a
+// single keypress (not just Enter) interrupts:
+//
+//   - Enter (KeyEnter or '\n') → accept and advance.
+//   - Any other key            → drop into the line-based interactive
+//                                 hold (copy loop for copyable steps,
+//                                 plain Enter wait otherwise).
+//   - Timer fires              → auto-advance.
+//
+// On terminals where raw mode is unavailable, WaitForKeyOrTimeout
+// falls back to line mode and the user has to press Enter to
+// interrupt — degraded but still functional.
 func (r *Renderer) waitWithCountdown(opts demokit.WaitOpts, copyables []copyableBlock, promptStyle lipgloss.Style) {
 	p := r.Palette
-	hint := "Enter to accept · type to review"
+	hint := "Enter accept · any key to review"
 
-	var line string
-	var gotInput bool
+	var key byte
+	var gotKey bool
 	if !opts.ShowCountdown {
-		fmt.Println(promptStyle.Render(fmt.Sprintf("  Press Enter to run (auto in %s) · type to review",
+		fmt.Println(promptStyle.Render(fmt.Sprintf("  Press Enter to run (auto in %s) · any key to review",
 			opts.AutoAcceptAfter.Round(time.Second))))
-		line, gotInput = demokit.WaitForLineOrTimeout(opts.AutoAcceptAfter, nil)
+		key, gotKey = demokit.WaitForKeyOrTimeout(opts.AutoAcceptAfter, nil)
 	} else {
-		line, gotInput = demokit.WaitForLineOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
+		key, gotKey = demokit.WaitForKeyOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
 			bar := plainCountdownBar(remaining, opts.AutoAcceptAfter, 20)
 			row := fmt.Sprintf("  %s  %4.1fs  (%s)", bar, remaining.Seconds(), hint)
 			fmt.Print("\r" + promptStyle.Render(row))
@@ -599,28 +615,19 @@ func (r *Renderer) waitWithCountdown(opts demokit.WaitOpts, copyables []copyable
 		fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
 	}
 
-	if !gotInput {
+	if !gotKey {
 		return // timer fired — auto-advance
 	}
-	cmd := strings.TrimSpace(line)
-	if cmd == "" {
-		return // empty Enter — accept and advance
+	if key == demokit.KeyEnter || key == '\n' {
+		return // Enter — accept and advance
 	}
 
-	// Non-empty input cancels the countdown. If we're on a copyable
-	// step and the input parses as a copy/switch command, dispatch
-	// immediately so the experienced user doesn't have to re-type;
-	// then fall into the copy loop for further interaction. Steps
-	// without copyables get a plain hold (Enter to advance).
+	// Any other key cancels the countdown. Drop into the interactive
+	// hold appropriate for the step. Raw-mode terminal is already
+	// restored by WaitForKeyOrTimeout, so cooked-mode line input
+	// (bufio + ReadString) works correctly below.
 	noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
 	if len(copyables) > 0 {
-		msg, switched := r.handleCopyCommand(cmd, copyables)
-		if msg != "" {
-			fmt.Println(noteStyle.Render("  " + msg))
-		}
-		if switched {
-			r.echoActiveVariant(copyables)
-		}
 		r.copyPromptLoop(copyables, promptStyle)
 		return
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -68,6 +68,14 @@ type Renderer struct {
 	Fraction float64       // fraction of terminal width to use; 0 means 0.80
 	Delay    time.Duration // per-line scroll delay; 0 means 18ms, negative disables
 	prompter FormPrompter
+
+	// lastStep is set by RenderStep and consulted by WaitForStep so the
+	// line-based copy prompt knows which verbatim blocks the user can
+	// reference. Cleared at RenderResult so a between-step Enter pause
+	// doesn't pick up the previous step's blocks if the next step has
+	// none. v1.1 raw-mode interaction will replace this with a real
+	// focus model.
+	lastStep *demokit.StepDef
 }
 
 // New creates a TUI Renderer with default settings.
@@ -195,6 +203,7 @@ func (r *Renderer) RenderHeader(title, description string, stepCount int) {
 }
 
 func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
+	r.lastStep = step
 	p := r.Palette
 	iw := r.innerWidth()
 
@@ -265,29 +274,69 @@ func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
 
 	r.smoothPrint(box.Render(content))
 
-	// Verbatim blocks render OUTSIDE the bordered box so lipgloss never
-	// soft-wraps long lines into the box border. Each line is emitted
-	// raw via fmt.Println — terminals that re-flow on resize (iTerm2,
-	// Terminal.app, gnome-terminal) preserve the underlying line for
-	// triple-click copy. This is how we guarantee character-exact
-	// recovery of curl recipes / JSON envelopes regardless of width.
+	r.renderVerbatimBlocks(step)
+}
+
+// renderVerbatimBlocks emits each verbatim block according to the demo's
+// boxing mode + per-block variant count:
+//
+//   - Single-variant + Demo.IsBoxedVerbatim() unset → today's behavior:
+//     printed OUTSIDE the bordered box so lipgloss never soft-wraps long
+//     lines into the box border, preserving triple-click copy.
+//   - Single-variant + Demo.IsBoxedVerbatim() set → rendered inside a
+//     styled box; keyboard copy via the pause prompt.
+//   - Multi-variant (always boxed regardless of the flag) → rendered
+//     inside a styled box with each variant stacked under its **label**;
+//     keyboard copy via `c <label>` at the pause prompt.
+func (r *Renderer) renderVerbatimBlocks(step *demokit.StepDef) {
+	p := r.Palette
 	blocks := step.VerbatimBlocks()
+	if len(blocks) == 0 {
+		return
+	}
+	demo := step.Demo()
+	boxedDefault := demo != nil && demo.IsBoxedVerbatim()
+	labelStyle := lipgloss.NewStyle().Italic(true).Foreground(p.Note)
+	variantLabelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Note)
+
 	for _, v := range blocks {
 		fmt.Println()
-		if v.Label != "" {
-			labelStyle := lipgloss.NewStyle().
-				Italic(true).
-				Foreground(p.Note)
-			fmt.Println(labelStyle.Render(v.Label))
+		multi := len(v.Variants) > 1
+		boxed := boxedDefault || multi
+		if !boxed {
+			if v.Label != "" {
+				fmt.Println(labelStyle.Render(v.Label))
+			}
+			r.smoothPrint(strings.TrimRight(v.Variants[0].Content, "\n"))
+			continue
 		}
-		// Trim only trailing newlines so the block doesn't carry a
-		// blank tail row; preserve every other byte exactly. Embedded
-		// \n flow through Println unchanged.
-		r.smoothPrint(strings.TrimRight(v.Content, "\n"))
+
+		// Boxed render. Single-variant: snippet inside the box.
+		// Multi-variant: stacked variants, each under its bold label.
+		var sections []string
+		if v.Label != "" {
+			sections = append(sections, labelStyle.Render(v.Label))
+		}
+		for i, va := range v.Variants {
+			if multi {
+				if i > 0 {
+					sections = append(sections, "")
+				}
+				if va.Label != "" {
+					sections = append(sections, variantLabelStyle.Render(va.Label))
+				}
+			}
+			sections = append(sections, strings.TrimRight(va.Content, "\n"))
+		}
+		content := lipgloss.JoinVertical(lipgloss.Left, sections...)
+		box := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(p.Note).
+			Padding(0, 1).
+			Width(r.width())
+		r.smoothPrint(box.Render(content))
 	}
-	if len(blocks) > 0 {
-		fmt.Println()
-	}
+	fmt.Println()
 }
 
 // statusColors returns the border and label colors for a given result status.
@@ -430,25 +479,44 @@ func (r *Renderer) WaitForStep(opts demokit.WaitOpts) {
 		Foreground(p.Prompt).
 		Italic(true)
 
-	if opts.AutoAcceptAfter <= 0 {
-		fmt.Println(style.Render("  Press Enter to run this step..."))
-		bufio.NewReader(os.Stdin).ReadString('\n')
+	// AutoAccept countdown owns its own input path (cancelreader-backed
+	// race against the timer). Wiring copy into it would require a
+	// raw-mode key dispatcher, which is deferred to v1.1. Steps that
+	// need copy must run without AutoAccept (the common case for
+	// interactive demos that show snippets).
+	if opts.AutoAcceptAfter > 0 {
+		if !opts.ShowCountdown {
+			fmt.Println(style.Render(fmt.Sprintf("  Press Enter to run (auto in %s)...",
+				opts.AutoAcceptAfter.Round(time.Second))))
+			demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, nil)
+			return
+		}
+		demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
+			bar := plainCountdownBar(remaining, opts.AutoAcceptAfter, 20)
+			line := fmt.Sprintf("  %s  %4.1fs  (Enter to accept)", bar, remaining.Seconds())
+			fmt.Print("\r" + style.Render(line))
+		})
+		fmt.Print("\r" + strings.Repeat(" ", 70) + "\r")
 		return
 	}
 
-	if !opts.ShowCountdown {
-		fmt.Println(style.Render(fmt.Sprintf("  Press Enter to run (auto in %s)...",
-			opts.AutoAcceptAfter.Round(time.Second))))
-		demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, nil)
-		return
+	// No countdown — line-based pause loop with optional copy command
+	// when the rendered step has boxed/multi-variant verbatim blocks
+	// the user can grab via the clipboard primitive.
+	copyables := r.copyableBlocks(r.lastStep)
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Println(style.Render(copyPromptHint(copyables)))
+		line, _ := reader.ReadString('\n')
+		cmd := strings.TrimSpace(line)
+		if cmd == "" {
+			return
+		}
+		if msg := r.handleCopyCommand(cmd, copyables); msg != "" {
+			noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
+			fmt.Println(noteStyle.Render("  " + msg))
+		}
 	}
-
-	demokit.WaitForEnterOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
-		bar := plainCountdownBar(remaining, opts.AutoAcceptAfter, 20)
-		line := fmt.Sprintf("  %s  %4.1fs  (Enter to accept)", bar, remaining.Seconds())
-		fmt.Print("\r" + style.Render(line))
-	})
-	fmt.Print("\r" + strings.Repeat(" ", 70) + "\r")
 }
 
 // Prompt delegates to the renderer's FormPrompter (default

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -76,6 +76,15 @@ type Renderer struct {
 	// none. v1.1 raw-mode interaction will replace this with a real
 	// focus model.
 	lastStep *demokit.StepDef
+
+	// activeVariant maps a block's index within the current step to
+	// the currently-active variant index within that block. Initial
+	// values seed from each block's Default-marked variant (or 0 if
+	// none is marked). The line-based pause loop mutates this when
+	// the user types a switch command; bare `c` then copies whichever
+	// variant is active. Reset at each RenderStep so a fresh step's
+	// defaults take over.
+	activeVariant map[int]int
 }
 
 // New creates a TUI Renderer with default settings.
@@ -204,6 +213,7 @@ func (r *Renderer) RenderHeader(title, description string, stepCount int) {
 
 func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
 	r.lastStep = step
+	r.activeVariant = initialActiveVariants(step)
 	p := r.Palette
 	iw := r.innerWidth()
 
@@ -277,66 +287,130 @@ func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
 	r.renderVerbatimBlocks(step)
 }
 
-// renderVerbatimBlocks emits each verbatim block according to the demo's
-// boxing mode + per-block variant count:
+// renderVerbatimBlocks emits each verbatim block according to the
+// demo's boxing mode + per-block variant count:
 //
 //   - Single-variant + Demo.IsBoxedVerbatim() unset → today's behavior:
-//     printed OUTSIDE the bordered box so lipgloss never soft-wraps long
-//     lines into the box border, preserving triple-click copy.
+//     printed OUTSIDE the bordered box so lipgloss never soft-wraps
+//     long lines into the box border, preserving triple-click copy.
 //   - Single-variant + Demo.IsBoxedVerbatim() set → rendered inside a
 //     styled box; keyboard copy via the pause prompt.
-//   - Multi-variant (always boxed regardless of the flag) → rendered
-//     inside a styled box with each variant stacked under its **label**;
-//     keyboard copy via `c <label>` at the pause prompt.
+//   - Multi-variant (always boxed regardless of the flag) → tab strip
+//     above (`<active>  other  other`), box below showing only the
+//     active variant. Default-marked variant starts active; user
+//     switches via line-input command at the pause; the new active
+//     variant is echoed inline.
 func (r *Renderer) renderVerbatimBlocks(step *demokit.StepDef) {
-	p := r.Palette
 	blocks := step.VerbatimBlocks()
 	if len(blocks) == 0 {
 		return
 	}
 	demo := step.Demo()
 	boxedDefault := demo != nil && demo.IsBoxedVerbatim()
-	labelStyle := lipgloss.NewStyle().Italic(true).Foreground(p.Note)
-	variantLabelStyle := lipgloss.NewStyle().Bold(true).Foreground(p.Note)
 
-	for _, v := range blocks {
+	for idx, v := range blocks {
 		fmt.Println()
 		multi := len(v.Variants) > 1
 		boxed := boxedDefault || multi
 		if !boxed {
-			if v.Label != "" {
-				fmt.Println(labelStyle.Render(v.Label))
-			}
-			r.smoothPrint(strings.TrimRight(v.Variants[0].Content, "\n"))
+			r.renderUnboxedVariant(v)
 			continue
 		}
-
-		// Boxed render. Single-variant: snippet inside the box.
-		// Multi-variant: stacked variants, each under its bold label.
-		var sections []string
-		if v.Label != "" {
-			sections = append(sections, labelStyle.Render(v.Label))
-		}
-		for i, va := range v.Variants {
-			if multi {
-				if i > 0 {
-					sections = append(sections, "")
-				}
-				if va.Label != "" {
-					sections = append(sections, variantLabelStyle.Render(va.Label))
-				}
-			}
-			sections = append(sections, strings.TrimRight(va.Content, "\n"))
-		}
-		content := lipgloss.JoinVertical(lipgloss.Left, sections...)
-		box := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(p.Note).
-			Padding(0, 1).
-			Width(r.width())
-		r.smoothPrint(box.Render(content))
+		r.renderBoxedBlock(idx, v, multi)
 	}
 	fmt.Println()
+}
+
+// renderUnboxedVariant emits a single-variant block in today's
+// outside-the-box style — italic label line then the raw content.
+// Preserves triple-click copy semantics for users on terminals
+// without OSC 52.
+func (r *Renderer) renderUnboxedVariant(v demokit.VerbatimView) {
+	labelStyle := lipgloss.NewStyle().Italic(true).Foreground(r.Palette.Note)
+	if v.Label != "" {
+		fmt.Println(labelStyle.Render(v.Label))
+	}
+	r.smoothPrint(strings.TrimRight(v.Variants[0].Content, "\n"))
+}
+
+// renderBoxedBlock emits a verbatim block inside a styled box. For
+// multi-variant blocks a tab strip is rendered above the box and only
+// the currently-active variant's content appears inside. blockIdx is
+// the block's index within the step; the renderer reads
+// r.activeVariant[blockIdx] to decide which variant is active.
+func (r *Renderer) renderBoxedBlock(blockIdx int, v demokit.VerbatimView, multi bool) {
+	p := r.Palette
+	labelStyle := lipgloss.NewStyle().Italic(true).Foreground(p.Note)
+	if v.Label != "" {
+		fmt.Println(labelStyle.Render(v.Label))
+	}
+	if multi {
+		fmt.Println(r.renderTabStrip(v.Variants, r.activeIndex(blockIdx)))
+	}
+	active := v.Variants[r.activeIndex(blockIdx)]
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(p.Note).
+		Padding(0, 1).
+		Width(r.width())
+	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
+}
+
+// renderTabStrip formats the per-variant tabs above a multi-variant
+// box. The active variant is wrapped in angle brackets and bolded;
+// others are dim. Spacing: two spaces between entries. Default-marked
+// variant gets a "(default)" trailing tag so the user knows what bare
+// `c` will copy when the active is reset.
+func (r *Renderer) renderTabStrip(variants []demokit.VariantView, activeIdx int) string {
+	active := lipgloss.NewStyle().Bold(true).Foreground(r.Palette.Header)
+	dim := lipgloss.NewStyle().Foreground(r.Palette.Dim)
+	parts := make([]string, len(variants))
+	for i, v := range variants {
+		label := v.Label
+		if label == "" {
+			label = fmt.Sprintf("variant %d", i+1)
+		}
+		if v.IsDefault {
+			label += " (default)"
+		}
+		if i == activeIdx {
+			parts[i] = active.Render("<" + label + ">")
+		} else {
+			parts[i] = dim.Render(" " + label + " ")
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
+// activeIndex returns the currently-active variant index for the
+// block at blockIdx within the current step. Falls back to 0 when
+// the state map hasn't been seeded (e.g. tests that construct a
+// Renderer without going through RenderStep).
+func (r *Renderer) activeIndex(blockIdx int) int {
+	if r.activeVariant == nil {
+		return 0
+	}
+	return r.activeVariant[blockIdx]
+}
+
+// initialActiveVariants computes the starting active-variant index
+// for each block on a step: the Default-marked variant if any,
+// otherwise the first. Returns a fresh map so the previous step's
+// state doesn't leak.
+func initialActiveVariants(step *demokit.StepDef) map[int]int {
+	if step == nil {
+		return nil
+	}
+	out := map[int]int{}
+	for i, v := range step.VerbatimBlocks() {
+		for j, va := range v.Variants {
+			if va.IsDefault {
+				out[i] = j
+				break
+			}
+		}
+	}
+	return out
 }
 
 // statusColors returns the border and label colors for a given result status.
@@ -534,14 +608,18 @@ func (r *Renderer) waitWithCountdown(opts demokit.WaitOpts, copyables []copyable
 	}
 
 	// Non-empty input cancels the countdown. If we're on a copyable
-	// step and the input parses as a copy command, dispatch
+	// step and the input parses as a copy/switch command, dispatch
 	// immediately so the experienced user doesn't have to re-type;
 	// then fall into the copy loop for further interaction. Steps
 	// without copyables get a plain hold (Enter to advance).
 	noteStyle := lipgloss.NewStyle().Foreground(p.Note).Italic(true)
 	if len(copyables) > 0 {
-		if msg := r.handleCopyCommand(cmd, copyables); msg != "" {
+		msg, switched := r.handleCopyCommand(cmd, copyables)
+		if msg != "" {
 			fmt.Println(noteStyle.Render("  " + msg))
+		}
+		if switched {
+			r.echoActiveVariant(copyables)
 		}
 		r.copyPromptLoop(copyables, promptStyle)
 		return
@@ -551,9 +629,10 @@ func (r *Renderer) waitWithCountdown(opts demokit.WaitOpts, copyables []copyable
 }
 
 // copyPromptLoop runs the line-based pause for steps that have
-// copyable verbatim blocks. Empty input continues; `c` and `c <label>`
-// copy via the clipboard primitive and stay in the loop so the user
-// can grab several variants before advancing.
+// copyable verbatim blocks. Empty input continues; `c` / `c <label>`
+// copy; `<label>` or `<n>` switches the active variant (and echoes
+// the new active inline so the user can see what they're about to
+// copy). Loops until empty Enter so users can stack multiple actions.
 func (r *Renderer) copyPromptLoop(copyables []copyableBlock, promptStyle lipgloss.Style) {
 	p := r.Palette
 	reader := bufio.NewReader(os.Stdin)
@@ -565,10 +644,35 @@ func (r *Renderer) copyPromptLoop(copyables []copyableBlock, promptStyle lipglos
 		if cmd == "" {
 			return
 		}
-		if msg := r.handleCopyCommand(cmd, copyables); msg != "" {
+		msg, switched := r.handleCopyCommand(cmd, copyables)
+		if msg != "" {
 			fmt.Println(noteStyle.Render("  " + msg))
 		}
+		if switched {
+			r.echoActiveVariant(copyables)
+		}
 	}
+}
+
+// echoActiveVariant re-emits the current active variant of the first
+// multi-variant block inline, so the user can see what they switched
+// to before deciding to copy. In raw-mode v1.1 this becomes an
+// in-place redraw; v1 line mode appends to scrollback (cheap and
+// works without cursor positioning).
+func (r *Renderer) echoActiveVariant(copyables []copyableBlock) {
+	target := r.firstMultiVariantBlock(copyables)
+	if target == nil {
+		return
+	}
+	fmt.Println()
+	fmt.Println(r.renderTabStrip(target.view.Variants, r.activeIndex(target.index)))
+	active := target.view.Variants[r.activeIndex(target.index)]
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(r.Palette.Note).
+		Padding(0, 1).
+		Width(r.width())
+	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
 }
 
 // Prompt delegates to the renderer's FormPrompter (default

--- a/variant_test.go
+++ b/variant_test.go
@@ -1,0 +1,260 @@
+package demokit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVariantMakeAndDefault(t *testing.T) {
+	v := MakeVariant("curl", "bash", "curl -X GET http://x")
+	if v.Label != "curl" || v.Lang != "bash" || v.Content != "curl -X GET http://x" {
+		t.Fatalf("MakeVariant fields = %+v", v)
+	}
+	if v.IsDefault {
+		t.Error("MakeVariant should leave IsDefault=false")
+	}
+	d := v.Default()
+	if !d.IsDefault {
+		t.Error(".Default() should set IsDefault=true")
+	}
+	// Default must not mutate the receiver — Variant is a value type.
+	if v.IsDefault {
+		t.Error("Variant.Default mutated the receiver — must be value-semantic")
+	}
+}
+
+func TestSingleVariantBackcompat(t *testing.T) {
+	tests := []struct {
+		name        string
+		build       func() *StepDef
+		wantLabel   string
+		wantLang    string
+		wantContent string
+	}{
+		{
+			name:        "Verbatim",
+			build:       func() *StepDef { return (&StepDef{}).Verbatim("hello", "world") },
+			wantLabel:   "hello",
+			wantContent: "world",
+		},
+		{
+			name:        "VerbatimLang",
+			build:       func() *StepDef { return (&StepDef{}).VerbatimLang("config", "yaml", "k: v") },
+			wantLabel:   "config",
+			wantLang:    "yaml",
+			wantContent: "k: v",
+		},
+		{
+			name:        "Shell",
+			build:       func() *StepDef { return (&StepDef{}).Shell("echo hi") },
+			wantLang:    "bash",
+			wantContent: "echo hi",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := tc.build().VerbatimBlocks()
+			if len(blocks) != 1 {
+				t.Fatalf("want 1 block, got %d", len(blocks))
+			}
+			b := blocks[0]
+			if b.Label != tc.wantLabel {
+				t.Errorf("block label = %q, want %q", b.Label, tc.wantLabel)
+			}
+			if len(b.Variants) != 1 {
+				t.Fatalf("single-variant constructor produced %d variants, want 1", len(b.Variants))
+			}
+			va := b.Variants[0]
+			if va.Lang != tc.wantLang || va.Content != tc.wantContent {
+				t.Errorf("variant = %+v, want lang=%q content=%q", va, tc.wantLang, tc.wantContent)
+			}
+		})
+	}
+}
+
+func TestVerbatimVariantsConstructor(t *testing.T) {
+	s := (&StepDef{}).VerbatimVariants("Fetch user",
+		MakeVariant("curl", "bash", "curl -X GET ...").Default(),
+		MakeVariant("python", "python", "requests.get(...)"),
+		MakeVariant("go", "go", "http.Get(...)"),
+	)
+	blocks := s.VerbatimBlocks()
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	b := blocks[0]
+	if b.Label != "Fetch user" {
+		t.Errorf("block label = %q", b.Label)
+	}
+	if len(b.Variants) != 3 {
+		t.Fatalf("variants len = %d, want 3", len(b.Variants))
+	}
+	if !b.Variants[0].IsDefault || b.Variants[1].IsDefault || b.Variants[2].IsDefault {
+		t.Errorf("expected only the first variant to be Default, got %+v", b.Variants)
+	}
+	wantLabels := []string{"curl", "python", "go"}
+	for i, va := range b.Variants {
+		if va.Label != wantLabels[i] {
+			t.Errorf("variants[%d].Label = %q, want %q", i, va.Label, wantLabels[i])
+		}
+	}
+}
+
+func TestBoxedVerbatimFlag(t *testing.T) {
+	d := New("t")
+	if d.IsBoxedVerbatim() {
+		t.Error("IsBoxedVerbatim should default to false")
+	}
+	d.BoxedVerbatim()
+	if !d.IsBoxedVerbatim() {
+		t.Error("IsBoxedVerbatim should return true after BoxedVerbatim()")
+	}
+}
+
+func TestStepCarriesDemoBackpointer(t *testing.T) {
+	d := New("t")
+	s := d.Step("foo")
+	if s.Demo() != d {
+		t.Errorf("Step.Demo() back-pointer not wired; got %p, want %p", s.Demo(), d)
+	}
+}
+
+func TestVariantSelectionApply(t *testing.T) {
+	vs := []Variant{
+		{Label: "curl", IsDefault: true},
+		{Label: "python"},
+		{Label: "go"},
+	}
+	t.Run("Default with one marked → just that one", func(t *testing.T) {
+		got := VariantSelectionDefault().Apply(vs)
+		if len(got) != 1 || got[0].Label != "curl" {
+			t.Errorf("default selection = %+v, want only curl", got)
+		}
+	})
+	t.Run("Default with no marker → all variants (lossless)", func(t *testing.T) {
+		all := []Variant{{Label: "a"}, {Label: "b"}}
+		got := VariantSelectionDefault().Apply(all)
+		if len(got) != 2 {
+			t.Errorf("default with no marker should return all, got %+v", got)
+		}
+	})
+	t.Run("All", func(t *testing.T) {
+		got := VariantSelectionAll().Apply(vs)
+		if len(got) != 3 {
+			t.Errorf("All selection len = %d, want 3", len(got))
+		}
+	})
+	t.Run("Named match", func(t *testing.T) {
+		got := VariantSelectionNamed("python").Apply(vs)
+		if len(got) != 1 || got[0].Label != "python" {
+			t.Errorf("named=python = %+v", got)
+		}
+	})
+	t.Run("Named is case-insensitive", func(t *testing.T) {
+		got := VariantSelectionNamed("CURL").Apply(vs)
+		if len(got) != 1 || got[0].Label != "curl" {
+			t.Errorf("named=CURL should match curl, got %+v", got)
+		}
+	})
+	t.Run("Named miss → empty (dropped from output)", func(t *testing.T) {
+		got := VariantSelectionNamed("ruby").Apply(vs)
+		if len(got) != 0 {
+			t.Errorf("named=ruby should drop the block, got %+v", got)
+		}
+	})
+}
+
+func TestDemoVariantSelectionFromFlag(t *testing.T) {
+	cases := map[string]string{
+		"":        "default",
+		"default": "default",
+		"all":     "all",
+		"curl":    "named",
+	}
+	for flag, kind := range cases {
+		t.Run("flag="+flag, func(t *testing.T) {
+			d := New("t")
+			d.flagVariant = flag
+			sel := d.VariantSelection()
+			// Indirect check: feed a known variant set and inspect the
+			// output shape.
+			vs := []Variant{
+				{Label: "curl", IsDefault: true},
+				{Label: "python"},
+			}
+			out := sel.Apply(vs)
+			switch kind {
+			case "default":
+				if len(out) != 1 || out[0].Label != "curl" {
+					t.Errorf("default behavior wrong: %+v", out)
+				}
+			case "all":
+				if len(out) != 2 {
+					t.Errorf("all behavior wrong: %+v", out)
+				}
+			case "named":
+				if len(out) != 1 || out[0].Label != "curl" {
+					t.Errorf("named=curl wrong: %+v", out)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkdownEmitsAllVariantsByDefault(t *testing.T) {
+	d := New("V").Description("d")
+	d.Step("only").ID("only").
+		VerbatimVariants("Fetch",
+			MakeVariant("curl", "bash", "curl -X GET ..."),
+			MakeVariant("python", "python", "requests.get(...)"),
+		)
+
+	out := d.Markdown()
+	mustContain := []string{
+		"#### Fetch",
+		"**curl**",
+		"**python**",
+		"curl -X GET ...",
+		"requests.get(...)",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("markdown missing %q\n--- output ---\n%s", s, out)
+		}
+	}
+}
+
+func TestMarkdownFiltersByVariantFlag(t *testing.T) {
+	d := New("V").Description("d")
+	d.flagVariant = "python"
+	d.Step("only").ID("only").
+		VerbatimVariants("Fetch",
+			MakeVariant("curl", "bash", "curl -X GET ..."),
+			MakeVariant("python", "python", "requests.get(...)"),
+		)
+
+	out := d.Markdown()
+	if strings.Contains(out, "curl -X GET") {
+		t.Errorf("--variant=python should drop the curl variant; got:\n%s", out)
+	}
+	if !strings.Contains(out, "requests.get(...)") {
+		t.Errorf("--variant=python should keep python; got:\n%s", out)
+	}
+}
+
+func TestMarkdownDefaultMarkerPicksOne(t *testing.T) {
+	d := New("V").Description("d")
+	d.Step("only").ID("only").
+		VerbatimVariants("Fetch",
+			MakeVariant("curl", "bash", "curl -X GET ..."),
+			MakeVariant("python", "python", "requests.get(...)").Default(),
+		)
+
+	out := d.Markdown()
+	if strings.Contains(out, "curl -X GET") {
+		t.Errorf("default-marked python should suppress the others; curl still present:\n%s", out)
+	}
+	if !strings.Contains(out, "requests.get(...)") {
+		t.Errorf("default-marked python missing from output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What changes

Verbatim blocks gain two capabilities:

1. **Variants** — a single labeled snippet can carry N alternative forms (curl / gcloud / Python). `MakeVariant` + `VerbatimVariants` compose at author time; the existing `Verbatim` / `VerbatimLang` / `Shell` setters stay unchanged and internally produce a one-element variants slice. `--variant=<label>|all|default` filters non-TUI output; TUI ignores it (interactive selection).
2. **Clipboard copy** — new `demokit.Copy(s)` primitive that writes the selected content via OSC 52 first, then falls back through `pbcopy` / `wl-copy` / `xclip` / `xsel` / `clip.exe`. The TUI exposes it via a line-based pause prompt: `c` copies the active variant, `c <label>` copies a named one. Multi-variant blocks render as a tab strip above a box showing only the active variant; the auto-accept countdown integrates a raw-mode "any key to review" escape so users can interrupt unattended-advance and switch / copy.

Boxing is **demo-level opt-in** via `Demo.BoxedVerbatim()`. Multi-variant blocks auto-box regardless. Single-variant unboxed verbatim — today's surface — keeps working unchanged.

## Reviewer's guide

Read in this order:

1. [PLAN.md](https://github.com/panyam/demokit/pull/10/files#diff-1d972b4ac04c89bf54f79f2111064626b16aeb8bb9488f4ca0aed3ab1e728d2c) — design document. The implementation follows its build sequence top-to-bottom; the "Open questions resolved" + "Out of scope" sections preempt the obvious "why didn't you just..." questions.
2. [step.go](https://github.com/panyam/demokit/pull/10/files#diff-02f8cadbcbdf5890db53dd9045479ed573d367d5760f66b6accecfa63b5cacd3) — data model. `Variant` / `MakeVariant` / `.Default()` ; `verbatimBlock` rewritten around `Variants []Variant`; existing constructors unchanged in signature; `VariantSelection` filter helper.
3. [clipboard.go](https://github.com/panyam/demokit/pull/10/files#diff-a4f51282835efb7e519debf0f868541d72b32b1bce1b8852c2c7e5578e51fa5c) + [clipboard_test.go](https://github.com/panyam/demokit/pull/10/files#diff-f7a93025f07d421a3ebdefe348684aa92e08c4d44aa8a19cf4bd99a9d5730d77) — standalone clipboard primitive, no demokit dependency. OSC 52 + shell fallbacks; 2s timeout per shell-out; test seam via `SetClipboardWriter` / `EnableShellClipboardFallback`.
4. [demokit.go](https://github.com/panyam/demokit/pull/10/files#diff-8d288d869eee51fb928e552417c1f39e03f623e07aaccfe068472e4c8feea6b3) — `Demo.BoxedVerbatim()` / `IsBoxedVerbatim()` ; `Demo.VariantSelection()` derived from `--variant` flag.
5. [tui/tui.go](https://github.com/panyam/demokit/pull/10/files#diff-d17b0c5a0bb7c530a6d6b632267185fd62ba569f222c504c039e0b1fc6a259cd) — the bulk of the interactive surface: `renderVerbatimBlocks` / `renderBoxedBlock` / `renderTabStrip` / `waitWithCountdown` / `copyPromptLoop` / `echoActiveVariant`.
6. [tui/copy.go](https://github.com/panyam/demokit/pull/10/files#diff-6f20a16444c8e08bb315ba7ae1f7b94db1bd94a3a1f97939137f17edea474482) — line-parser for `c` / `c <label>` / `<label>` / `<n>`. Returns `(msg, switched)` so the prompt loop knows whether to re-emit the active variant inline.
7. [renderer.go](https://github.com/panyam/demokit/pull/10/files#diff-7258d4cda94c0f2089e19c82059aec4031ab065c7aca2a5a09909fe958b448c9) — `WaitForKeyOrTimeout` (raw-mode byte read + cancelreader race) and `WaitForLineOrTimeout` (line variant). Existing `WaitForEnterOrTimeout` becomes a thin wrapper.
8. [examples/graph/main.go](https://github.com/panyam/demokit/pull/10/files#diff-450da218f3cfd2c41675b06800b71bd45101fb62aea40c937e98f62ade41665c) + `Makefile` — `BoxedVerbatim()` on the demo; `VerbatimVariants(...)` on the refresh step with 3 client forms (curl marked Default); `doc-md-default` / `doc-md-python` Makefile targets demonstrate the filter modes.

Tests:

9. [variant_test.go](https://github.com/panyam/demokit/pull/10/files#diff-0b8cdfda2316a888cf4ab620643bc512bd5c3f552f3b9b758c90c4632d494bc4) — `Variant` value-semantic Default; single-variant backcompat for `Verbatim` / `VerbatimLang` / `Shell`; `VariantSelection` filter behavior; markdown rendering of multi-variant + filter.
10. [tui/copy_test.go](https://github.com/panyam/demokit/pull/10/files#diff-3e496de494597bd0c5bd0df599405a9f4fef81fbec251cbc6e1990e037932d04) — `copyableBlocks` boxed/unboxed gating; `handleCopyCommand` for bare `c`, `c <label>`, switch by label, switch by number; OSC 52 byte-exact verification of the copied payload.

Skim or skip: [examples/graph/README.md](https://github.com/panyam/demokit/pull/10/files#diff-6a8b760bf77030a19d0f19cb95b87755d76700cee582d7527a0216607173af5e) (regenerated from the trace).

## Diff groups

- **Production:** `step.go`, `demokit.go`, `markdown.go`, `markdown_load.go`, `render_json.go`, `render_trace.go`, `args.go`, `renderer.go`, `clipboard.go`, `tui/tui.go`, `tui/copy.go`
- **Tests:** `variant_test.go`, `clipboard_test.go`, `tui/copy_test.go`, `demokit_test.go` (updated assertions), `render_json_test.go` (reshaped variants), `args_test.go` (variant flag stripping)
- **Examples / docs:** `examples/graph/main.go`, `examples/graph/Makefile`, `examples/graph/README.md`, `PLAN.md`, `considered-rejected.md`

## Decision log

- **Demo-level `BoxedVerbatim()`, not per-block `.Boxed()`.** Considered per-block (with a `VerbatimRef` chain type) but the surface bloat — embedded-struct return type, new public type — wasn't justified when "I want my TUI demo to look polished" is a per-demo decision, not a per-block one. Multi-variant auto-boxes regardless since tabs need a frame.
- **`MakeVariant` (function name) + `Variant` (type name).** Go doesn't allow a function and a type to share a name; the alternatives — `NewVariant` (verbose) or making `Variant` the function and `variant` the type (breaks exported access) — were both worse.
- **JSON projection reshape from `{label, lang, content}` to `{label, variants:[{lang, content}]}`.** Single-snippet blocks emit a one-element array so embed hosts read the same shape unconditionally — no `if Variants {} else {}` branching downstream. Wire-format break is real; called out under Risk.
- **Markdown emits all variants by default, filtered by `--variant`.** Different from non-interactive runtime (default-marked picks single). Reason: markdown is reference doc — readers want to see every form; CLI runtime is a presentation — showing one is the natural mode.
- **Countdown uses raw mode for the key read; rest of the pause is line-based.** Hybrid: any single key interrupts the countdown (matches user mental model); cooked-mode line input handles follow-up `c` / `c <label>` / `<n>` commands. Full raw-mode key dispatch (Tab cycling, single-keystroke `c` without Enter) is the v1.1 follow-up.

## Risk / blast radius

- **Affects:** existing demokit consumers that use `Verbatim` / `VerbatimLang` / `Shell` — single-variant backcompat is preserved (those produce a one-element `Variants` slice; rendered markdown / HTML / plain output is byte-equal pre-change when no `BoxedVerbatim()` flag is set).
- **Wire-format break:** `--doc json` output reshapes Verbatim from flat `{label, lang, content}` to `{label, variants:[{...}]}`. Embed hosts reading the old shape need to migrate. The `render_json_test.go` update pins the new shape.
- **Tests covering this:** `variant_test.go` (data model + selection + markdown), `tui/copy_test.go` (TUI parser + copy via OSC 52), `clipboard_test.go` (clipboard primitive), `render_json_test.go` (JSON shape), `demokit_test.go` (VerbatimView projection).
- **Be paranoid about:** terminal raw-mode restore on panic — `WaitForKeyOrTimeout` uses `defer term.Restore` but if a panic crosses the boundary mid-read, the terminal could be left in raw mode. Worth reviewing whether to add a signal handler. Also: OSC 52 silently succeeds on terminals that ignore the escape sequence (no in-band ack); the strategy reported back to the user may not reflect actual clipboard state on those terminals.

## Before / after

Multi-variant block in TUI rendering (graph example, step 4):

```
Refresh the token

<curl (default)>   python    go
╭──────────────────────────────────────────────────╮
│ curl -s -X POST https://auth.example/oauth2/...  │
╰──────────────────────────────────────────────────╯
```

Markdown output with `--variant=all` (gen-readme default) shows every variant under bolded labels; `--variant=python` filters to one; `--variant=default` picks the Default-marked one.

## Out of scope (deliberately deferred)

- **Sidecar markdown `variants` fenced-block syntax** — Go-only declaration in v1; sidecar gets the syntax in a follow-up.
- **Web player tabbed UI** — JSON projection lands; the `<demokit-demo>` vanilla-JS player upgrade is its own work.
- **v1.1 proper TUI keypress UX** — Tab cycling, single-keystroke `c` without Enter, in-place redraw, visual copy confirmation, focus model for multi-block steps with `[` / `]`. Early review surfaced that the line-mode dispatcher feels half-baked in practice; likely worth taking on either in this PR or as the immediate next one.
- **Per-block boxing override** — YAGNI until a real demo needs mixed boxed/unboxed.
- **Generic "stop countdown" affordance on non-copyable steps** — different UX axis, separate PR.
- **Cross-step history navigation** — reserved arrow-key bindings only.
