### PR TITLE
feat(notebook): phase-1 standalone package with header/note/verbatim cells

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/muesli/cancelreader v0.2.2
-	github.com/panyam/gocurrent v0.0.17
-	github.com/panyam/servicekit v0.0.20
+	github.com/panyam/gocurrent v0.1.1
+	github.com/panyam/servicekit v0.1.1
 	github.com/panyam/templar v0.1.0
 	github.com/yuin/goldmark v1.8.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -54,12 +54,12 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/panyam/gocurrent v0.0.17 h1:A2rXyrf6jeKAPwCYwurDNKhaK8UIxeU6wOu7HccC6Vk=
-github.com/panyam/gocurrent v0.0.17/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
+github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezegaU=
+github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=
 github.com/panyam/goutils v0.1.13/go.mod h1:vd3iFcv1DjaeV6h8tslIJh9d09RLndg8UYNSGROBrM4=
-github.com/panyam/servicekit v0.0.20 h1:TFPlbpL5Ff1+veL6tu6KxW++TjDZC5WugSCPTRjP018=
-github.com/panyam/servicekit v0.0.20/go.mod h1:zK2rZAMSladqAJIwn3sytRqs2RF3OtN9OeYFV2NZPAc=
+github.com/panyam/servicekit v0.1.1 h1:aIvVWjpIw2xBF5V4hpf7GY4RqinkY7u3OBbjQd8a1vU=
+github.com/panyam/servicekit v0.1.1/go.mod h1:kvuEgs3iJjwRyqGlKTkppwiFDpM69MPeihVi1m/B97o=
 github.com/panyam/templar v0.1.0 h1:yy4sqois9gvNhIy2xsNyRoI5r/qvz1tVY+YuxnmzbWY=
 github.com/panyam/templar v0.1.0/go.mod h1:Pqn7VhOod9MGZ0GqrwoHw16jFjiAxPgWXZBAFou1fZ0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/notebook/cell.go
+++ b/notebook/cell.go
@@ -1,0 +1,78 @@
+// Package notebook is a standalone cell-based TUI component built
+// on Bubble Tea. It has no dependency on demokit, events, or any
+// other consumer — callers drive it via Append/Update/Stream and
+// AwaitAdvance/AwaitInput. Bridges (e.g. demokit/notebookbridge)
+// translate domain events into these calls.
+//
+// Rendering is range-based: the viewport asks each cell for just
+// the row window it intends to display, never the full cell body.
+// That contract is what unlocks lazy materialization without
+// touching the viewport code.
+package notebook
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Mode is the notebook's mode state. Hierarchical and vim-ish:
+// SelectMode (cursor navigates cells) wraps FocusedMode (focused
+// cell owns keystrokes), which in turn has ViewMode (today's
+// interactive defaults) and EditMode (reserved). Esc pops up one
+// level.
+//
+// Encoded as a small interface rather than an enum so future modes
+// (Edit, Visual, Search) don't churn switch statements.
+type Mode interface {
+	Name() string
+}
+
+type selectMode struct{}
+type viewMode struct{}
+type editMode struct{}
+
+func (selectMode) Name() string { return "SELECT" }
+func (viewMode) Name() string   { return "VIEW" }
+func (editMode) Name() string   { return "EDIT" }
+
+// SelectMode is the default outermost mode — the cell cursor moves
+// between cells; the focused cell, if any, does not receive keys.
+var SelectMode Mode = selectMode{}
+
+// ViewMode is the inner interactive mode that owns keys when a cell
+// is focused.
+var ViewMode Mode = viewMode{}
+
+// EditMode is reserved for in-TUI authoring. Not wired into key
+// handling yet; declared so the Cell interface can already receive
+// it without a future signature change.
+var EditMode Mode = editMode{}
+
+// Cell is the unit the notebook viewport navigates and renders.
+// Implementations own their content.
+//
+// Rendering is range-based — viewport calls RenderRows(width, lo, hi)
+// for just the visible row window, never RenderAll.
+type Cell interface {
+	// ID returns a stable identifier unique within the notebook.
+	// Insert rejects duplicate IDs; Remove/Get/IndexOf lookup by ID.
+	ID() string
+
+	// HeightHint reports the row count the cell would occupy at the
+	// given width. Must be cheap & deterministic — the viewport
+	// invokes it once per visible-window calculation. Implementations
+	// should cache (width → height) and invalidate on width change.
+	HeightHint(width int) int
+
+	// RenderRows returns the row slice for the half-open range
+	// [startRow, endRow) at the given width. Cells with large bodies
+	// compute only the requested window.
+	RenderRows(width, startRow, endRow int, focused bool, mode Mode) []string
+
+	// Update receives Bubble Tea messages only when the cell is the
+	// focused cell. Returns the updated cell and an optional command.
+	Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd)
+
+	// StatusHint returns the right-side status text shown when this
+	// cell is focused.
+	StatusHint(mode Mode) string
+}

--- a/notebook/cells/box.go
+++ b/notebook/cells/box.go
@@ -1,0 +1,35 @@
+// Package cells provides the built-in widget library for the
+// notebook component — HeaderCell, NoteCell, VerbatimCell,
+// OutputCell, PromptCell. Each cell is a self-contained, styleable
+// widget that implements notebook.Cell. Consumers are free to
+// implement their own Cells alongside these.
+package cells
+
+import "charm.land/lipgloss/v2"
+
+// focusedBorder returns the lipgloss border shape to apply for a
+// cell at the given focus state. Both shapes occupy identical
+// character positions so HeightHint stays accurate when focus
+// moves between cells.
+//
+// Built-in cells use this; custom cells outside this package can
+// pick their own focus signaling. Not exported because it's a
+// convention of the built-in set, not a contract.
+func focusedBorder(focused bool) lipgloss.Border {
+	if focused {
+		return lipgloss.ThickBorder()
+	}
+	return lipgloss.RoundedBorder()
+}
+
+// maxBoxWidth returns the inner content width for a lipgloss
+// bordered box at the given outer width: 2 chars for vertical
+// borders + 2 chars horizontal padding = 4 reserved. Clamped to a
+// minimum so narrow terminals don't blow up wrap logic.
+func maxBoxWidth(outer int) int {
+	w := outer - 4
+	if w < 10 {
+		w = 10
+	}
+	return w
+}

