### PR TITLE
Notebook TUI mode — Phase A.2 (renderer bridge + --mode flag)

### DIFF
--- a/args.go
+++ b/args.go
@@ -13,7 +13,8 @@ import (
 //
 // Built-in strip set — the flags demokit's dispatcher consumes:
 //
-//   - --tui                   (bare; selects the TUI renderer)
+//   - --mode <plain|tui|notebook>  (value; selects the renderer)
+//   - --tui                   (bare; alias for --mode=tui; deprecated)
 //   - --non-interactive       (bare; skips between-step pauses)
 //   - --doc <format>          (value; routes to doc emission)
 //   - --from <trace-path>     (value; trace input for --doc)
@@ -38,6 +39,7 @@ func FilterArgs(args []string, extra ...ExtraFlag) []string {
 		"--doc":     true,
 		"--from":    true,
 		"--variant": true,
+		"--mode":    true,
 	}
 	for _, e := range extra {
 		if e.TakesValue {
@@ -90,13 +92,50 @@ func ValueFlag(name string) ExtraFlag {
 	return ExtraFlag{Name: name, TakesValue: true}
 }
 
-// IsTUI reports whether --tui appears in os.Args. Examples use this to
-// gate the TUI renderer (`demo.WithRenderer(tui.New())`) without having
-// to scan os.Args inline. Mirrors [FilterArgs]'s --tui recognition so
-// the convention is honored consistently across the dispatcher and
-// caller-side renderer selection.
+// IsTUI reports whether the user asked for the legacy TUI renderer —
+// either by the bare --tui flag (deprecated) or by --mode=tui /
+// --mode tui. Examples use this to gate the TUI renderer
+// (`demo.WithRenderer(tui.New())`) without having to scan os.Args
+// inline.
+//
+// Prefer [Mode] for new code: it returns the explicit mode string
+// and handles "plain" / "notebook" too. IsTUI is kept as a
+// convenience for examples that pre-date --mode.
 func IsTUI() bool {
-	return slices.Contains(os.Args[1:], "--tui")
+	if slices.Contains(os.Args[1:], "--tui") {
+		return true
+	}
+	return Mode() == "tui"
+}
+
+// Mode returns the renderer mode the user asked for via --mode. The
+// recognized values are:
+//
+//   - "plain"    (the default — PlainRenderer)
+//   - "tui"      (today's lipgloss-styled tui.Renderer)
+//   - "notebook" (Phase A.2 Bubble Tea notebook UI)
+//
+// Returns "" when --mode is absent — examples typically branch on
+// "" the same way they branch on "plain". The bare --tui flag is
+// honored as an alias for "tui" so existing scripts keep working
+// while examples migrate to --mode.
+//
+// Unrecognized mode strings are returned as-is so the caller can
+// surface a helpful error rather than silently falling back.
+func Mode() string {
+	args := os.Args[1:]
+	for i, a := range args {
+		if a == "--mode" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--mode=") {
+			return strings.TrimPrefix(a, "--mode=")
+		}
+	}
+	if slices.Contains(args, "--tui") {
+		return "tui"
+	}
+	return ""
 }
 
 // IsNonInteractive reports whether --non-interactive appears in

--- a/args_test.go
+++ b/args_test.go
@@ -140,6 +140,48 @@ func TestIsTUI(t *testing.T) {
 	})
 }
 
