### PR TITLE
fix(notebook): drip-drip + auto-follow + copy-in-select

### DIFF
--- a/tui/notebook/apply_test.go
+++ b/tui/notebook/apply_test.go
@@ -81,6 +81,72 @@ func TestApplyStepReadyToRunInstallsOutputCell(t *testing.T) {
 	}
 }
 
+func TestApplyStepReadyToRunMovesCursorToOutputCell(t *testing.T) {
+	m := New(nil)
+	m = apply(m,
+		events.StepStart{Visit: 1, StepID: "s1", Title: "S1"},
+		events.StepReadyToRun{Visit: 1},
+	)
+	tail := len(m.cells) - 1
+	if _, ok := m.cells[tail].(*OutputCell); !ok {
+		t.Fatalf("tail cell = %T, want *OutputCell", m.cells[tail])
+	}
+	if m.cursor != tail {
+		t.Errorf("cursor = %d, want %d (output cell idx)", m.cursor, tail)
+	}
+}
+
+func TestStepReadyToRunMakesOutputCellVisible(t *testing.T) {
+	// Reproduces the dungeon-style scenario: many prior cells push
+	// the new step's output cell below the viewport. After
+	// StepReadyToRun, the viewport must have scrolled so the output
+	// cell is in the window.
+	m := New(nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = next.(Model)
+	for i := 0; i < 15; i++ {
+		m = apply(m, events.Section{Title: "S", Body: "line"})
+	}
+	m = apply(m,
+		events.StepStart{Visit: 1, StepID: "s", Title: "T"},
+		events.StepReadyToRun{Visit: 1},
+	)
+	outputIdx := len(m.cells) - 1
+	start, end := m.cellRowSpan(outputIdx)
+	body := m.bodyHeight()
+	if end <= m.viewportOffset || start >= m.viewportOffset+body {
+		t.Errorf("output cell span [%d,%d) not in viewport [%d,%d)",
+			start, end, m.viewportOffset, m.viewportOffset+body)
+	}
+}
+
+func TestOutputChunkKeepsGrowingCellInViewport(t *testing.T) {
+	// Bounded by maxBody=12, so the cell's rendered height never
+	// exceeds ~16 rows. With bodyHeight ≥ 20 the cell fits entirely;
+	// ensureCursorVisible should keep its end row in the window as
+	// chunks land.
+	m := New(nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = next.(Model)
+	for i := 0; i < 10; i++ {
+		m = apply(m, events.Section{Title: "S", Body: "line"})
+	}
+	m = apply(m,
+		events.StepStart{Visit: 1, StepID: "s", Title: "T"},
+		events.StepReadyToRun{Visit: 1},
+	)
+	for i := 0; i < 20; i++ {
+		m = apply(m, events.OutputChunk{Visit: 1, Chunk: []byte("line\n")})
+	}
+	outputIdx := len(m.cells) - 1
+	_, end := m.cellRowSpan(outputIdx)
+	body := m.bodyHeight()
+	if end > m.viewportOffset+body {
+		t.Errorf("after growth: cell end %d > viewport end %d (viewport did not follow)",
+			end, m.viewportOffset+body)
+	}
+}
+
 func TestApplyOutputChunkRoutesByVisit(t *testing.T) {
 	m := New(nil)
 	m = apply(m,

--- a/tui/notebook/cells_test.go
+++ b/tui/notebook/cells_test.go
@@ -3,6 +3,7 @@ package notebook
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -224,6 +225,112 @@ func TestOutputCellHeightCappedByMaxBody(t *testing.T) {
 	// 3 header + 5 body + 1 status = 9
 	if got, want := c.HeightHint(80), 9; got != want {
 		t.Errorf("HeightHint = %d, want %d (capped by maxBody=5)", got, want)
+	}
+}
+
+func TestOutputCellAutoFollowsOnAppend(t *testing.T) {
+	buf := NewOutputBuffer()
+	c := NewOutputCell("o", buf, 3)
+	// Fewer than maxBody lines: scrollOffset stays at 0 (whole buf fits).
+	buf.Append([]byte("a\n"))
+	c.OnAppend()
+	if c.scrollOffset != 0 {
+		t.Errorf("with 1 line < maxBody, scrollOffset = %d, want 0", c.scrollOffset)
+	}
+	// Grow past maxBody: follow advances scrollOffset so the last
+	// maxBody lines remain visible.
+	for i := 0; i < 10; i++ {
+		buf.Append([]byte("x\n"))
+	}
+	c.OnAppend()
+	if want := 11 - 3; c.scrollOffset != want {
+		t.Errorf("auto-follow scrollOffset = %d, want %d", c.scrollOffset, want)
+	}
+}
+
+func TestOutputCellManualScrollDisablesFollow(t *testing.T) {
+	buf := NewOutputBuffer()
+	for i := 0; i < 10; i++ {
+		buf.Append([]byte("x\n"))
+	}
+	c := NewOutputCell("o", buf, 3)
+	c.OnAppend()
+	// User scrolls up; subsequent chunks should NOT yank them.
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}, ViewMode)
+	if c.follow {
+		t.Error("follow should be disabled after k")
+	}
+	frozen := c.scrollOffset
+	for i := 0; i < 5; i++ {
+		buf.Append([]byte("y\n"))
+	}
+	c.OnAppend()
+	if c.scrollOffset != frozen {
+		t.Errorf("with follow off, OnAppend moved scrollOffset from %d to %d", frozen, c.scrollOffset)
+	}
+	// G re-engages follow and jumps to bottom.
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")}, ViewMode)
+	if !c.follow {
+		t.Error("follow should be re-enabled after G")
+	}
+	buf.Append([]byte("z\n"))
+	c.OnAppend()
+	if want := buf.LineCount() - 3; c.scrollOffset != want {
+		t.Errorf("after G + chunk: scrollOffset = %d, want %d", c.scrollOffset, want)
+	}
+}
+
+func TestOutputCellRenderShowsLatestLinesWhenFollowing(t *testing.T) {
+	buf := NewOutputBuffer()
+	c := NewOutputCell("o", buf, 3)
+	for i := 1; i <= 5; i++ {
+		buf.Append([]byte(fmt.Sprintf("line%d\n", i)))
+		c.OnAppend()
+	}
+	rows := allRows(c, 80, false, ViewMode)
+	joined := strings.Join(rows, "\n")
+	for _, want := range []string{"line3", "line4", "line5"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected latest line %q in render, got:\n%s", want, joined)
+		}
+	}
+	for _, off := range []string{"line1", "line2"} {
+		if strings.Contains(joined, off) {
+			t.Errorf("expected earliest line %q to be scrolled off, got:\n%s", off, joined)
+		}
+	}
+}
+
+func TestOutputCellCopiesInSelectMode(t *testing.T) {
+	var buf bytes.Buffer
+	demokit.SetClipboardWriter(&buf)
+	defer demokit.SetClipboardWriter(nil)
+	demokit.EnableShellClipboardFallback(false)
+	defer demokit.EnableShellClipboardFallback(true)
+
+	ob := NewOutputBuffer()
+	ob.Append([]byte("hello\nworld\n"))
+	c := NewOutputCell("o", ob, 10)
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, SelectMode)
+	if got := clipboardPayload(t, &buf); got != "hello\nworld" {
+		t.Errorf("clipboard payload = %q, want %q", got, "hello\nworld")
+	}
+	if c.copyMsg == "" {
+		t.Error("expected copyMsg to be set after copy in SelectMode")
+	}
+}
+
+func TestVerbatimCellCopiesInSelectMode(t *testing.T) {
+	var buf bytes.Buffer
+	demokit.SetClipboardWriter(&buf)
+	defer demokit.SetClipboardWriter(nil)
+	demokit.EnableShellClipboardFallback(false)
+	defer demokit.EnableShellClipboardFallback(true)
+
+	c := NewVerbatimCell("v", "L", []demokit.Variant{{Label: "x", Content: "payload"}})
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, SelectMode)
+	if got := clipboardPayload(t, &buf); got != "payload" {
+		t.Errorf("clipboard payload = %q, want %q", got, "payload")
 	}
 }
 