--- a/notebook/cells/cells_test.go
+++ b/notebook/cells/cells_test.go
@@ -1,0 +1,245 @@
+package cells
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// allRows asks a cell for its full row list at the given width.
+func allRows(c notebook.Cell, width int, focused bool, mode notebook.Mode) []string {
+	return c.RenderRows(width, 0, c.HeightHint(width), focused, mode)
+}
+
+// captureClipboard returns a Clipboard that records the last
+// payload into *got. strategy is fixed to "test".
+func captureClipboard(got *string) notebook.Clipboard {
+	return func(s string) (string, bool) {
+		*got = s
+		return "test", true
+	}
+}
+
+// --- HeaderCell ---
+
+func TestHeaderCellRendersTitleAndBody(t *testing.T) {
+	c := NewHeader("h", "Authentication starts", "Set up the client.\nVerify creds load.")
+	joined := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	for _, want := range []string{"Authentication starts", "Set up the client."} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in render, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestHeaderCellFocusedChangesBorder(t *testing.T) {
+	a := strings.Join(allRows(NewHeader("h", "Hello", ""), 60, false, notebook.SelectMode), "\n")
+	b := strings.Join(allRows(NewHeader("h", "Hello", ""), 60, true, notebook.SelectMode), "\n")
+	if a == b {
+		t.Errorf("focused / unfocused renders identical:\n%s", a)
+	}
+}
+
+func TestHeaderCellRenderRowsClampsRange(t *testing.T) {
+	c := NewHeader("h", "T", "Body line one")
+	full := c.HeightHint(60)
+	if out := c.RenderRows(60, full-1, full+5, false, notebook.SelectMode); len(out) != 1 {
+		t.Errorf("over-end clamp: got %d rows, want 1", len(out))
+	}
+	if out := c.RenderRows(60, full+1, full+5, false, notebook.SelectMode); out != nil {
+		t.Errorf("past-end render should return nil, got %v", out)
+	}
+}
+
+func TestHeaderCellWidthInvalidatesCache(t *testing.T) {
+	c := NewHeader("h", "T", "this is a longer body that should wrap differently at different widths")
+	h1 := c.HeightHint(40)
+	h2 := c.HeightHint(120)
+	if h1 == h2 {
+		t.Errorf("HeightHint did not change with width: 40→%d, 120→%d", h1, h2)
+	}
+	if got := c.HeightHint(40); got != h1 {
+		t.Errorf("cache invalidation on width re-shrink: got %d, want %d", got, h1)
+	}
+}
+
+func TestHeaderCellStyleChangeInvalidatesCache(t *testing.T) {
+	c := NewHeader("h", "Hello", "")
+	a := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	c.Style = LightHeaderStyle()
+	b := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	if a == b {
+		t.Errorf("style change did not invalidate cache; render unchanged:\n%s", a)
+	}
+}
+
+func TestHeaderCellTitleMutationReflects(t *testing.T) {
+	c := NewHeader("h", "Original", "")
+	_ = strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	c.Title = "Replaced"
+	joined := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	if !strings.Contains(joined, "Replaced") {
+		t.Errorf("title mutation not reflected; got:\n%s", joined)
+	}
+}
+
+// --- NoteCell ---
+
+func TestNoteCellRendersTitleAndBody(t *testing.T) {
+	c := NewNote("n", "Heads up", "Important context here.")
+	joined := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	for _, want := range []string{"Heads up", "Important context here."} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in render, got:\n%s", want, joined)
+		}
+	}
+}
+
+func TestNoteCellCopyInViewModeUsesClipboard(t *testing.T) {
+	var got string
+	c := NewNote("n", "T", "the-payload")
+	c.SetClipboard(captureClipboard(&got))
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, notebook.ViewMode)
+	if got != "the-payload" {
+		t.Errorf("clipboard payload = %q, want %q", got, "the-payload")
+	}
+	if c.copyMsg == "" {
+		t.Error("expected copyMsg to be set after copy")
+	}
+}
+
+func TestNoteCellCopyInSelectModeAlsoWorks(t *testing.T) {
+	var got string
+	c := NewNote("n", "T", "another-payload")
+	c.SetClipboard(captureClipboard(&got))
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, notebook.SelectMode)
+	if got != "another-payload" {
+		t.Errorf("clipboard in SelectMode = %q, want %q", got, "another-payload")
+	}
+}
+
+func TestNoteCellNoClipboardFallback(t *testing.T) {
+	c := NewNote("n", "T", "x")
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, notebook.ViewMode)
+	if !strings.Contains(c.copyMsg, "copy failed") {
+		t.Errorf("expected fallback copyMsg, got %q", c.copyMsg)
+	}
+}
+
+func TestNoteCellSetClipboardNilUsesNoClipboard(t *testing.T) {
+	c := NewNote("n", "T", "x")
+	c.SetClipboard(nil)
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, notebook.ViewMode)
+	if !strings.Contains(c.copyMsg, "copy failed") {
+		t.Errorf("nil clipboard should fall back to NoClipboard; got %q", c.copyMsg)
+	}
+}
+
+// --- VerbatimCell ---
+
+func TestVerbatimCellDefaultActiveHonorsIsDefault(t *testing.T) {
+	c := NewVerbatim("v", "L", []Variant{
+		{Label: "a", Content: "A"},
+		{Label: "b", Content: "B", IsDefault: true},
+		{Label: "c", Content: "C"},
+	})
+	if c.Active != 1 {
+		t.Errorf("Active = %d, want 1 (the IsDefault variant)", c.Active)
+	}
+}
+
+func TestVerbatimCellTabCycles(t *testing.T) {
+	c := NewVerbatim("v", "L", []Variant{
+		{Label: "a", Content: "A"},
+		{Label: "b", Content: "B"},
+		{Label: "c", Content: "C"},
+	})
+	c.Update(tea.KeyMsg{Type: tea.KeyTab}, notebook.ViewMode)
+	if c.Active != 1 {
+		t.Errorf("after Tab: Active = %d, want 1", c.Active)
+	}
+	c.Update(tea.KeyMsg{Type: tea.KeyTab}, notebook.ViewMode)
+	c.Update(tea.KeyMsg{Type: tea.KeyTab}, notebook.ViewMode) // wrap
+	if c.Active != 0 {
+		t.Errorf("Tab wrap: Active = %d, want 0", c.Active)
+	}
+	c.Update(tea.KeyMsg{Type: tea.KeyShiftTab}, notebook.ViewMode)
+	if c.Active != 2 {
+		t.Errorf("Shift+Tab from 0: Active = %d, want 2", c.Active)
+	}
+}
+
+func TestVerbatimCellNumericJump(t *testing.T) {
+	c := NewVerbatim("v", "L", []Variant{
+		{Content: "A"}, {Content: "B"}, {Content: "C"},
+	})
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")}, notebook.ViewMode)
+	if c.Active != 1 {
+		t.Errorf("'2' → Active = %d, want 1", c.Active)
+	}
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("9")}, notebook.ViewMode)
+	if c.Active != 1 {
+		t.Errorf("out-of-range '9' should be no-op; Active = %d", c.Active)
+	}
+}
+
+func TestVerbatimCellCopyInSelectModeUsesActiveVariant(t *testing.T) {
+	var got string
+	c := NewVerbatim("v", "L", []Variant{
+		{Label: "curl", Content: "curl-payload"},
+		{Label: "python", Content: "python-payload"},
+	})
+	c.SetClipboard(captureClipboard(&got))
+	c.Update(tea.KeyMsg{Type: tea.KeyTab}, notebook.ViewMode) // switch to python
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, notebook.SelectMode)
+	if got != "python-payload" {
+		t.Errorf("clipboard = %q, want python-payload", got)
+	}
+}
+
+func TestVerbatimCellTabIgnoredInSelectMode(t *testing.T) {
+	c := NewVerbatim("v", "L", []Variant{{Content: "A"}, {Content: "B"}})
+	c.Update(tea.KeyMsg{Type: tea.KeyTab}, notebook.SelectMode)
+	if c.Active != 0 {
+		t.Errorf("Tab in SelectMode should be ignored; Active = %d", c.Active)
+	}
+}
+
+func TestVerbatimCellStatusHintAdaptsToCount(t *testing.T) {
+	single := NewVerbatim("v", "L", []Variant{{Content: "x"}})
+	if got := single.StatusHint(notebook.ViewMode); got != "c copy" {
+		t.Errorf("single-variant hint = %q, want %q", got, "c copy")
+	}
+	multi := NewVerbatim("v", "L", []Variant{{Content: "a"}, {Content: "b"}, {Content: "c"}})
+	if got := multi.StatusHint(notebook.ViewMode); !strings.Contains(got, "1-3 jump") {
+		t.Errorf("multi-variant hint missing 1-3 jump, got %q", got)
+	}
+}
+
+// --- Theme ---
+
+func TestDarkAndLightThemesDifferAtTheStyleLevel(t *testing.T) {
+	dark, light := DarkTheme(), LightTheme()
+	if dark.Header == light.Header {
+		t.Error("DarkTheme.Header == LightTheme.Header — theme is not mode-aware")
+	}
+	if dark.Note == light.Note {
+		t.Error("DarkTheme.Note == LightTheme.Note")
+	}
+	if dark.Verbatim == light.Verbatim {
+		t.Error("DarkTheme.Verbatim == LightTheme.Verbatim")
+	}
+}
+
+func TestApplyingThemeToCellChangesRender(t *testing.T) {
+	c := NewHeader("h", "Hello", "")
+	a := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	c.Style = LightTheme().Header
+	b := strings.Join(allRows(c, 60, false, notebook.SelectMode), "\n")
+	if a == b {
+		t.Error("applying LightTheme produced identical render")
+	}
+}