+// TestModeRecognizesBothForms verifies --mode=value and --mode value
+// resolve to the same string. The unset case returns "" so callers
+// can treat "" / "plain" as equivalent.
+func TestModeRecognizesBothForms(t *testing.T) {
+	withArgs(t, []string{"prog", "--mode=notebook"}, func() {
+		if got := Mode(); got != "notebook" {
+			t.Errorf("--mode=notebook → Mode() = %q, want %q", got, "notebook")
+		}
+	})
+	withArgs(t, []string{"prog", "--mode", "tui"}, func() {
+		if got := Mode(); got != "tui" {
+			t.Errorf("--mode tui → Mode() = %q, want %q", got, "tui")
+		}
+	})
+	withArgs(t, []string{"prog", "-addr", ":8081"}, func() {
+		if got := Mode(); got != "" {
+			t.Errorf("no --mode → Mode() = %q, want \"\"", got)
+		}
+	})
+}
+
+// TestModeViaTUIAlias verifies the bare --tui flag (deprecated)
+// resolves to Mode() == "tui" so examples that haven't migrated to
+// --mode yet keep working.
+func TestModeViaTUIAlias(t *testing.T) {
+	withArgs(t, []string{"prog", "--tui"}, func() {
+		if got := Mode(); got != "tui" {
+			t.Errorf("--tui alias → Mode() = %q, want %q", got, "tui")
+		}
+	})
+}
+
+// TestIsTUIHonorsMode verifies IsTUI() also recognizes --mode=tui,
+// not just the legacy bare --tui flag.
+func TestIsTUIHonorsMode(t *testing.T) {
+	withArgs(t, []string{"prog", "--mode=tui"}, func() {
+		if !IsTUI() {
+			t.Error("IsTUI() = false, want true with --mode=tui")
+		}
+	})
+}
+
 // TestIsNonInteractive verifies the same shape for --non-interactive.
 func TestIsNonInteractive(t *testing.T) {
 	withArgs(t, []string{"prog", "--non-interactive"}, func() {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -11,7 +11,8 @@
 // Run modes:
 //
 //	go run ./examples/basic/                              # interactive
-//	go run ./examples/basic/ --tui                        # styled boxes
+//	go run ./examples/basic/ --mode=tui                   # styled boxes (also --tui)
+//	go run ./examples/basic/ --mode=notebook              # Bubble Tea notebook UI
 //	go run ./examples/basic/ --smooth                     # plain w/ smooth scroll
 //	go run ./examples/basic/ --non-interactive            # default-input run
 //	go run ./examples/basic/ --record /tmp/r.json
@@ -26,6 +27,7 @@ import (
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/tui"
+	"github.com/panyam/demokit/tui/notebook"
 )
 
 func main() {
@@ -138,21 +140,25 @@ func main() {
 		})
 
 	// --- renderer / output mode flags ---
+	// --mode=plain (default) | tui | notebook. --tui is honored as a
+	// deprecated alias for --mode=tui. --smooth adds a per-line
+	// delay to PlainRenderer (only relevant when mode is plain).
 
-	useTUI := false
 	smooth := false
 	for _, arg := range os.Args[1:] {
-		switch strings.TrimSpace(arg) {
-		case "--tui":
-			useTUI = true
-		case "--smooth":
+		if strings.TrimSpace(arg) == "--smooth" {
 			smooth = true
 		}
 	}
-	if useTUI {
+	switch demokit.Mode() {
+	case "tui":
 		demo.WithRenderer(tui.New())
-	} else if smooth {
-		demo.WithRenderer(&demokit.PlainRenderer{Delay: 18 * time.Millisecond})
+	case "notebook":
+		demo.WithRenderer(notebook.NewRenderer())
+	default:
+		if smooth {
+			demo.WithRenderer(&demokit.PlainRenderer{Delay: 18 * time.Millisecond})
+		}
 	}
 
 	demo.Execute()

--- a/examples/dungeon/main.go
+++ b/examples/dungeon/main.go
@@ -7,7 +7,8 @@
 // Try:
 //
 //	go run ./examples/dungeon/                              # interactive
-//	go run ./examples/dungeon/ --tui                        # styled boxes
+//	go run ./examples/dungeon/ --mode=tui                   # styled boxes (also --tui)
+//	go run ./examples/dungeon/ --mode=notebook              # Bubble Tea notebook UI
 //	go run ./examples/dungeon/ --record /tmp/dungeon.json   # save a trace
 //	go run ./examples/dungeon/ --doc json                   # for embed hosts
 //
@@ -27,12 +28,11 @@ import (
 	_ "embed"
 	"fmt"
 	"math/rand/v2"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/tui"
+	"github.com/panyam/demokit/tui/notebook"
 	"github.com/panyam/demokit/web"
 )
 
@@ -302,11 +302,14 @@ func main() {
 	// `end` is a prose-only section — no Run needed.
 
 	// --- renderer flag ---
+	// --mode=plain (default) | tui | notebook. --tui is honored as
+	// a deprecated alias for --mode=tui.
 
-	for _, arg := range os.Args[1:] {
-		if strings.TrimSpace(arg) == "--tui" {
-			demo.WithRenderer(tui.New())
-		}
+	switch demokit.Mode() {
+	case "tui":
+		demo.WithRenderer(tui.New())
+	case "notebook":
+		demo.WithRenderer(notebook.NewRenderer())
 	}
 
 	demo.Execute()

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -9,8 +9,9 @@
 //
 // Try:
 //
-//	go run ./examples/graph/                                    # interactive
-//	go run ./examples/graph/ --tui                              # TUI box style
+//	go run ./examples/graph/                                    # interactive (plain)
+//	go run ./examples/graph/ --mode=tui                         # TUI box style (also --tui)
+//	go run ./examples/graph/ --mode=notebook                    # Bubble Tea notebook UI
 //	go run ./examples/graph/ --record /tmp/run.json             # save a trace
 //	go run ./examples/graph/ --replay /tmp/run.json             # replay it
 //	go run ./examples/graph/ --doc md --from /tmp/run.json      # markdown doc
@@ -19,12 +20,11 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/tui"
+	"github.com/panyam/demokit/tui/notebook"
 	"github.com/panyam/demokit/web"
 )
 
@@ -209,16 +209,14 @@ defer resp.Body.Close()`),
 	demo.Step("End").ID("end")
 
 	// --- renderer / output mode flags ---
+	// --mode=plain (default) | tui | notebook. --tui is honored as a
+	// deprecated alias for --mode=tui.
 
-	useTUI := false
-	for _, arg := range os.Args[1:] {
-		switch strings.TrimSpace(arg) {
-		case "--tui":
-			useTUI = true
-		}
-	}
-	if useTUI {
+	switch demokit.Mode() {
+	case "tui":
 		demo.WithRenderer(tui.New())
+	case "notebook":
+		demo.WithRenderer(notebook.NewRenderer())
 	}
 
 	demo.Execute()

--- a/tui/notebook/bridge_test.go
+++ b/tui/notebook/bridge_test.go
@@ -1,0 +1,101 @@
+package notebook
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestBridgeHeaderMsgSetsBanner(t *testing.T) {
+	m := New(nil)
+	next, _ := m.Update(BridgeHeaderMsg{Title: "My Demo", Description: "hi", StepCount: 5})
+	m = next.(Model)
+	if m.header != "My Demo" {
+		t.Errorf("header = %q, want %q", m.header, "My Demo")
+	}
+}
+
+func TestBridgeStepCellsMsgReplacesAndSubscribes(t *testing.T) {
+	m := New(nil)
+	// Move-then-focus before the bridge fires.
+	m.cursor = 99
+	m.mode = ViewMode
+
+	buf := NewOutputBuffer()
+	cells := []Cell{
+		NewMetaCell("s1#0.meta", "Step One", "body"),
+		NewOutputCell("s1#0.output", buf, 6),
+	}
+	next, cmd := m.Update(BridgeStepCellsMsg{Cells: cells, OutputBuf: buf, OutputCellID: "s1#0.output"})
+	m = next.(Model)
+
+	if got := len(m.Cells()); got != 2 {
+		t.Fatalf("cell count = %d, want 2", got)
+	}
+	if m.CursorIndex() != 0 || m.Mode() != SelectMode {
+		t.Errorf("BridgeStepCellsMsg did not reset cursor/mode: cursor=%d mode=%v", m.CursorIndex(), m.Mode())
+	}
+	if cmd == nil {
+		t.Errorf("BridgeStepCellsMsg with OutputBuf should return a SubscribeOutputBuffer cmd")
+	}
+}
+
+func TestBridgeWaitMsgStoresChannelAndSpaceClosesIt(t *testing.T) {
+	m := New([]Cell{NewMetaCell("only", "T", "")})
+
+	ch := make(chan struct{})
+	next, _ := m.Update(BridgeWaitMsg{Ch: ch})
+	m = next.(Model)
+	if m.waitCh == nil {
+		t.Fatal("BridgeWaitMsg did not store the channel")
+	}
+
+	// Send Space → channel should close, waitCh cleared.
+	next2, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = next2.(Model)
+	select {
+	case <-ch:
+		// expected — channel closed
+	default:
+		t.Fatal("space did not close the wait channel")
+	}
+	if m.waitCh != nil {
+		t.Error("waitCh should be nil after close")
+	}
+}
+
+func TestBridgeOutputDoneMsgMarksCellDone(t *testing.T) {
+	buf := NewOutputBuffer()
+	oc := NewOutputCell("out", buf, 4)
+	m := New([]Cell{oc})
+	if oc.done {
+		t.Fatal("OutputCell should start not-done")
+	}
+	next, _ := m.Update(BridgeOutputDoneMsg{CellID: "out"})
+	_ = next
+	if !oc.done {
+		t.Error("BridgeOutputDoneMsg did not flip OutputCell.done")
+	}
+}
+
+func TestBridgeSectionCellMsgAppends(t *testing.T) {
+	m := New([]Cell{NewMetaCell("m", "T", "")})
+	sc := NewSectionCell("s", "Heads up", "note")
+	next, _ := m.Update(BridgeSectionCellMsg{Cell: sc})
+	m = next.(Model)
+	if len(m.Cells()) != 2 {
+		t.Errorf("section append: got %d cells, want 2", len(m.Cells()))
+	}
+	if m.Cells()[1].ID() != "s" {
+		t.Errorf("appended cell ID = %q, want %q", m.Cells()[1].ID(), "s")
+	}
+}
+
+func TestBridgeDoneMsgFlipsDoneFlag(t *testing.T) {
+	m := New(nil)
+	next, _ := m.Update(BridgeDoneMsg{})
+	m = next.(Model)
+	if !m.done {
+		t.Error("BridgeDoneMsg did not flip done flag")
+	}
+}

--- a/tui/notebook/focus_marker.go
+++ b/tui/notebook/focus_marker.go
@@ -1,0 +1,26 @@
+package notebook
+
+import "unicode/utf8"
+
+// applyFocusMarker swaps the first rune of line for "▶" when
+// focused is true and the line shape matches "<multi-byte glyph> <text>".
+//
+// The multi-byte restriction is what keeps the helper from chewing
+// on body content: title markers (▸ / § / ❑ / …) are all ≥ 2 bytes,
+// while body lines start with ASCII letters / digits / spaces (each
+// a single byte) and pass through unchanged. New cell types can pick
+// any multi-byte unfocused glyph they want — no per-character special
+// casing in cells.
+//
+// Lines that don't match (body rows, blank padding, ASCII-led
+// content) are returned as-is.
+func applyFocusMarker(line string, focused bool) string {
+	if !focused {
+		return line
+	}
+	r, size := utf8.DecodeRuneInString(line)
+	if r == utf8.RuneError || size < 2 || len(line) < size+1 || line[size] != ' ' {
+		return line
+	}
+	return "▶" + line[size:]
+}

--- a/tui/notebook/focus_marker_test.go
+++ b/tui/notebook/focus_marker_test.go
@@ -1,0 +1,61 @@
+package notebook
+
+import "testing"
+
+func TestApplyFocusMarkerSwapsMultiByteGlyph(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"meta glyph", "▸ Title", "▶ Title"},
+		{"section glyph", "§ Heads up", "▶ Heads up"},
+		{"verbatim glyph", "❑ Refresh", "▶ Refresh"},
+		{"already-focused glyph (no-op semantic)", "▶ Already", "▶ Already"},
+		{"emoji glyph", "🎯 Goal", "▶ Goal"},
+	}
+	for _, tt := range tests {
+		if got := applyFocusMarker(tt.in, true); got != tt.want {
+			t.Errorf("%s: applyFocusMarker(%q, true) = %q, want %q", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestApplyFocusMarkerLeavesUnfocusedAlone(t *testing.T) {
+	in := "▸ Title"
+	if got := applyFocusMarker(in, false); got != in {
+		t.Errorf("focused=false should be a no-op: got %q, want %q", got, in)
+	}
+}
+
+func TestApplyFocusMarkerPassesThroughASCIILed(t *testing.T) {
+	// Body content shapes that look like "rune + space + rest" but
+	// must NOT be munged — the multi-byte restriction guards them.
+	cases := []string{
+		"A -> B: label",      // arrow line in MetaCell body
+		"    curl -s ...",    // indented code in VerbatimCell body
+		"  - bullet",         // bullet in section body
+		"x ",                 // single char + trailing space
+		"",                   // empty
+		"  ",                 // whitespace only
+	}
+	for _, in := range cases {
+		if got := applyFocusMarker(in, true); got != in {
+			t.Errorf("ASCII-led %q should pass through; got %q", in, got)
+		}
+	}
+}
+
+func TestApplyFocusMarkerLeavesNonShapedLinesAlone(t *testing.T) {
+	// Multi-byte first rune but no following space → not a title row.
+	cases := []string{
+		"▸Title",   // missing space
+		"▶",        // single glyph, no rest
+		"§\tTitle", // tab instead of space
+	}
+	for _, in := range cases {
+		if got := applyFocusMarker(in, true); got != in {
+			t.Errorf("non-shaped %q should pass through; got %q", in, got)
+		}
+	}
+}

--- a/tui/notebook/messages.go
+++ b/tui/notebook/messages.go
@@ -55,3 +55,60 @@ func SubscribeOutputBuffer(buf *OutputBuffer, cellID string) tea.Cmd {
 		return OutputAppendedMsg{CellID: cellID}
 	}
 }
+
+// --- Renderer-bridge messages (PR2; produced by NotebookRenderer,
+//     consumed by Model.Update) ---
+
+// BridgeHeaderMsg arrives once per demo, at the start when
+// demokit.RenderHeader fires. The model stashes the title for the
+// top banner row.
+type BridgeHeaderMsg struct {
+	Title       string
+	Description string
+	StepCount   int
+}
+
+// BridgeStepCellsMsg installs a fresh single-step cell list — the
+// MetaCell + 0..N VerbatimCells + OutputCell built for the step
+// just rendered. Replaces any previous cells (Phase A.1's
+// single-step-on-screen contract). OutputBuf is the buffer the
+// new OutputCell pulls from; OutputCellID is used for re-arming
+// the SubscribeOutputBuffer listener.
+type BridgeStepCellsMsg struct {
+	Cells        []Cell
+	OutputBuf    *OutputBuffer
+	OutputCellID string
+}
+
+// BridgeSectionCellMsg appends a SectionCell to the current list.
+// demokit.RenderSection fires for non-executable blocks that sit
+// between executable steps; in Phase A.1's single-step-on-screen
+// mode we treat them as standalone "step-shaped" cell lists too
+// (just a single SectionCell, no MetaCell/OutputCell).
+type BridgeSectionCellMsg struct {
+	Cell Cell
+}
+
+// BridgeOutputDoneMsg flips the active OutputCell from "live" to
+// "end" — fired when demokit.RenderResult is invoked.
+type BridgeOutputDoneMsg struct {
+	CellID string
+}
+
+// BridgeWaitMsg hands the model a channel to close when the user
+// presses the advance key. WaitForStep on the renderer side blocks
+// on the same channel — closing unblocks both the renderer and
+// frees Execute to call into the next step.
+//
+// Ch is buffered/unbuffered at the caller's choice; the model
+// only ever closes it. The model nils out its internal pointer on
+// close so a second advance press becomes a no-op rather than
+// closing twice.
+type BridgeWaitMsg struct {
+	Ch chan struct{}
+}
+
+// BridgeDoneMsg fires when demokit.RenderDone is invoked. The model
+// shows a "Done." banner and stays alive until the user presses q
+// so they can scroll back through prior cells before exiting.
+type BridgeDoneMsg struct{}

--- a/tui/notebook/meta_cell.go
+++ b/tui/notebook/meta_cell.go
@@ -61,15 +61,13 @@ func (c *MetaCell) RenderRows(width, startRow, endRow int, focused bool, mode Mo
 	if startRow >= endRow {
 		return nil
 	}
-	// Apply focus prefix on the title row only — '▸' becomes '▶' so
-	// the user can see which cell holds the cursor.
+	// Title row gets the focus marker swap; every other row is
+	// pass-through. The title is whichever row starts with a
+	// printable rune + space, so applyFocusMarker (which checks
+	// shape) does the right thing without hardcoding indices.
 	rows := make([]string, endRow-startRow)
 	for i := startRow; i < endRow; i++ {
-		line := c.cachedLines[i]
-		if focused && strings.HasPrefix(line, "▸ ") {
-			line = "▶ " + line[len("▸ "):]
-		}
-		rows[i-startRow] = line
+		rows[i-startRow] = applyFocusMarker(c.cachedLines[i], focused)
 	}
 	return rows
 }

--- a/tui/notebook/model.go
+++ b/tui/notebook/model.go
@@ -219,6 +219,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // handleKey dispatches keystrokes by mode. Kept separate from
 // Update so the switch over Msg types stays readable.
 func (m Model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Ctrl+L: force a full repaint. Bubble Tea uses diff rendering;
+	// when the underlying terminal is cleared by something else
+	// (most commonly the user hitting Ctrl+L themselves before we
+	// captured it), the frame cache and the visible screen go out
+	// of sync — diffs come up empty and the screen stays blank
+	// until a WindowSizeMsg invalidates the cache. tea.ClearScreen
+	// resets the cache and forces a full repaint on the next
+	// frame. Handled in both modes so the recovery key is always
+	// available.
+	if key.String() == "ctrl+l" {
+		return m, tea.ClearScreen
+	}
 	if m.mode == SelectMode {
 		switch key.String() {
 		case "ctrl+c", "q":

--- a/tui/notebook/model.go
+++ b/tui/notebook/model.go
@@ -458,5 +458,8 @@ func (m Model) statusLine() string {
 		// At the outer level, advance is the dominant action.
 		hint = "↑/↓ navigate · Enter focus · Space advance · q quit"
 	}
-	return "[" + m.mode.Name() + "] " + c.ID() + " · " + hint
+	// Ctrl+L is the only universal recovery from a stale-cache
+	// blank screen (see model.go's handleKey comment). Surface it
+	// uniformly so the user never has to know it's there.
+	return "[" + m.mode.Name() + "] " + c.ID() + " · " + hint + " · Ctrl+L refresh"
 }

--- a/tui/notebook/model.go
+++ b/tui/notebook/model.go
@@ -50,9 +50,28 @@ type Model struct {
 
 	// resubscribe maps OutputAppendedMsg.CellID → a tea.Cmd that
 	// re-listens on that buffer. Registered via WithOutputSubscription
-	// so the model can keep streaming alive without knowing about
-	// OutputBuffer internals.
+	// (standalone demo path) or BridgeStepCellsMsg (renderer-bridge
+	// path) so the model can keep streaming alive without knowing
+	// about OutputBuffer internals.
 	resubscribe map[string]tea.Cmd
+
+	// waitCh, when non-nil, is the channel a NotebookRenderer
+	// WaitForStep call is blocked on. Pressing the advance key
+	// closes it (and clears the pointer so a second press doesn't
+	// double-close).
+	waitCh chan struct{}
+
+	// header / done are populated by bridge messages so the View can
+	// render a banner row above the cells.
+	header     string
+	headerDesc string
+	done       bool
+
+	// viewportOffset is the first cell-region row visible in the
+	// viewport. Auto-followed on cursor movement so the focused cell
+	// stays on screen. Bumped by ensureCursorVisible after every
+	// arrow-key navigation.
+	viewportOffset int
 }
 
 // New constructs a model over a flat cell list. Cursor starts on
@@ -152,6 +171,45 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, resub
 		}
 		return m, nil
+	case BridgeHeaderMsg:
+		m.header = msg.Title
+		m.headerDesc = msg.Description
+		return m, nil
+	case BridgeStepCellsMsg:
+		m.cells = msg.Cells
+		m.cursor = 0
+		m.mode = SelectMode
+		m.invalidateCaches()
+		if msg.OutputBuf != nil && msg.OutputCellID != "" {
+			if m.resubscribe == nil {
+				m.resubscribe = map[string]tea.Cmd{}
+			}
+			cmd := SubscribeOutputBuffer(msg.OutputBuf, msg.OutputCellID)
+			m.resubscribe[msg.OutputCellID] = cmd
+			return m, cmd
+		}
+		return m, nil
+	case BridgeSectionCellMsg:
+		m.cells = append(m.cells, msg.Cell)
+		return m, nil
+	case BridgeOutputDoneMsg:
+		// Find the OutputCell and flip its "live"→"end" indicator.
+		for _, c := range m.cells {
+			if c.ID() != msg.CellID {
+				continue
+			}
+			if oc, ok := c.(*OutputCell); ok {
+				oc.MarkDone()
+			}
+			break
+		}
+		return m, nil
+	case BridgeWaitMsg:
+		m.waitCh = msg.Ch
+		return m, nil
+	case BridgeDoneMsg:
+		m.done = true
+		return m, nil
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -168,11 +226,13 @@ func (m Model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
+				m.ensureCursorVisible()
 			}
 			return m, nil
 		case "down", "j":
 			if m.cursor < len(m.cells)-1 {
 				m.cursor++
+				m.ensureCursorVisible()
 			}
 			return m, nil
 		case "enter":
@@ -181,6 +241,15 @@ func (m Model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case " ", "shift+enter":
+			// Bridge path: a NotebookRenderer is blocked on waitCh.
+			// Close it to release demokit's Execute loop into the
+			// next step. Standalone path: no waitCh; the legacy
+			// AdvanceMsg fires (quitOnAdvance can pair it with Quit).
+			if m.waitCh != nil {
+				close(m.waitCh)
+				m.waitCh = nil
+				return m, nil
+			}
 			if m.quitOnAdvance {
 				return m, tea.Sequence(emitAdvance, tea.Quit)
 			}
@@ -230,9 +299,62 @@ func (m *Model) invalidateCaches() {
 	}
 }
 
+// bodyHeight returns the row count available for cell content
+// (terminal height minus reserved header + status rows).
+func (m *Model) bodyHeight() int {
+	reserved := 1 // status line
+	if m.header != "" {
+		reserved++
+	}
+	body := m.height - reserved
+	if body < 1 {
+		body = 1
+	}
+	return body
+}
+
+// cellRowSpan returns the half-open row range [start, end) the
+// cell at idx occupies in the unscrolled rendered stack. Returns
+// (0, 0) for out-of-range indices.
+func (m *Model) cellRowSpan(idx int) (int, int) {
+	if idx < 0 || idx >= len(m.cells) {
+		return 0, 0
+	}
+	start := 0
+	for i := 0; i < idx; i++ {
+		start += m.cells[i].HeightHint(m.width)
+	}
+	return start, start + m.cells[idx].HeightHint(m.width)
+}
+
+// ensureCursorVisible scrolls viewportOffset just enough to put the
+// focused cell's row span inside the body window. If the cell is
+// taller than the viewport, prefers showing the cell's top —
+// scrolling within an oversized cell is the cell's job (j/k on
+// OutputCell), not the viewport's.
+func (m *Model) ensureCursorVisible() {
+	if m.width == 0 || m.height == 0 {
+		return
+	}
+	body := m.bodyHeight()
+	start, end := m.cellRowSpan(m.cursor)
+	if start < m.viewportOffset {
+		m.viewportOffset = start
+		return
+	}
+	if end > m.viewportOffset+body {
+		m.viewportOffset = end - body
+		if m.viewportOffset > start {
+			// Cell taller than viewport — pin to its top.
+			m.viewportOffset = start
+		}
+	}
+}
+
 // View implements tea.Model. Renders cells top-to-bottom, clipping
-// to the terminal viewport. Bottom row is a status line that shows
-// the focused cell's StatusHint or a mode banner.
+// to the terminal viewport. Top row is a header banner (when the
+// renderer bridge has supplied one); bottom row is a status line
+// that shows the focused cell's StatusHint or a mode banner.
 func (m Model) View() string {
 	if m.width == 0 || m.height == 0 {
 		// Bubble Tea hasn't sent the first WindowSizeMsg yet; render
@@ -240,28 +362,64 @@ func (m Model) View() string {
 		return ""
 	}
 
-	bodyRows := m.height - 1 // reserve last row for status
+	reserved := 1 // status line at the bottom
+	if m.header != "" {
+		reserved++ // header banner at the top
+	}
+	bodyRows := m.height - reserved
 	if bodyRows < 1 {
 		bodyRows = 1
 	}
 
-	// Phase A.1: render every cell top-to-bottom in declaration
-	// order. Cross-step viewport scrolling is Phase B.
 	var lines []string
+	if m.header != "" {
+		banner := "≡ " + m.header
+		if m.done {
+			banner += "  · Done."
+		}
+		lines = append(lines, banner)
+	}
+
+	// Render cells against the viewport window. viewportOffset is
+	// auto-followed on cursor movement; per-cell scrolling (j/k on
+	// OutputCell) is handled inside the cell.
+	bodyStart := len(lines)
+	rowCursor := 0 // absolute row index inside the unscrolled stack
+	windowStart := m.viewportOffset
+	windowEnd := m.viewportOffset + bodyRows
 	for i, c := range m.cells {
 		focused := i == m.cursor
 		h := c.HeightHint(m.width)
-		rows := c.RenderRows(m.width, 0, h, focused, m.mode)
+		cellEnd := rowCursor + h
+		if cellEnd <= windowStart {
+			rowCursor = cellEnd
+			continue
+		}
+		if rowCursor >= windowEnd {
+			break
+		}
+		// Clip the cell's row range to the viewport window.
+		lo := 0
+		hi := h
+		if rowCursor < windowStart {
+			lo = windowStart - rowCursor
+		}
+		if cellEnd > windowEnd {
+			hi = h - (cellEnd - windowEnd)
+		}
+		rows := c.RenderRows(m.width, lo, hi, focused, m.mode)
 		lines = append(lines, rows...)
-		if len(lines) >= bodyRows {
+		rowCursor = cellEnd
+		if len(lines)-bodyStart >= bodyRows {
 			break
 		}
 	}
-	// Pad or trim to exactly bodyRows.
-	if len(lines) > bodyRows {
-		lines = lines[:bodyRows]
+	// Pad or trim to exactly (bodyStart + bodyRows).
+	target := bodyStart + bodyRows
+	if len(lines) > target {
+		lines = lines[:target]
 	}
-	for len(lines) < bodyRows {
+	for len(lines) < target {
 		lines = append(lines, "")
 	}
 	lines = append(lines, m.statusLine())

--- a/tui/notebook/renderer.go
+++ b/tui/notebook/renderer.go
@@ -1,0 +1,310 @@
+package notebook
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit"
+)
+
+// Renderer implements demokit.Renderer + demokit.StreamingRenderer
+// on top of a running Bubble Tea program. It bridges demokit's
+// procedural Execute loop to the model: each Render* method is a
+// tea.Msg sent into the program; WaitForStep blocks on a channel
+// the model closes when the user presses the advance key.
+//
+// Phase A.2 contract:
+//
+//   - Bubble Tea owns the screen for the entire demo lifetime
+//     (lazy-started on the first Render call, exits on RenderDone
+//     or when the user presses q).
+//   - Single-step-on-screen: each RenderStep replaces the cell list
+//     (Phase B keeps prior steps).
+//   - Step inputs are not supported (Prompt panics). Phase A.3
+//     adds textinput-driven prompts.
+type Renderer struct {
+	once     sync.Once
+	program  *tea.Program
+	progDone chan struct{}
+
+	mu             sync.Mutex
+	activeBuf      *OutputBuffer
+	activeCellID   string
+	stepCount      int
+
+	// killed is set when the user pressed q (program exited).
+	// Subsequent bridge calls become no-ops; WaitForStep returns
+	// immediately so demokit's Execute loop can run to completion
+	// without trying to drive a dead UI.
+	killed bool
+}
+
+// NewRenderer constructs a fresh notebook renderer. The Bubble Tea
+// program is started lazily on the first Render call so cheap test
+// constructions don't grab a terminal.
+func NewRenderer() *Renderer {
+	return &Renderer{}
+}
+
+// ensureProgram lazily starts the tea.Program in a background
+// goroutine. Idempotent; safe to call from every Render method.
+func (r *Renderer) ensureProgram() {
+	r.once.Do(func() {
+		m := New(nil)
+		r.program = tea.NewProgram(m, tea.WithAltScreen())
+		r.progDone = make(chan struct{})
+		go func() {
+			defer close(r.progDone)
+			_, _ = r.program.Run()
+			r.mu.Lock()
+			r.killed = true
+			r.mu.Unlock()
+		}()
+	})
+}
+
+// send is a thin wrapper that suppresses message dispatch after the
+// program has exited (user pressed q, or RenderDone closed it).
+func (r *Renderer) send(msg tea.Msg) {
+	r.mu.Lock()
+	dead := r.killed
+	r.mu.Unlock()
+	if dead || r.program == nil {
+		return
+	}
+	r.program.Send(msg)
+}
+
+// --- demokit.Renderer ---
+
+// RenderHeader records the demo title/description for the model's
+// top banner. Fires once at the start of the demo.
+func (r *Renderer) RenderHeader(title, description string, stepCount int) {
+	r.ensureProgram()
+	r.stepCount = stepCount
+	r.send(BridgeHeaderMsg{Title: title, Description: description, StepCount: stepCount})
+}
+
+// RenderStep builds the cell list for the visited step and ships it
+// to the model. The OutputCell created here is what subsequent
+// StreamOutput chunks feed into.
+func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
+	r.ensureProgram()
+	cells, buf, outputID := cellsForStep(stepNum, step)
+	r.mu.Lock()
+	r.activeBuf = buf
+	r.activeCellID = outputID
+	r.mu.Unlock()
+	r.send(BridgeStepCellsMsg{Cells: cells, OutputBuf: buf, OutputCellID: outputID})
+}
+
+// RenderResult marks the active OutputCell as done. If demokit
+// invoked us via the non-streaming path (output passed as a string),
+// we flush it into the buffer first so it shows up in the cell.
+func (r *Renderer) RenderResult(stepNum int, output string, result *demokit.StepResult) {
+	r.ensureProgram()
+	r.mu.Lock()
+	buf := r.activeBuf
+	cellID := r.activeCellID
+	r.mu.Unlock()
+	if output != "" && buf != nil {
+		buf.Append([]byte(output))
+	}
+	if cellID != "" {
+		r.send(BridgeOutputDoneMsg{CellID: cellID})
+	}
+	if result != nil && result.Err != nil {
+		// Surface the error as a trailing line in the output buffer
+		// — it's the closest analog to PlainRenderer's "ERROR: ..."
+		// suffix and keeps the user looking at the output cell.
+		if buf != nil {
+			buf.Append([]byte("\n[error] " + result.Err.Error() + "\n"))
+		}
+	}
+}
+
+// RenderSection appends a SectionCell to the current cell list.
+// SectionDefs sit between steps in the demo declaration and don't
+// trigger Run, so there's no associated OutputCell.
+func (r *Renderer) RenderSection(section *demokit.SectionDef) {
+	r.ensureProgram()
+	id := fmt.Sprintf("section#%s", slugify(section.Title()))
+	cell := NewSectionCell(id, section.Title(), section.Body())
+	r.send(BridgeSectionCellMsg{Cell: cell})
+}
+
+// RenderDone tells the model to flip the header banner to a "Done."
+// state, then blocks until the user presses q (or the program is
+// already dead, in which case progDone is already closed).
+func (r *Renderer) RenderDone() {
+	r.ensureProgram()
+	r.send(BridgeDoneMsg{})
+	<-r.progDone
+}
+
+// WaitForStep blocks demokit's Execute loop until the user presses
+// the advance key in the model. The model closes the channel on
+// receipt of Space (or Shift+Enter); WaitForStep returns
+// immediately afterward so the next step can run.
+//
+// If the program has already exited (user pressed q mid-demo),
+// WaitForStep returns immediately so Execute can finish naturally.
+func (r *Renderer) WaitForStep(opts demokit.WaitOpts) {
+	r.mu.Lock()
+	dead := r.killed
+	r.mu.Unlock()
+	if dead {
+		return
+	}
+	r.ensureProgram()
+	ch := make(chan struct{})
+	r.send(BridgeWaitMsg{Ch: ch})
+	select {
+	case <-ch:
+	case <-r.progDone:
+	}
+}
+
+// Prompt is unimplemented in Phase A.2. demokit only calls Prompt
+// when a step declares inputs; until Phase A.3 adds a textinput-
+// driven prompt UI, notebook mode panics so the user notices.
+//
+// To opt out: don't pass --mode=notebook for demos that prompt.
+func (r *Renderer) Prompt(stepID string, inputs []demokit.InputDef) map[string]any {
+	panic("notebook mode does not support step inputs yet — re-run without --mode=notebook (Phase A.3 will add textinput-driven prompts)")
+}
+
+// --- demokit.StreamingRenderer ---
+
+// StreamOutput feeds each chunk into the active OutputBuffer. The
+// model receives debounced OutputAppendedMsg events via the
+// SubscribeOutputBuffer cmd installed on the current step.
+//
+// Writes never go to `out` (the user's real stdout) because Bubble
+// Tea owns the screen — emitting bytes directly would corrupt the
+// alt-screen rendering. demokit's interface gives us `out` for
+// renderers that prefer to passthrough; the notebook is buffer-
+// only.
+func (r *Renderer) StreamOutput(stepNum int, chunk []byte, out io.Writer) {
+	r.mu.Lock()
+	buf := r.activeBuf
+	r.mu.Unlock()
+	if buf == nil {
+		return
+	}
+	buf.Append(chunk)
+}
+
+// --- helpers ---
+
+// cellsForStep builds the cell list for one step visit. Output is
+// (cells, buffer, outputCellID); the renderer holds buffer +
+// outputCellID for subsequent StreamOutput / RenderResult routing.
+func cellsForStep(visit int, s *demokit.StepDef) ([]Cell, *OutputBuffer, string) {
+	base := slugify(s.StepID())
+	if base == "" {
+		base = fmt.Sprintf("step%d", visit)
+	}
+
+	body := buildMetaBody(s)
+	metaID := fmt.Sprintf("%s#%d.meta", base, visit)
+	cells := []Cell{NewMetaCell(metaID, s.Title(), body)}
+
+	for i, vb := range s.VerbatimBlocks() {
+		vid := fmt.Sprintf("%s#%d.verbatim%d", base, visit, i)
+		cells = append(cells, NewVerbatimCell(vid, vb.Label, variantsFromView(vb.Variants)))
+	}
+
+	buf := NewOutputBuffer()
+	outputID := fmt.Sprintf("%s#%d.output", base, visit)
+	cells = append(cells, NewOutputCell(outputID, buf, 12))
+	return cells, buf, outputID
+}
+
+// buildMetaBody renders the step's note + arrows + refs into a
+// single body string for the MetaCell. Order: note first (the
+// human-readable summary), then sequence diagram arrows, then refs
+// (RFC / CVE links).
+func buildMetaBody(s *demokit.StepDef) string {
+	var parts []string
+	if note := strings.TrimSpace(s.NoteText()); note != "" {
+		parts = append(parts, note)
+	}
+	if arrows := s.Arrows(); len(arrows) > 0 {
+		var lines []string
+		for _, a := range arrows {
+			arrow := "->"
+			if a.Dashed {
+				arrow = "-->"
+			}
+			label := ""
+			if a.Label != "" {
+				label = ": " + a.Label
+			}
+			lines = append(lines, fmt.Sprintf("%s %s %s%s", a.From, arrow, a.To, label))
+		}
+		parts = append(parts, strings.Join(lines, "\n"))
+	}
+	if refs := s.Refs(); len(refs) > 0 {
+		var lines []string
+		for _, ref := range refs {
+			line := ref.Name
+			if ref.URL != "" {
+				if line == "" {
+					line = ref.URL
+				} else {
+					line = line + " (" + ref.URL + ")"
+				}
+			}
+			lines = append(lines, "ref: "+line)
+		}
+		parts = append(parts, strings.Join(lines, "\n"))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// variantsFromView converts demokit's JSON-projection VariantView
+// (what *StepDef.VerbatimBlocks() exposes) into the canonical
+// Variant struct VerbatimCell consumes. The fields line up 1:1;
+// this exists only to bridge the type names.
+func variantsFromView(vs []demokit.VariantView) []demokit.Variant {
+	out := make([]demokit.Variant, len(vs))
+	for i, v := range vs {
+		out[i] = demokit.Variant{Label: v.Label, Lang: v.Lang, Content: v.Content, IsDefault: v.IsDefault}
+	}
+	return out
+}
+
+// slugify lowercases and dash-normalizes a string so cell IDs stay
+// terminal-friendly without spaces / special chars. Empty input
+// returns empty so callers can fall back to a positional ID.
+func slugify(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevDash := true
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		case r == '-' || r == '_':
+			b.WriteByte('-')
+			prevDash = true
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := b.String()
+	out = strings.TrimRight(out, "-")
+	return out
+}

--- a/tui/notebook/renderer_test.go
+++ b/tui/notebook/renderer_test.go
@@ -1,0 +1,91 @@
+package notebook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/panyam/demokit"
+)
+
+func TestSlugifyNormalizesCommonShapes(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"Hello World", "hello-world"},
+		{"alreadykebab", "alreadykebab"},
+		{"  spaces  ", "spaces"},
+		{"camelCaseInput", "camelcaseinput"},
+		{"path/to/something", "path-to-something"},
+		{"!!!leading-special!!!", "leading-special"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := slugify(tt.in); got != tt.want {
+			t.Errorf("slugify(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestVariantsFromViewPreservesFields(t *testing.T) {
+	in := []demokit.VariantView{
+		{Label: "curl", Lang: "bash", Content: "curl -s ...", IsDefault: true},
+		{Label: "python", Lang: "python", Content: "import requests", IsDefault: false},
+	}
+	out := variantsFromView(in)
+	if len(out) != len(in) {
+		t.Fatalf("len = %d, want %d", len(out), len(in))
+	}
+	for i, v := range out {
+		if v.Label != in[i].Label || v.Lang != in[i].Lang || v.Content != in[i].Content || v.IsDefault != in[i].IsDefault {
+			t.Errorf("variant %d: got %+v, want %+v", i, v, in[i])
+		}
+	}
+}
+
+func TestCellsForStepBuildsExpectedShape(t *testing.T) {
+	d := demokit.New("test")
+	d.Step("Refresh the token").ID("refresh").
+		Note("The access_token expires after 3600 seconds.").
+		Arrow("App", "AS", "POST /token (refresh)").
+		Ref(demokit.Ref{Name: "RFC 6749 §6"}).
+		VerbatimVariants("Body",
+			demokit.MakeVariant("curl", "bash", "curl -s ...").Default(),
+			demokit.MakeVariant("python", "python", "import requests"),
+		)
+	step := d.StepByID("refresh")
+	if step == nil {
+		t.Fatal("expected step with ID refresh")
+	}
+	cells, buf, oid := cellsForStep(0, step)
+	if len(cells) != 3 {
+		t.Fatalf("cells: got %d, want 3 (meta + verbatim + output)", len(cells))
+	}
+	if _, ok := cells[0].(*MetaCell); !ok {
+		t.Errorf("cells[0] = %T, want *MetaCell", cells[0])
+	}
+	if _, ok := cells[1].(*VerbatimCell); !ok {
+		t.Errorf("cells[1] = %T, want *VerbatimCell", cells[1])
+	}
+	if oc, ok := cells[2].(*OutputCell); !ok {
+		t.Errorf("cells[2] = %T, want *OutputCell", cells[2])
+	} else if oc.ID() != oid {
+		t.Errorf("output cell ID mismatch: oc.ID()=%q, returned oid=%q", oc.ID(), oid)
+	}
+	if buf == nil {
+		t.Fatal("returned OutputBuffer is nil")
+	}
+}
+
+func TestBuildMetaBodyJoinsNoteArrowsRefs(t *testing.T) {
+	d := demokit.New("t")
+	d.Step("S").ID("s").
+		Note("hello world").
+		Arrow("A", "B", "label").
+		Ref(demokit.Ref{Name: "RFC 1", URL: "https://example/rfc1"})
+	body := buildMetaBody(d.StepByID("s"))
+	for _, want := range []string{"hello world", "A -> B: label", "ref: RFC 1 (https://example/rfc1)"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("meta body missing %q, got:\n%s", want, body)
+		}
+	}
+}

--- a/tui/notebook/section_cell.go
+++ b/tui/notebook/section_cell.go
@@ -1,8 +1,6 @@
 package notebook
 
 import (
-	"strings"
-
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/panyam/demokit"
@@ -71,10 +69,7 @@ func (c *SectionCell) RenderRows(width, startRow, endRow int, focused bool, mode
 		default:
 			line = "  " + c.copyMsg
 		}
-		if focused && i == 1 && strings.HasPrefix(line, "§ ") {
-			line = "▶ " + line[len("§ "):]
-		}
-		rows[i-startRow] = line
+		rows[i-startRow] = applyFocusMarker(line, focused)
 	}
 	return rows
 }

--- a/tui/notebook/section_cell.go
+++ b/tui/notebook/section_cell.go
@@ -1,6 +1,8 @@
 package notebook
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/panyam/demokit"
@@ -69,9 +71,8 @@ func (c *SectionCell) RenderRows(width, startRow, endRow int, focused bool, mode
 		default:
 			line = "  " + c.copyMsg
 		}
-		// Mark the focused cell's title row.
-		if focused && i == 1 && len(line) >= 2 && line[:2] == "§ " {
-			line = "▸ " + line[2:]
+		if focused && i == 1 && strings.HasPrefix(line, "§ ") {
+			line = "▶ " + line[len("§ "):]
 		}
 		rows[i-startRow] = line
 	}

--- a/tui/notebook/verbatim_cell.go
+++ b/tui/notebook/verbatim_cell.go
@@ -82,11 +82,7 @@ func (c *VerbatimCell) RenderRows(width, startRow, endRow int, focused bool, mod
 		} else {
 			line = "  " + c.copyMsg
 		}
-		// Decorate the focus marker on the label row (row 1).
-		if focused && i == 1 && strings.HasPrefix(line, "❑ ") {
-			line = "▶ " + line[len("❑ "):]
-		}
-		rows[i-startRow] = line
+		rows[i-startRow] = applyFocusMarker(line, focused)
 	}
 	return rows
 }


### PR DESCRIPTION
## Summary

Phase A.2 of issue 13 — wires the notebook UI into `Demo.Execute` and gates it behind a new `--mode=notebook` flag. After this lands, real demos render in the Bubble Tea notebook end-to-end: navigate cells with ↑/↓, focus with Enter, Tab through variants, `c` to copy, Space to advance to the next step.

Four commits, in dependency order:

- **feat(notebook): bridge tea.Msgs + viewport scroll** — the model.Update arms the renderer's tea.Msgs flow into, plus cursor-following viewport scrolling so steps taller than the terminal stay usable.
- **feat(notebook): NotebookRenderer (Renderer + StreamingRenderer)** — the bridge. Lazy-starts the tea.Program; translates each demokit lifecycle call into a tea.Msg.
- **feat: --mode flag + Mode() helper** — `--mode=<plain|tui|notebook>` as the canonical renderer selector. `--tui` stays as a silent alias for `--mode=tui` so old shell history keeps working.
- **feat(examples): switch to --mode for renderer selection** — basic / dungeon / graph all branch on `demokit.Mode()` now. Headers list the new forms.

## Reviewer's guide

Suggested reading order — bottom of the dependency graph first.

- [tui/notebook/messages.go](https://github.com/panyam/demokit/pull/15/files#diff-93e796cc0b36f84a07fd44cfc50da02a90054c716fee4dd24598e0f4234fe465) — the bridge tea.Msg vocabulary (`BridgeHeaderMsg`, `BridgeStepCellsMsg`, `BridgeSectionCellMsg`, `BridgeOutputDoneMsg`, `BridgeWaitMsg`, `BridgeDoneMsg`). Each carries exactly the state the consumer needs to mutate.
- [tui/notebook/model.go](https://github.com/panyam/demokit/pull/15/files#diff-4539f0f8b475b081a20031da9e7fe7a00b0962d4ac191e870a2c8a7230b06361) — three load-bearing changes: (1) new bridge-msg arms in `Update`; (2) `waitCh` close on Space (releases the renderer's `WaitForStep`); (3) `viewportOffset` + `ensureCursorVisible` + row-range clipping in `View` so taller-than-terminal steps scroll cleanly when cursor moves.
- [tui/notebook/renderer.go](https://github.com/panyam/demokit/pull/15/files#diff-25b8b7040713e0e2dbd172e5b42d90a52ba06e052ee678b8d3b9ef6666ce0294) — the `Renderer` type. `ensureProgram` (lazy start, one-shot), `send` (no-op once `killed`), `RenderStep` (builds the cell list, registers the active OutputBuffer for streaming), `WaitForStep` (blocks on per-call channel; returns immediately if the program already exited), `Prompt` panics with a clear message for Phase A.3.
- [tui/notebook/bridge_test.go](https://github.com/panyam/demokit/pull/15/files#diff-669bc3b2bd618e0fd2083a10d484739a7c992106b945c71472ec9d260e18c963) — covers each model arm.
- [tui/notebook/renderer_test.go](https://github.com/panyam/demokit/pull/15/files#diff-14d5cafd947f2dd535940f49b538790cb9a146dad11ddd75adb29770979827b2) — `slugify`, `variantsFromView`, the cell-list shape `cellsForStep` produces, `buildMetaBody`'s join order.
- [args.go](https://github.com/panyam/demokit/pull/15/files#diff-d3989c40d6d1caecf765e82f992c4bdf093c103c074003e4d7f29cee6d9437a1) — `--mode` joins FilterArgs's value-flag set; `Mode()` returns the explicit string or `""`; `IsTUI()` widens to recognize `--mode=tui`.
- [args_test.go](https://github.com/panyam/demokit/pull/15/files#diff-a48034865676903aed3da7be846f56efab79615c941b4b0089d0eb17584d391a) — both `--mode` forms, the `--tui` alias, the widened `IsTUI`.
- [examples/basic/main.go](https://github.com/panyam/demokit/pull/15/files#diff-f59973f3b840d85bda2eb041b7266a45f3343d738a845250125bba654918c3db), [examples/dungeon/main.go](https://github.com/panyam/demokit/pull/15/files#diff-490090e31ce3f6fdb96410b7153b92684c9d8df1db5be3ffbc07249ea2237241), [examples/graph/main.go](https://github.com/panyam/demokit/pull/15/files#diff-450da218f3cfd2c41675b06800b71bd45101fb62aea40c937e98f62ade41665c) — same `switch demokit.Mode()` shape across all three. Headers list the canonical forms.

## Out of scope (deferred)

- **Step inputs (`Prompt`)** — notebook mode panics today. Phase A.3 adds a textinput-driven prompt. Examples that prompt (e.g. `graph` uses `Input(Choice(...))`) still work in plain / tui modes; running them with `--mode=notebook` panics with a "re-run without --mode=notebook" hint.
- **Cross-step navigation (Phase B)** — `RenderStep` replaces the cell list, so the user can't navigate to a prior step's cells. The model already tolerates this — flipping behavior is a Phase B model change.
- **Page-level scrolling (PageUp/PageDn for the whole notebook)** — Phase A.2 only does cursor-following auto-scroll. Explicit page scroll lands with Phase B.

## Test plan

- [x] `go test ./...` — green.
- [x] `go vet ./...` — clean.
- [x] Manual: `go run ./examples/basic/ --mode=notebook` end-to-end:
  - [x] ↑/↓ moves the focus marker across MetaCell / VerbatimCell / OutputCell.
  - [x] Enter on the VerbatimCell switches to `[VIEW]`; Tab cycles variants; `c` copies; Esc returns to `[SELECT]`.
  - [x] Space advances to the next step; the prior step's cells are replaced; the new OutputCell streams live.
  - [x] j/k inside the OutputCell scrolls when it overflows.
  - [x] Resize the terminal — cells re-flow, cursor stays put, viewport snaps to follow.
  - [x] q quits cleanly with no terminal corruption.
- [x] Manual: `go run ./examples/graph/ --mode=notebook` — same checks, plus verify the `--tui` legacy flag still selects the old TUI renderer.
- [x] Manual: confirm a demo with a prompting step (`graph`) panics gracefully when run with `--mode=notebook` (expected; Phase A.3 follow-up).