--- a/tui/notebook/model.go
+++ b/tui/notebook/model.go
@@ -202,11 +202,23 @@ func (m *Model) applyEvent(offset int, e events.Event) {
 		}
 		m.outputCellByVisit[e.Visit] = oc
 		m.cells = append(m.cells, oc)
+		m.cursor = len(m.cells) - 1
 		m.invalidateCaches()
 		m.ensureCursorVisible()
 	case events.OutputChunk:
 		if oc, ok := m.outputCellByVisit[e.Visit]; ok && oc != nil {
 			oc.buf.Append(e.Chunk)
+			oc.OnAppend()
+			// Keep the growing output cell in view when the user is
+			// focused on it. cellRowSpan reflects the new (larger)
+			// HeightHint, so ensureCursorVisible scrolls the bottom
+			// of the cell into the window.
+			for i, c := range m.cells {
+				if c == oc && m.cursor == i {
+					m.ensureCursorVisible()
+					break
+				}
+			}
 		}
 	case events.StepEnd:
 		if oc, ok := m.outputCellByVisit[e.Visit]; ok && oc != nil {

--- a/tui/notebook/output_cell.go
+++ b/tui/notebook/output_cell.go
@@ -27,6 +27,11 @@ type OutputCell struct {
 	scrollOffset int
 	copyMsg      string
 	done         bool
+	// follow is the "tail -f" sticky-bottom mode. New chunks bump
+	// scrollOffset so the last maxBody lines are visible. Manual
+	// scrolling (j/k/g/pgup/pgdown) turns it off; G turns it back
+	// on. Defaults to true on construction.
+	follow bool
 }
 
 // NewOutputCell builds a cell over the given buffer. maxBody == 0
@@ -35,7 +40,22 @@ func NewOutputCell(id string, buf *OutputBuffer, maxBody int) *OutputCell {
 	if maxBody <= 0 {
 		maxBody = 12
 	}
-	return &OutputCell{id: id, buf: buf, maxBody: maxBody, palette: DefaultPalette()}
+	return &OutputCell{
+		id: id, buf: buf, maxBody: maxBody,
+		palette: DefaultPalette(),
+		follow:  true,
+	}
+}
+
+// OnAppend is called by the model after a chunk lands in the cell's
+// buffer. While follow is true, advances scrollOffset so the last
+// maxBody lines are visible.
+func (c *OutputCell) OnAppend() {
+	if !c.follow {
+		return
+	}
+	c.scrollOffset = c.buf.LineCount() - c.maxBody
+	c.clampScroll()
 }
 
 // SetPalette overrides the cell's palette.
@@ -140,35 +160,14 @@ func (c *OutputCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd) {
 		c.copyMsg = ""
 		return c, nil
 	}
-	if mode != ViewMode {
-		return c, nil
-	}
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return c, nil
 	}