--- a/notebook/cells/header.go
+++ b/notebook/cells/header.go
@@ -1,0 +1,152 @@
+package cells
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// HeaderStyle is HeaderCell's per-cell styling. Concrete colors,
+// no mode flag — light/dark selection happens at the theme layer
+// (see DarkTheme / LightTheme in theme.go).
+type HeaderStyle struct {
+	BorderColor      color.Color
+	FocusBorderColor color.Color
+	TitleColor       color.Color
+	BodyColor        color.Color
+}
+
+// DarkHeaderStyle returns the dark-terminal defaults — currently
+// the package default.
+func DarkHeaderStyle() HeaderStyle {
+	return HeaderStyle{
+		BorderColor:      lipgloss.Color("#7D56F4"),
+		FocusBorderColor: lipgloss.Color("#FF6B6B"),
+		TitleColor:       lipgloss.Color("#FAFAFA"),
+		BodyColor:        lipgloss.Color("#CCCCCC"),
+	}
+}
+
+// LightHeaderStyle returns the light-terminal defaults.
+func LightHeaderStyle() HeaderStyle {
+	return HeaderStyle{
+		BorderColor:      lipgloss.Color("#5A3FCE"),
+		FocusBorderColor: lipgloss.Color("#D34545"),
+		TitleColor:       lipgloss.Color("#1A1A1A"),
+		BodyColor:        lipgloss.Color("#444444"),
+	}
+}
+
+// DefaultHeaderStyle returns the package default style — Dark.
+func DefaultHeaderStyle() HeaderStyle { return DarkHeaderStyle() }
+
+// HeaderCell renders a titled-text block — bold title plus a
+// wrapped body. Read-only. Typically used as the header of a
+// logical section (e.g. a demokit step header). Title and Body
+// are mutable; Update() can rewrite them in place via
+// notebook.Notebook.Update.
+type HeaderCell struct {
+	Title string
+	Body  string
+	Style HeaderStyle
+
+	id            string
+	cachedWidth   int
+	cachedFocused bool
+	cachedStyle   HeaderStyle
+	cachedTitle   string
+	cachedBody    string
+	cachedLines   []string
+	cachedHeight  int
+}
+
+// NewHeader builds a HeaderCell with DefaultHeaderStyle. Caller
+// can mutate Style afterward or assign a Theme-provided style.
+func NewHeader(id, title, body string) *HeaderCell {
+	return &HeaderCell{
+		id:    id,
+		Title: title,
+		Body:  body,
+		Style: DefaultHeaderStyle(),
+	}
+}
+
+// ID implements notebook.Cell.
+func (c *HeaderCell) ID() string { return c.id }
+
+// HeightHint implements notebook.Cell.
+func (c *HeaderCell) HeightHint(width int) int {
+	c.materialize(width, c.cachedFocused)
+	return c.cachedHeight
+}
+
+// RenderRows implements notebook.Cell.
+func (c *HeaderCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
+	c.materialize(width, focused)
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > c.cachedHeight {
+		endRow = c.cachedHeight
+	}
+	if startRow >= endRow {
+		return nil
+	}
+	out := make([]string, endRow-startRow)
+	copy(out, c.cachedLines[startRow:endRow])
+	return out
+}
+
+// Update implements notebook.Cell. HeaderCell is read-only.
+func (c *HeaderCell) Update(_ tea.Msg, _ notebook.Mode) (notebook.Cell, tea.Cmd) {
+	return c, nil
+}
+
+// StatusHint implements notebook.Cell.
+func (c *HeaderCell) StatusHint(_ notebook.Mode) string {
+	return "Space/Shift+Enter advance"
+}
+
+func (c *HeaderCell) materialize(width int, focused bool) {
+	if width <= 0 {
+		width = 80
+	}
+	if c.cachedWidth == width &&
+		c.cachedFocused == focused &&
+		c.cachedStyle == c.Style &&
+		c.cachedTitle == c.Title &&
+		c.cachedBody == c.Body &&
+		c.cachedLines != nil {
+		return
+	}
+	border := c.Style.BorderColor
+	if focused {
+		border = c.Style.FocusBorderColor
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(c.Style.TitleColor)
+	content := titleStyle.Render(c.Title)
+	if strings.TrimSpace(c.Body) != "" {
+		bodyStyle := lipgloss.NewStyle().Foreground(c.Style.BodyColor)
+		content = content + "\n\n" + bodyStyle.Render(c.Body)
+	}
+
+	boxStyle := lipgloss.NewStyle().
+		Border(focusedBorder(focused)).
+		BorderForeground(border).
+		Padding(0, 1).
+		Width(maxBoxWidth(width))
+
+	rendered := boxStyle.Render(content)
+	c.cachedWidth = width
+	c.cachedFocused = focused
+	c.cachedStyle = c.Style
+	c.cachedTitle = c.Title
+	c.cachedBody = c.Body
+	c.cachedLines = strings.Split(rendered, "\n")
+	c.cachedHeight = len(c.cachedLines)
+}

--- a/notebook/cells/note.go
+++ b/notebook/cells/note.go
@@ -1,0 +1,194 @@
+package cells
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// NoteStyle is NoteCell's per-cell styling. Concrete colors, no
+// mode flag — light/dark selection happens at the theme layer.
+type NoteStyle struct {
+	BorderColor      color.Color
+	FocusBorderColor color.Color
+	TitleColor       color.Color
+	BodyColor        color.Color
+}
+
+// DarkNoteStyle returns the dark-terminal defaults.
+func DarkNoteStyle() NoteStyle {
+	return NoteStyle{
+		BorderColor:      lipgloss.Color("#626262"),
+		FocusBorderColor: lipgloss.Color("#FF6B6B"),
+		TitleColor:       lipgloss.Color("#FAFAFA"),
+		BodyColor:        lipgloss.Color("#CCCCCC"),
+	}
+}
+
+// LightNoteStyle returns the light-terminal defaults.
+func LightNoteStyle() NoteStyle {
+	return NoteStyle{
+		BorderColor:      lipgloss.Color("#999999"),
+		FocusBorderColor: lipgloss.Color("#D34545"),
+		TitleColor:       lipgloss.Color("#1A1A1A"),
+		BodyColor:        lipgloss.Color("#444444"),
+	}
+}
+
+// DefaultNoteStyle returns the package default — Dark.
+func DefaultNoteStyle() NoteStyle { return DarkNoteStyle() }
+
+// NoteCell renders an italic-titled explanatory block — title
+// plus body of wrapped text. 'c' copies the body via the injected
+// Clipboard regardless of mode (frictionless copy from navigation).
+// Typically used for narrative breaks, hints, sidebars.
+type NoteCell struct {
+	Title string
+	Body  string
+	Style NoteStyle
+
+	id            string
+	clip          notebook.Clipboard
+	cachedWidth   int
+	cachedFocused bool
+	cachedStyle   NoteStyle
+	cachedTitle   string
+	cachedBody    string
+	cachedLines   []string
+	cachedHeight  int
+	copyMsg       string
+}
+
+// NewNote builds a NoteCell with DefaultNoteStyle. Clipboard
+// defaults to notebook.NoClipboard until SetClipboard is called.
+func NewNote(id, title, body string) *NoteCell {
+	return &NoteCell{
+		id:    id,
+		Title: title,
+		Body:  body,
+		Style: DefaultNoteStyle(),
+		clip:  notebook.NoClipboard,
+	}
+}
+
+// SetClipboard wires the clipboard the cell uses on 'c'. Pass nil
+// to disable copy (falls back to notebook.NoClipboard).
+func (c *NoteCell) SetClipboard(clip notebook.Clipboard) {
+	if clip == nil {
+		clip = notebook.NoClipboard
+	}
+	c.clip = clip
+}
+
+// ID implements notebook.Cell.
+func (c *NoteCell) ID() string { return c.id }
+
+// HeightHint implements notebook.Cell.
+func (c *NoteCell) HeightHint(width int) int {
+	c.materialize(width, c.cachedFocused)
+	h := c.cachedHeight
+	if c.copyMsg != "" {
+		h++
+	}
+	return h
+}
+
+// RenderRows implements notebook.Cell.
+func (c *NoteCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
+	c.materialize(width, focused)
+	total := c.cachedHeight
+	if c.copyMsg != "" {
+		total++
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > total {
+		endRow = total
+	}
+	if startRow >= endRow {
+		return nil
+	}
+	rows := make([]string, endRow-startRow)
+	for i := startRow; i < endRow; i++ {
+		if i < c.cachedHeight {
+			rows[i-startRow] = c.cachedLines[i]
+			continue
+		}
+		rows[i-startRow] = "  " + c.copyMsg
+	}
+	return rows
+}
+
+// Update implements notebook.Cell. 'c' copies regardless of mode;
+// Enter in ViewMode signals cell-advance.
+func (c *NoteCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+	if cm, ok := msg.(notebook.ClearCopyMsg); ok && cm.CellID == c.id {
+		c.copyMsg = ""
+		return c, nil
+	}
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return c, nil
+	}
+	if keyMsg.String() == "c" {
+		strategy, ok := c.clip(c.Body)
+		if ok {
+			c.copyMsg = "(copied via " + strategy + ")"
+		} else {
+			c.copyMsg = "(copy failed — no clipboard provider)"
+		}
+		return c, notebook.ClearCopyAfter(c.id)
+	}
+	if mode != notebook.ViewMode {
+		return c, nil
+	}
+	if keyMsg.String() == "enter" {
+		return c, notebook.CellAdvance
+	}
+	return c, nil
+}
+
+// StatusHint implements notebook.Cell.
+func (c *NoteCell) StatusHint(_ notebook.Mode) string { return "c copy" }
+
+func (c *NoteCell) materialize(width int, focused bool) {
+	if width <= 0 {
+		width = 80
+	}
+	if c.cachedWidth == width &&
+		c.cachedFocused == focused &&
+		c.cachedStyle == c.Style &&
+		c.cachedTitle == c.Title &&
+		c.cachedBody == c.Body &&
+		c.cachedLines != nil {
+		return
+	}
+	border := c.Style.BorderColor
+	if focused {
+		border = c.Style.FocusBorderColor
+	}
+
+	titleStyle := lipgloss.NewStyle().Italic(true).Foreground(c.Style.TitleColor)
+	bodyStyle := lipgloss.NewStyle().Foreground(c.Style.BodyColor)
+	content := titleStyle.Render(c.Title) + "\n\n" + bodyStyle.Render(c.Body)
+
+	boxStyle := lipgloss.NewStyle().
+		Border(focusedBorder(focused)).
+		BorderForeground(border).
+		Padding(0, 1).
+		Width(maxBoxWidth(width))
+
+	rendered := boxStyle.Render(content)
+	c.cachedWidth = width
+	c.cachedFocused = focused
+	c.cachedStyle = c.Style
+	c.cachedTitle = c.Title
+	c.cachedBody = c.Body
+	c.cachedLines = strings.Split(rendered, "\n")
+	c.cachedHeight = len(c.cachedLines)
+}

--- a/notebook/cells/theme.go
+++ b/notebook/cells/theme.go
@@ -1,0 +1,39 @@
+package cells
+
+// Theme bundles the built-in cell styles for batch application. A
+// theme is the appropriate layer for light/dark mode selection —
+// each individual cell style holds concrete colors with no mode
+// flag; the theme picks which set of styles to use.
+//
+// Theme is intentionally a value type with exported fields. The
+// notebook package itself doesn't depend on Theme — consumers can
+// use these styles directly without going through Theme, or
+// implement their own bundle. Theme is just a convenience.
+type Theme struct {
+	Header   HeaderStyle
+	Note     NoteStyle
+	Verbatim VerbatimStyle
+}
+
+// DarkTheme returns the dark-terminal styles for all built-in
+// cells.
+func DarkTheme() Theme {
+	return Theme{
+		Header:   DarkHeaderStyle(),
+		Note:     DarkNoteStyle(),
+		Verbatim: DarkVerbatimStyle(),
+	}
+}
+
+// LightTheme returns the light-terminal styles for all built-in
+// cells.
+func LightTheme() Theme {
+	return Theme{
+		Header:   LightHeaderStyle(),
+		Note:     LightNoteStyle(),
+		Verbatim: LightVerbatimStyle(),
+	}
+}
+
+// DefaultTheme returns the package default — Dark.
+func DefaultTheme() Theme { return DarkTheme() }

--- a/notebook/cells/verbatim.go
+++ b/notebook/cells/verbatim.go
@@ -1,0 +1,289 @@
+package cells
+
+import (
+	"fmt"
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// Variant is one labelled flavor of a VerbatimCell's content —
+// e.g. the same command rendered as `curl`, `python`, and `go`.
+// IsDefault marks the variant the cell highlights on construction
+// (first one wins if multiple are flagged). Lang is a
+// syntax-highlighting hint for future chroma adoption.
+type Variant struct {
+	Label     string
+	Lang      string
+	Content   string
+	IsDefault bool
+}
+
+// VerbatimStyle is VerbatimCell's per-cell styling.
+type VerbatimStyle struct {
+	BorderColor      color.Color
+	FocusBorderColor color.Color
+	LabelColor       color.Color
+	ContentColor     color.Color
+	ActiveTabColor   color.Color
+	InactiveTabColor color.Color
+}
+
+// DarkVerbatimStyle returns the dark-terminal defaults.
+func DarkVerbatimStyle() VerbatimStyle {
+	return VerbatimStyle{
+		BorderColor:      lipgloss.Color("#5BB1FF"),
+		FocusBorderColor: lipgloss.Color("#FF6B6B"),
+		LabelColor:       lipgloss.Color("#FAFAFA"),
+		ContentColor:     lipgloss.Color("#CCCCCC"),
+		ActiveTabColor:   lipgloss.Color("#FF6B6B"),
+		InactiveTabColor: lipgloss.Color("#888888"),
+	}
+}
+
+// LightVerbatimStyle returns the light-terminal defaults.
+func LightVerbatimStyle() VerbatimStyle {
+	return VerbatimStyle{
+		BorderColor:      lipgloss.Color("#2A77D6"),
+		FocusBorderColor: lipgloss.Color("#D34545"),
+		LabelColor:       lipgloss.Color("#1A1A1A"),
+		ContentColor:     lipgloss.Color("#333333"),
+		ActiveTabColor:   lipgloss.Color("#D34545"),
+		InactiveTabColor: lipgloss.Color("#777777"),
+	}
+}
+
+// DefaultVerbatimStyle returns the package default — Dark.
+func DefaultVerbatimStyle() VerbatimStyle { return DarkVerbatimStyle() }
+
+// VerbatimCell renders one verbatim block — possibly with multiple
+// variants shown as a tab strip + a single active variant's body.
+//
+//   - Tab / Shift+Tab cycle the active variant (wrap)
+//   - '1'..'9' jump directly (out-of-range ignored)
+//   - 'c' copies the active variant's Content via the injected Clipboard
+//
+// Single-variant blocks omit the tab strip but still respect 'c'.
+type VerbatimCell struct {
+	Label    string
+	Variants []Variant
+	Active   int
+	Style    VerbatimStyle
+
+	id            string
+	clip          notebook.Clipboard
+	cachedWidth   int
+	cachedFocused bool
+	cachedActive  int
+	cachedStyle   VerbatimStyle
+	cachedLabel   string
+	cachedLines   []string
+	cachedHeight  int
+	copyMsg       string
+}
+
+// NewVerbatim builds a VerbatimCell with DefaultVerbatimStyle.
+// Active variant defaults to whichever carries IsDefault (first
+// wins), or 0 if none does. Clipboard defaults to
+// notebook.NoClipboard.
+func NewVerbatim(id, label string, variants []Variant) *VerbatimCell {
+	active := 0
+	for i, v := range variants {
+		if v.IsDefault {
+			active = i
+			break
+		}
+	}
+	return &VerbatimCell{
+		id:       id,
+		Label:    label,
+		Variants: variants,
+		Active:   active,
+		Style:    DefaultVerbatimStyle(),
+		clip:     notebook.NoClipboard,
+	}
+}
+
+// SetClipboard wires the clipboard the cell uses on 'c'.
+func (c *VerbatimCell) SetClipboard(clip notebook.Clipboard) {
+	if clip == nil {
+		clip = notebook.NoClipboard
+	}
+	c.clip = clip
+}
+
+// ID implements notebook.Cell.
+func (c *VerbatimCell) ID() string { return c.id }
+
+// HeightHint implements notebook.Cell.
+func (c *VerbatimCell) HeightHint(width int) int {
+	c.materialize(width, c.cachedFocused)
+	h := c.cachedHeight
+	if c.copyMsg != "" {
+		h++
+	}
+	return h
+}
+
+// RenderRows implements notebook.Cell.
+func (c *VerbatimCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
+	c.materialize(width, focused)
+	total := c.cachedHeight
+	if c.copyMsg != "" {
+		total++
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > total {
+		endRow = total
+	}
+	if startRow >= endRow {
+		return nil
+	}
+	rows := make([]string, endRow-startRow)
+	for i := startRow; i < endRow; i++ {
+		if i < c.cachedHeight {
+			rows[i-startRow] = c.cachedLines[i]
+			continue
+		}
+		rows[i-startRow] = "  " + c.copyMsg
+	}
+	return rows
+}
+
+// Update implements notebook.Cell. 'c' copies regardless of mode;
+// other keys require ViewMode.
+func (c *VerbatimCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+	if cm, ok := msg.(notebook.ClearCopyMsg); ok && cm.CellID == c.id {
+		c.copyMsg = ""
+		return c, nil
+	}
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return c, nil
+	}
+	if keyMsg.String() == "c" {
+		v := c.Variants[c.Active]
+		strategy, ok := c.clip(v.Content)
+		if ok {
+			label := v.Label
+			if label == "" {
+				c.copyMsg = "(copied via " + strategy + ")"
+			} else {
+				c.copyMsg = "(copied " + label + " via " + strategy + ")"
+			}
+		} else {
+			c.copyMsg = "(copy failed — no clipboard provider)"
+		}
+		return c, notebook.ClearCopyAfter(c.id)
+	}
+	if mode != notebook.ViewMode {
+		return c, nil
+	}
+	switch keyMsg.String() {
+	case "enter":
+		return c, notebook.CellAdvance
+	case "tab":
+		c.cycle(+1)
+	case "shift+tab":
+		c.cycle(-1)
+	default:
+		s := keyMsg.String()
+		if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
+			idx := int(s[0] - '1')
+			if idx < len(c.Variants) {
+				c.Active = idx
+				c.cachedLines = nil
+			}
+		}
+	}
+	return c, nil
+}
+
+// StatusHint implements notebook.Cell.
+func (c *VerbatimCell) StatusHint(_ notebook.Mode) string {
+	if len(c.Variants) <= 1 {
+		return "c copy"
+	}
+	return fmt.Sprintf("Tab cycle · 1-%d jump · c copy", len(c.Variants))
+}
+
+func (c *VerbatimCell) cycle(delta int) {
+	n := len(c.Variants)
+	if n == 0 {
+		return
+	}
+	c.Active = (c.Active + delta + n) % n
+	c.cachedLines = nil
+}
+
+func (c *VerbatimCell) materialize(width int, focused bool) {
+	if width <= 0 {
+		width = 80
+	}
+	if c.cachedWidth == width &&
+		c.cachedFocused == focused &&
+		c.cachedActive == c.Active &&
+		c.cachedStyle == c.Style &&
+		c.cachedLabel == c.Label &&
+		c.cachedLines != nil {
+		return
+	}
+	border := c.Style.BorderColor
+	if focused {
+		border = c.Style.FocusBorderColor
+	}
+
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(c.Style.LabelColor)
+	label := c.Label
+	if label == "" {
+		label = "verbatim"
+	}
+	parts := []string{labelStyle.Render(label)}
+
+	if len(c.Variants) > 1 {
+		parts = append(parts, c.renderTabs())
+	}
+
+	codeStyle := lipgloss.NewStyle().Foreground(c.Style.ContentColor)
+	parts = append(parts, codeStyle.Render(c.Variants[c.Active].Content))
+
+	content := strings.Join(parts, "\n\n")
+	boxStyle := lipgloss.NewStyle().
+		Border(focusedBorder(focused)).
+		BorderForeground(border).
+		Padding(0, 1).
+		Width(maxBoxWidth(width))
+	rendered := boxStyle.Render(content)
+
+	c.cachedWidth = width
+	c.cachedFocused = focused
+	c.cachedActive = c.Active
+	c.cachedStyle = c.Style
+	c.cachedLabel = c.Label
+	c.cachedLines = strings.Split(rendered, "\n")
+	c.cachedHeight = len(c.cachedLines)
+}
+
+func (c *VerbatimCell) renderTabs() string {
+	active := lipgloss.NewStyle().Bold(true).Foreground(c.Style.ActiveTabColor)
+	dim := lipgloss.NewStyle().Foreground(c.Style.InactiveTabColor)
+	var out []string
+	for i, v := range c.Variants {
+		name := v.Label
+		if name == "" {
+			name = fmt.Sprintf("#%d", i+1)
+		}
+		if i == c.Active {
+			out = append(out, active.Render("["+name+"]"))
+		} else {
+			out = append(out, dim.Render(" "+name+" "))
+		}
+	}
+	return strings.Join(out, " ")
+}

--- a/notebook/clipboard.go
+++ b/notebook/clipboard.go
@@ -1,0 +1,16 @@
+package notebook
+
+// Clipboard is the injection point cells call when the user presses
+// 'c'. Returns (strategy, ok) — strategy is a human-readable label
+// like "OSC52" or "pbcopy" that the cell displays in its toast;
+// ok is whether the write succeeded.
+//
+// Decoupled from any specific clipboard implementation so the
+// notebook package depends only on stdlib + charm. Callers wire
+// their own implementation via WithClipboard or Cell.SetClipboard.
+type Clipboard func(content string) (strategy string, ok bool)
+
+// NoClipboard always fails. Used as the default when no clipboard
+// is injected — cells render a "(copy failed — no clipboard
+// provider)" toast.
+var NoClipboard Clipboard = func(string) (string, bool) { return "", false }

--- a/notebook/messages.go
+++ b/notebook/messages.go
@@ -1,0 +1,47 @@
+package notebook
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ClearCopyMsg is the deferred message that tells a cell to drop
+// its transient "(copied …)" status line. Built-in cells listen
+// for it; the notebook routes it back to the originating cell by
+// CellID.
+//
+// Exported so cells in subpackages (notebook/cells) can both emit
+// it via ClearCopyAfter and pattern-match against it in their
+// Update implementations.
+type ClearCopyMsg struct {
+	CellID string
+}
+
+// CopyToastDuration is how long the per-cell "(copied …)" line
+// stays on screen before fading. Exposed so consumers building
+// custom cells can match the built-in cadence.
+const CopyToastDuration = 1200 * time.Millisecond
+
+// ClearCopyAfter returns a tea.Cmd that emits a ClearCopyMsg for
+// cellID after CopyToastDuration. Cells call this from Update
+// after a successful copy so the toast clears itself.
+func ClearCopyAfter(cellID string) tea.Cmd {
+	return tea.Tick(CopyToastDuration, func(_ time.Time) tea.Msg {
+		return ClearCopyMsg{CellID: cellID}
+	})
+}
+
+// CellAdvanceMsg signals that a focused cell has finished its
+// interactive work — the notebook should return to SelectMode AND
+// advance to the next cell.
+//
+// Cells that don't use Enter for their own purposes (Verbatim,
+// Output, etc.) emit this on Enter so the default UX matches
+// SelectMode Enter. PromptCell emits it on successful submit.
+type CellAdvanceMsg struct{}
+
+// CellAdvance is the tea.Cmd that emits CellAdvanceMsg. Use it as
+// the second return value from Cell.Update when a cell wants to
+// hand focus back to the notebook.
+func CellAdvance() tea.Msg { return CellAdvanceMsg{} }


### PR DESCRIPTION
Phase 1 of 5 for issue 25 — decoupling the notebook into a standalone testable component. Pure addition; no existing code touched. The current `tui/notebook/` keeps running until phase 5.

## What changes

New `notebook/` package + `notebook/cells/` subpackage. Layout B (runtime vs cells split), per-cell styles, no demokit imports.

```
notebook/                       runtime + interface
├── cell.go                     Cell interface + Mode (SelectMode/ViewMode/EditMode)
├── clipboard.go                Clipboard type + NoClipboard
└── messages.go                 ClearCopyMsg, CellAdvanceMsg, helpers (exported)

notebook/cells/                 widget library
├── box.go                      internal focusedBorder + maxBoxWidth
├── header.go                   HeaderCell + HeaderStyle + Dark/Light/Default factories
├── note.go                     NoteCell + NoteStyle (italic-titled, copyable)
├── verbatim.go                 VerbatimCell + VerbatimStyle + Variant
├── theme.go                    Theme aggregator + DarkTheme/LightTheme/DefaultTheme
└── cells_test.go               17 tests
```

## Reviewer's guide

Read in this order:

1. [notebook/cell.go](https://github.com/panyam/demokit/pull/26/files#diff-58467d95ab70136413e1529e553324e2f46e59792ef2e7996d8c54e356b2aee5) — start here. The Cell interface and Mode types define the boundary.
2. [notebook/messages.go](https://github.com/panyam/demokit/pull/26/files#diff-8a36622340a8c34ca99f6e98a52154e05f5edb002c4231ceecf2982c3c0c1af1) — exported message helpers (cells in subpackages emit/receive these).
3. [notebook/cells/header.go](https://github.com/panyam/demokit/pull/26/files#diff-c80c7ee1a79087f57ca6b7361fbf5aa4a1a253f1719a1621af145366d8ea5e93) — the canonical built-in cell. Note how Style is a struct field, materialize() compares cached vs current, light/dark live in factory functions not on the Style struct.
4. [notebook/cells/theme.go](https://github.com/panyam/demokit/pull/26/files#diff-c659f1ef97b4fa3eb73bd24f1160b38ce284c0d1b7c549af94aaf38918e77978) — Theme is an opt-in convenience that bundles built-in styles. Consumers can use it OR set styles per cell.
5. [notebook/cells/cells_test.go](https://github.com/panyam/demokit/pull/26/files#diff-95135734342bfe76127fd25438eb64028e538bf87ef750920569f908de725fc6) — exercises rendering, focus, copy in both modes, style mutation, theme switching. No demokit imports.

The other cell files (`note.go`, `verbatim.go`) follow the same pattern as `header.go`.

## Decision log

- **Layout B (notebook + notebook/cells split)** chosen over a flat layout. Forces import-graph enforcement of the boundary — cells can't accidentally reach into the runtime, runtime can't import cells. Cycles become compile errors.
- **Per-cell Style structs**, not a shared Palette. The old Palette knew the name of every cell type (MetaBorder, SectionBorder, etc.) — adding a new cell forced a Palette field. Now adding a new cell adds its own Style struct in its own file. Theme is a separate aggregator for "set them all consistently."
- **Light/dark lives at the theme layer**, not on Style structs. Each Style holds concrete colors with no mode flag; `DarkHeaderStyle()` and `LightHeaderStyle()` are different factory functions returning different concrete values. `DarkTheme()` / `LightTheme()` bundle one set or the other.
- **Style/Title/Body fields exported**, ID kept private with `ID()` method. Consumers can mutate cell state directly (notebook.Update will pass mutator funcs in phase 3); materialize() compares cached vs current fields to invalidate the render cache. ID is immutable post-construction so the private+method shape fits.
- **`focusedBorder` / `maxBoxWidth` kept unexported in cells/**. They're conventions of the built-in cells, not a contract. Custom cells outside this package pick their own focus signaling.
- **MetaCell → HeaderCell**, **SectionCell → NoteCell**. The old names ("meta" for step intro, "section" for narrative break) only made sense in demokit's vocabulary. New names describe the visual role (bold-titled vs italic-titled). The bridge in phase 4 translates events.StepStart → HeaderCell and events.Section → NoteCell.

## Risk / blast radius

- Pure addition — no existing files modified. `tui/notebook/` is unchanged.
- `go test ./...` passes (notebook + cells + tui + tui/notebook + web all green).
- Be paranoid about: the materialize() cache-invalidation logic depends on Style being comparable with `==`. If Style ever holds an uncomparable type (slice, map) it'd panic — tests pin this down for now.

## Out of scope

- OutputCell + PromptCell — phase 2 (they need clipboard injection and Input interface decoupling)
- Notebook struct + Run / Append / Stream / AwaitX — phase 3
- Bridge that wires demokit events to the new notebook — phase 4
- Deleting tui/notebook/ + switching examples — phase 5