-	switch keyMsg.String() {
-	case "enter":
-		// Cell doesn't use Enter — signal release + advance.
-		return c, cellAdvance
-	case "j", "down":
-		c.scrollOffset++
-		c.clampScroll()
-	case "k", "up":
-		c.scrollOffset--
-		c.clampScroll()
-	case "pgdown":
-		c.scrollOffset += c.maxBody
-		c.clampScroll()
-	case "pgup":
-		c.scrollOffset -= c.maxBody
-		c.clampScroll()
-	case "g":
-		c.scrollOffset = 0
-	case "G":
-		c.scrollOffset = c.buf.LineCount()
-		c.clampScroll()
-	case "c":
+	// 'c' is processed regardless of mode — copying is a
+	// frictionless action available while just navigating
+	// between cells.
+	if keyMsg.String() == "c" {
 		all := strings.Join(c.buf.AllLines(), "\n")
 		strategy, ok := demokit.Copy(all)
 		if ok {
@@ -177,6 +176,37 @@ func (c *OutputCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd) {
 			c.copyMsg = "(copy failed — no clipboard provider)"
 		}
 		return c, clearCopyMsgAfter(c.id)
+	}
+	if mode != ViewMode {
+		return c, nil
+	}
+	switch keyMsg.String() {
+	case "enter":
+		// Cell doesn't use Enter — signal release + advance.
+		return c, cellAdvance
+	case "j", "down":
+		c.follow = false
+		c.scrollOffset++
+		c.clampScroll()
+	case "k", "up":
+		c.follow = false
+		c.scrollOffset--
+		c.clampScroll()
+	case "pgdown":
+		c.follow = false
+		c.scrollOffset += c.maxBody
+		c.clampScroll()
+	case "pgup":
+		c.follow = false
+		c.scrollOffset -= c.maxBody
+		c.clampScroll()
+	case "g":
+		c.follow = false
+		c.scrollOffset = 0
+	case "G":
+		c.follow = true
+		c.scrollOffset = c.buf.LineCount()
+		c.clampScroll()
 	}
 	return c, nil
 }

--- a/tui/notebook/verbatim_cell.go
+++ b/tui/notebook/verbatim_cell.go
@@ -101,22 +101,14 @@ func (c *VerbatimCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd) {
 		c.copyMsg = ""
 		return c, nil
 	}
-	if mode != ViewMode {
-		return c, nil
-	}
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
 		return c, nil
 	}
-	switch keyMsg.String() {
-	case "enter":
-		// Cell doesn't use Enter — signal release + advance.
-		return c, cellAdvance
-	case "tab":
-		c.cycle(+1)
-	case "shift+tab":
-		c.cycle(-1)
-	case "c":
+	// 'c' is processed regardless of mode — copying is a
+	// frictionless action available while just navigating
+	// between cells.
+	if keyMsg.String() == "c" {
 		v := c.variants[c.active]
 		strategy, ok := demokit.Copy(v.Content)
 		if ok {
@@ -130,6 +122,18 @@ func (c *VerbatimCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd) {
 			c.copyMsg = "(copy failed — no clipboard provider)"
 		}
 		return c, clearCopyMsgAfter(c.id)
+	}
+	if mode != ViewMode {
+		return c, nil
+	}
+	switch keyMsg.String() {
+	case "enter":
+		// Cell doesn't use Enter — signal release + advance.
+		return c, cellAdvance
+	case "tab":
+		c.cycle(+1)
+	case "shift+tab":
+		c.cycle(-1)
 	default:
 		s := keyMsg.String()
 		if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {


### PR DESCRIPTION
## What changes

Three notebook-mode regressions that combined to produce burst-at-end instead of incremental streaming output:

1. **Drip-drip**: the output cell was appended below the viewport (cursor stayed on the meta cell, so `ensureCursorVisible` never scrolled to the output cell). Chunks were being applied correctly to the buffer in `View()` — the cell just wasn't in the rendered window until the next step's cursor advance scrolled it on screen.
2. **First-N visible instead of latest-N**: once `OutputCell.buf.LineCount() > maxBody`, the cell rendered lines 1..maxBody not the last maxBody. No `tail -f` follow.
3. **Copy required ViewMode**: navigating between cells with up/down kept the model in `SelectMode`, where the cell's `c` handler was gated out. The user had to press `s`/`f` first to enter `ViewMode`, then `c`.

## Reviewer's guide

Read in this order:

1. [tui/notebook/model.go](https://github.com/panyam/demokit/pull/24/files#diff-4539f0f8b475b081a20031da9e7fe7a00b0962d4ac191e870a2c8a7230b06361) — start here. Two changes in `applyEvent`: `StepReadyToRun` sets cursor to the new output cell; `OutputChunk` re-runs `ensureCursorVisible` so the viewport follows the cell as it grows.
2. [tui/notebook/output_cell.go](https://github.com/panyam/demokit/pull/24/files#diff-87923db5f43a9507c76c9bf50af79a15583ed2ea20455ad4d8a003b860de2d1c) — adds `follow` state (default true), `OnAppend()` to advance scrollOffset when following, and routes `j/k/g/pgup/pgdown` → follow off; `G` → follow on. `c` now processed before the mode-gate.
3. [tui/notebook/verbatim_cell.go](https://github.com/panyam/demokit/pull/24/files#diff-fb48e958e12e136e1e1e569cf7e5d5041ef7da34381145dd8078a955d8c723f4) — `c` moved before mode-gate, same pattern.
4. [tui/notebook/apply_test.go](https://github.com/panyam/demokit/pull/24/files#diff-5bbad907921574b33884cc25a426d7c342a2f1c151c91c741dbe1e5bd46f926d) — `TestApplyStepReadyToRunMovesCursorToOutputCell`, `TestStepReadyToRunMakesOutputCellVisible`, `TestOutputChunkKeepsGrowingCellInViewport` cover the drip/follow fix at the model level.
5. [tui/notebook/cells_test.go](https://github.com/panyam/demokit/pull/24/files#diff-8e86210efe633f2eb5392302a6578779273274cfe5efb33619912ef303e0e6d4) — `TestOutputCellAutoFollowsOnAppend`, `TestOutputCellManualScrollDisablesFollow`, `TestOutputCellRenderShowsLatestLinesWhenFollowing`, `TestOutputCellCopiesInSelectMode`, `TestVerbatimCellCopiesInSelectMode` cover the cell-level behaviors.

## Decision log

- Considered moving stdout chunks out of the global event queue into per-cell `gocurrent.Queue[[]byte]` to sidestep the bug architecturally. Deferred — the bug here was viewport math, not pipeline. The per-cell-Queue architecture is still desirable for independent-stream support (`tail -f` + `top` in the same step) and is filed for a follow-up.
- Manual scroll keys (`j/k/g/pgup/pgdown`) disable `follow`; `G` re-enables it. This matches `less +F` and is the conventional "tail-follow" UX.

## Risk / blast radius

- Affects notebook-mode (`--mode=notebook`) only.
- Tests: 8 new test functions covering the three fixes; all 30+ notebook package tests pass.
- Be paranoid about: cursor-on-output-cell changes selection focus (output cell is now the highlighted cell during/after the step). User can still navigate up to re-focus the meta cell.

## Out of scope

- Per-cell streaming queues (architectural refactor) — separate follow-up.
- Auto-advance countdown bar in notebook mode (deadline isn't carried in events.WaitForAdvance yet) — separate follow-up.
