### PR TITLE
feat(notebook): phase-3b Stream + AwaitAdvance + AwaitInput + concurrency tests

### DIFF
--- a/notebook/cells/output.go
+++ b/notebook/cells/output.go
@@ -106,17 +106,6 @@ func (c *OutputCell) SetClipboard(clip notebook.Clipboard) {
 // MarkDone flips the box state accent from "·live" to "·end".
 func (c *OutputCell) MarkDone() { c.done = true }
 
-// OnAppend is called after a chunk lands in the cell's buffer.
-// While follow is true, advances scrollOffset so the last maxBody
-// lines stay visible.
-func (c *OutputCell) OnAppend() {
-	if !c.follow {
-		return
-	}
-	c.scrollOffset = c.buf.LineCount() - c.maxBody
-	c.clampScroll()
-}
-
 // ID implements notebook.Cell.
 func (c *OutputCell) ID() string { return c.id }
 
@@ -266,9 +255,19 @@ func (c *OutputCell) StatusHint(_ notebook.Mode) string {
 	return "c copy"
 }
 
-// clampScroll pins scrollOffset to [0, max(0, total-maxBody)].
+// clampScroll updates scrollOffset for the current LineCount. When
+// follow is true, it sticks scrollOffset to the end of the buffer
+// so the latest maxBody lines stay visible (the "tail -f" behavior).
+// When follow is false, it just clamps the manually-set offset.
+//
+// Called at the top of RenderRows so every frame reflects the
+// current buffer state without an external "append happened"
+// hook — Stream writes to the buffer, the next render picks it up.
 func (c *OutputCell) clampScroll() {
 	total := c.buf.LineCount()
+	if c.follow {
+		c.scrollOffset = total - c.maxBody
+	}
 	hi := max(total-c.maxBody, 0)
 	if c.scrollOffset > hi {
 		c.scrollOffset = hi

--- a/notebook/cells/output_test.go
+++ b/notebook/cells/output_test.go
@@ -9,11 +9,20 @@ import (
 	"github.com/panyam/demokit/notebook"
 )
 
+// feed writes lines to the cell's buffer. The cell's render-time
+// clampScroll handles follow-mode scrolling — no explicit "append
+// happened" hook is needed.
 func feed(c *OutputCell, lines ...string) {
 	for _, l := range lines {
 		c.Buffer().Append([]byte(l + "\n"))
-		c.OnAppend()
 	}
+}
+
+// render triggers a render so clampScroll runs and (when
+// follow is on) scrollOffset settles to the buffer end. Tests
+// that inspect scrollOffset directly call this before asserting.
+func render(c *OutputCell) {
+	_ = c.RenderRows(80, 0, c.HeightHint(80), false, notebook.ViewMode)
 }
 
 func TestOutputCellRendersBufferContent(t *testing.T) {
@@ -46,19 +55,19 @@ func TestOutputCellHeightCappedByMaxBody(t *testing.T) {
 	}
 }
 
-func TestOutputCellAutoFollowsOnAppend(t *testing.T) {
+func TestOutputCellFollowsBufferEndOnRender(t *testing.T) {
 	c := NewOutput("o", 3)
 	c.Buffer().Append([]byte("a\n"))
-	c.OnAppend()
+	render(c)
 	if c.scrollOffset != 0 {
 		t.Errorf("1 line < maxBody: scrollOffset = %d, want 0", c.scrollOffset)
 	}
 	for i := 0; i < 10; i++ {
 		c.Buffer().Append([]byte("x\n"))
 	}
-	c.OnAppend()
+	render(c)
 	if want := 11 - 3; c.scrollOffset != want {
-		t.Errorf("auto-follow scrollOffset = %d, want %d", c.scrollOffset, want)
+		t.Errorf("follow scrollOffset = %d, want %d", c.scrollOffset, want)
 	}
 }
 
@@ -67,7 +76,7 @@ func TestOutputCellManualScrollDisablesFollow(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		c.Buffer().Append([]byte("x\n"))
 	}
-	c.OnAppend()
+	render(c) // initial follow-driven scroll
 	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}, notebook.ViewMode)
 	if c.follow {
 		t.Error("follow should be off after k")
@@ -76,13 +85,17 @@ func TestOutputCellManualScrollDisablesFollow(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		c.Buffer().Append([]byte("y\n"))
 	}
-	c.OnAppend()
+	render(c)
 	if c.scrollOffset != frozen {
-		t.Errorf("follow off: OnAppend moved scrollOffset %d→%d", frozen, c.scrollOffset)
+		t.Errorf("follow off: render advanced scrollOffset %d→%d", frozen, c.scrollOffset)
 	}
 	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")}, notebook.ViewMode)
 	if !c.follow {
 		t.Error("follow should be on after G")
+	}
+	render(c)
+	if want := c.buf.LineCount() - 3; c.scrollOffset != want {
+		t.Errorf("after G + render: scrollOffset = %d, want %d", c.scrollOffset, want)
 	}
 }
 

--- a/notebook/concurrent_test.go
+++ b/notebook/concurrent_test.go
@@ -1,0 +1,378 @@
+package notebook
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- streamCell: a Cell with an OutputBuffer for Stream tests ---
+
+type streamCell struct {
+	id  string
+	buf *OutputBuffer
+}
+
+func newStreamCell(id string) *streamCell {
+	return &streamCell{id: id, buf: NewOutputBuffer()}
+}
+
+func (c *streamCell) ID() string                { return c.id }
+func (c *streamCell) HeightHint(int) int        { return c.buf.LineCount() + 2 }
+func (c *streamCell) StatusHint(Mode) string    { return "" }
+func (c *streamCell) Buffer() *OutputBuffer     { return c.buf }
+func (c *streamCell) Update(tea.Msg, Mode) (Cell, tea.Cmd) {
+	return c, nil
+}
+
+func (c *streamCell) RenderRows(width, startRow, endRow int, _ bool, _ Mode) []string {
+	rows := []string{"--- " + c.id + " ---"}
+	rows = append(rows, c.buf.AllLines()...)
+	rows = append(rows, "--- end ---")
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > len(rows) {
+		endRow = len(rows)
+	}
+	if startRow >= endRow {
+		return nil
+	}
+	return rows[startRow:endRow]
+}
+
+// waitForInputWaiter spins until the rendezvous has at least one
+// registered input waiter (for the given cell id), so the test
+// can safely Send a resolution without racing the await goroutine.
+func waitForInputWaiter(t *testing.T, nb *Notebook, id CellID) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		nb.rdv.mu.Lock()
+		_, ok := nb.rdv.inputs[id]
+		nb.rdv.mu.Unlock()
+		if ok {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("no input waiter for %q after 200ms", id)
+}
+
+// waitForAdvanceWaiter spins until the rendezvous has at least
+// one registered advance waiter.
+func waitForAdvanceWaiter(t *testing.T, nb *Notebook) {
+	t.Helper()
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		nb.rdv.mu.Lock()
+		n := len(nb.rdv.advances)
+		nb.rdv.mu.Unlock()
+		if n > 0 {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("no advance waiter registered after 200ms")
+}
+
+// --- Stream ---
+
+func TestStreamFillsCellIncrementally(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(80, 20))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	c := newStreamCell("out")
+	nb.Append(c)
+	w := nb.Stream("out")
+	for i := 0; i < 5; i++ {
+		fmt.Fprintf(w, "line %d\n", i)
+	}
+	if got := c.buf.LineCount(); got != 5 {
+		t.Errorf("LineCount = %d, want 5", got)
+	}
+	// Snapshot should reflect the streamed content.
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "line 4") {
+		t.Errorf("Snapshot missing latest line:\n%s", snap)
+	}
+}
+
+func TestStreamAfterRemoveDiscards(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(80, 20))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	c := newStreamCell("out")
+	nb.Append(c)
+	w := nb.Stream("out")
+	nb.Remove("out")
+	// After removal, the next Stream("out") returns Discard.
+	if w2 := nb.Stream("out"); w2 != io.Discard {
+		t.Errorf("Stream after Remove = %T, want io.Discard", w2)
+	}
+	// The previously-returned writer still works on the buffer
+	// (the buffer outlives the cell's presence in the store);
+	// drops are silent in that the buffer is no longer rendered.
+	fmt.Fprintln(w, "post-remove")
+	if c.buf.LineCount() != 1 {
+		t.Errorf("buffer should have 1 line; got %d", c.buf.LineCount())
+	}
+}
+
+func TestStreamForMissingCellReturnsDiscard(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+	if w := nb.Stream("missing"); w != io.Discard {
+		t.Errorf("Stream(missing) = %T, want io.Discard", w)
+	}
+}
+
+// --- AwaitAdvance / AwaitInput ---
+
+func TestPromptResolvesWithSubmittedAnswer(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	nb.Append(newStreamCell("p")) // any cell; AwaitInputBy doesn't care
+	done := make(chan InputResponse, 1)
+	go func() { done <- nb.AwaitInputBy("p") }()
+	waitForInputWaiter(t, nb, "p")
+
+	nb.program.Send(PromptSubmittedMsg{
+		CellID:  "p",
+		Answers: map[string]any{"name": "alice"},
+	})
+	select {
+	case resp := <-done:
+		if resp.Source != "user-submitted" {
+			t.Errorf("Source = %q, want user-submitted", resp.Source)
+		}
+		if resp.Answers["name"] != "alice" {
+			t.Errorf("answer = %v, want alice", resp.Answers["name"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitInputBy did not return within 1s")
+	}
+}
+
+func TestAwaitAdvanceResolvesOnEnter(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	done := make(chan AdvanceResponse, 1)
+	go func() { done <- nb.AwaitAdvance(time.Time{}) }()
+	waitForAdvanceWaiter(t, nb)
+
+	nb.program.Send(tea.KeyMsg{Type: tea.KeyEnter})
+	select {
+	case resp := <-done:
+		if resp.Source != "user-enter" {
+			t.Errorf("Source = %q, want user-enter", resp.Source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitAdvance did not return within 1s")
+	}
+}
+
+func TestAwaitAdvanceDeadlineFiresAsAutoAdvance(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	resp := nb.AwaitAdvance(time.Now().Add(30 * time.Millisecond))
+	if resp.Source != "auto-advance" {
+		t.Errorf("Source = %q, want auto-advance", resp.Source)
+	}
+}
+
+func TestAwaitInputCancelledOnRemove(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	nb.Append(newStreamCell("p"))
+	done := make(chan InputResponse, 1)
+	go func() { done <- nb.AwaitInputBy("p") }()
+	waitForInputWaiter(t, nb, "p")
+
+	nb.Remove("p")
+	select {
+	case resp := <-done:
+		if resp.Source != "cancelled" {
+			t.Errorf("Source = %q, want cancelled", resp.Source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitInputBy did not unblock after Remove")
+	}
+}
+
+// --- Stop unblocks awaits ---
+
+func TestStopUnblocksAwaitAdvance(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+
+	done := make(chan AdvanceResponse, 1)
+	go func() { done <- nb.AwaitAdvance(time.Time{}) }()
+	waitForAdvanceWaiter(t, nb)
+
+	nb.Stop()
+	select {
+	case resp := <-done:
+		if resp.Source != "cancelled" {
+			t.Errorf("Source = %q, want cancelled", resp.Source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitAdvance did not unblock after Stop")
+	}
+}
+
+func TestStopUnblocksAwaitInput(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+
+	nb.Append(newStreamCell("p"))
+	done := make(chan InputResponse, 1)
+	go func() { done <- nb.AwaitInputBy("p") }()
+	waitForInputWaiter(t, nb, "p")
+
+	nb.Stop()
+	select {
+	case resp := <-done:
+		if resp.Source != "cancelled" {
+			t.Errorf("Source = %q, want cancelled", resp.Source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AwaitInputBy did not unblock after Stop")
+	}
+}
+
+// --- Concurrent writers ---
+
+func TestConcurrentStreams(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(80, 20))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	const cells = 4
+	const linesPerCell = 200
+	for i := 0; i < cells; i++ {
+		nb.Append(newStreamCell(fmt.Sprintf("c%d", i)))
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < cells; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			w := nb.Stream(fmt.Sprintf("c%d", idx))
+			for j := 0; j < linesPerCell; j++ {
+				fmt.Fprintf(w, "c%d line %d\n", idx, j)
+			}
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < cells; i++ {
+		c, _ := nb.Get(fmt.Sprintf("c%d", i))
+		if got := c.(*streamCell).buf.LineCount(); got != linesPerCell {
+			t.Errorf("c%d LineCount = %d, want %d", i, got, linesPerCell)
+		}
+	}
+}
+
+func TestAppendDuringStream(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(80, 20))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	c := newStreamCell("stream")
+	nb.Append(c)
+	w := nb.Stream("stream")
+
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		for i := 0; i < 500; i++ {
+			fmt.Fprintf(w, "x%d\n", i)
+		}
+	}()
+
+	// Append many cells while the stream runs.
+	for i := 0; i < 100; i++ {
+		if _, err := nb.Append(newStreamCell(fmt.Sprintf("a%d", i))); err != nil {
+			t.Fatalf("Append a%d error: %v", i, err)
+		}
+	}
+	<-streamDone
+
+	if got := c.buf.LineCount(); got != 500 {
+		t.Errorf("stream LineCount = %d, want 500", got)
+	}
+	if got := nb.Len(); got != 101 {
+		t.Errorf("Len = %d, want 101 (1 stream + 100 appended)", got)
+	}
+}
+
+func TestStreamLineCountUnderLoad(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(80, 20))
+	go nb.Run()
+	t.Cleanup(nb.Stop)
+
+	c := newStreamCell("hi")
+	nb.Append(c)
+	w := nb.Stream("hi")
+
+	const N = 5000
+	var n atomic.Int64
+	var wg sync.WaitGroup
+	for g := 0; g < 5; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < N/5; i++ {
+				fmt.Fprintln(w, "x")
+				n.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := c.buf.LineCount(), int(n.Load()); got != want {
+		t.Errorf("LineCount = %d, want %d (no lost lines)", got, want)
+	}
+}
+
+// --- Buffer io.Writer concurrency ---
+
+func TestOutputBufferConcurrentWrites(t *testing.T) {
+	buf := NewOutputBuffer()
+	var wg sync.WaitGroup
+	const writers = 8
+	const linesPer = 250
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < linesPer; i++ {
+				var b bytes.Buffer
+				fmt.Fprintf(&b, "w%d-%d\n", id, i)
+				buf.Append(b.Bytes())
+			}
+		}(w)
+	}
+	wg.Wait()
+	if got, want := buf.LineCount(), writers*linesPer; got != want {
+		t.Errorf("LineCount = %d, want %d", got, want)
+	}
+}

--- a/notebook/crud.go
+++ b/notebook/crud.go
@@ -32,8 +32,16 @@ func (nb *Notebook) Update(id CellID, fn func(Cell) Cell) bool {
 // up; removing the focused cell leaves the cursor on the next
 // cell down (or the new last cell if the removed cell was the
 // end).
+//
+// If there's a pending AwaitInputBy on the removed cell, it
+// resolves with Source: "cancelled" so the caller goroutine
+// doesn't block forever.
 func (nb *Notebook) Remove(id CellID) bool {
-	return nb.store.remove(id)
+	ok := nb.store.remove(id)
+	if ok {
+		nb.rdv.resolveInput(id, nil, "cancelled")
+	}
+	return ok
 }
 
 // Get returns the cell with the given ID. The bool reports

--- a/notebook/model.go
+++ b/notebook/model.go
@@ -32,6 +32,7 @@ type snapshotMsg struct {
 // BT-goroutine-local viewport, size, and mode.
 type model struct {
 	store          *store
+	rdv            *rendezvous
 	viewportOffset int
 	width          int
 	height         int
@@ -39,9 +40,10 @@ type model struct {
 	ready          chan struct{}
 }
 
-func newModel(s *store, ready chan struct{}, width, height int) model {
+func newModel(s *store, rdv *rendezvous, ready chan struct{}, width, height int) model {
 	return model{
 		store:  s,
+		rdv:    rdv,
 		mode:   SelectMode,
 		width:  width,
 		height: height,
@@ -80,6 +82,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.store.moveCursor(+1)
 		m.ensureCursorVisible()
 		return m, nil
+	case PromptSubmittedMsg:
+		// The PromptCell already updated itself; the model just
+		// resolves the pending AwaitInputBy and moves on like any
+		// other "this cell is done" event.
+		if m.rdv != nil {
+			m.rdv.resolveInput(msg.CellID, msg.Answers, "user-submitted")
+		}
+		m.mode = SelectMode
+		m.store.moveCursor(+1)
+		m.ensureCursorVisible()
+		return m, nil
 	case ClearCopyMsg:
 		return m, m.routeToCell(msg.CellID, msg)
 	case tea.KeyMsg:
@@ -110,6 +123,13 @@ func (m model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "s", "f":
 			if m.store.count() > 0 {
 				m.mode = ViewMode
+			}
+			return m, nil
+		case "enter", " ":
+			// Resolve a pending AwaitAdvance, if any. If no
+			// advance is pending, Enter is a no-op in SelectMode.
+			if m.rdv != nil {
+				m.rdv.resolveAdvance("user-enter")
 			}
 			return m, nil
 		}

--- a/notebook/notebook.go
+++ b/notebook/notebook.go
@@ -3,7 +3,9 @@ package notebook
 import (
 	"io"
 	"os"
+	"strconv"
 	"sync"
+	"sync/atomic"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -22,11 +24,16 @@ import (
 // waits for the program loop to be live (signalled via the ready
 // channel) before issuing its Send.
 type Notebook struct {
-	store   *store
-	program *tea.Program
-	clip    Clipboard
+	store         *store
+	program       *tea.Program
+	clip          Clipboard
+	rdv           *rendezvous
+	promptFactory PromptFactory
 
-	ready chan struct{}
+	ready   chan struct{}
+	stopped chan struct{}
+
+	promptSeq atomic.Uint64
 
 	startOnce sync.Once
 	stopOnce  sync.Once
@@ -37,10 +44,11 @@ type Notebook struct {
 type Option func(*notebookOpts)
 
 type notebookOpts struct {
-	headless bool
-	width    int
-	height   int
-	clip     Clipboard
+	headless      bool
+	width         int
+	height        int
+	clip          Clipboard
+	promptFactory PromptFactory
 }
 
 // WithHeadless runs the Bubble Tea program against a blocking
@@ -64,6 +72,18 @@ func WithClipboard(c Clipboard) Option {
 	return func(o *notebookOpts) { o.clip = c }
 }
 
+// WithPromptFactory configures the function AwaitInput uses to
+// build a prompt cell from a list of Inputs. Without one,
+// AwaitInput panics — callers that don't supply a factory can
+// still use AwaitInputBy with their own cells.
+//
+// The notebook package can't import its own cells subpackage, so
+// real consumers wire this via cells.PromptFactory() (or a
+// custom function).
+func WithPromptFactory(f PromptFactory) Option {
+	return func(o *notebookOpts) { o.promptFactory = f }
+}
+
 // New constructs a Notebook. The Bubble Tea program is wired up
 // but not started; call Run to start it (Run blocks).
 func New(opts ...Option) *Notebook {
@@ -77,13 +97,18 @@ func New(opts ...Option) *Notebook {
 
 	st := newStore()
 	ready := make(chan struct{})
-	m := newModel(st, ready, cfg.width, cfg.height)
+	stopped := make(chan struct{})
+	rdv := newRendezvous()
+	m := newModel(st, rdv, ready, cfg.width, cfg.height)
 
 	progOpts := []tea.ProgramOption{}
 	nb := &Notebook{
-		store: st,
-		clip:  cfg.clip,
-		ready: ready,
+		store:         st,
+		clip:          cfg.clip,
+		rdv:           rdv,
+		promptFactory: cfg.promptFactory,
+		ready:         ready,
+		stopped:       stopped,
 	}
 	if cfg.headless {
 		nb.blockIn = newBlockingReader()
@@ -112,15 +137,24 @@ func (nb *Notebook) Run() error {
 	return err
 }
 
-// Stop signals the program to quit. Run returns shortly after.
-// Idempotent.
+// Stop signals the program to quit and drains any pending
+// AwaitAdvance / AwaitInput callers with Source: "cancelled".
+// Run returns shortly after. Idempotent.
 func (nb *Notebook) Stop() {
 	nb.stopOnce.Do(func() {
+		close(nb.stopped)
+		nb.rdv.cancelAll()
 		nb.program.Quit()
 		if nb.blockIn != nil {
 			nb.blockIn.close()
 		}
 	})
+}
+
+// nextPromptID returns a monotonically-increasing ID for prompt
+// cells created by AwaitInput.
+func (nb *Notebook) nextPromptID() CellID {
+	return "prompt-" + strconv.FormatUint(nb.promptSeq.Add(1), 10)
 }
 
 // Snapshot returns the rendered View as it would appear right now.

--- a/notebook/notebook_test.go
+++ b/notebook/notebook_test.go
@@ -250,7 +250,7 @@ func TestStopUnblocksRun(t *testing.T) {
 func newSizedModel(t *testing.T, width, height int) (*model, *store) {
 	t.Helper()
 	st := newStore()
-	m := newModel(st, make(chan struct{}), width, height)
+	m := newModel(st, newRendezvous(), make(chan struct{}), width, height)
 	return &m, st
 }
 

--- a/notebook/rendezvous.go
+++ b/notebook/rendezvous.go
@@ -1,0 +1,216 @@
+package notebook
+
+import (
+	"sync"
+	"time"
+)
+
+// AdvanceResponse is what AwaitAdvance returns.
+//
+// Source classifies how the wait ended:
+//   - "user-enter": the user pressed Enter in SelectMode.
+//   - "auto-advance": the deadline fired before any user input.
+//   - "cancelled": Stop was called while the wait was pending.
+type AdvanceResponse struct {
+	Source string
+	At     time.Time
+}
+
+// InputResponse is what AwaitInput / AwaitInputBy returns.
+//
+// Source classifies how the wait ended:
+//   - "user-submitted": the PromptCell emitted PromptSubmittedMsg.
+//   - "cancelled": Stop was called, or the prompt cell was Removed,
+//     while the wait was pending.
+type InputResponse struct {
+	Answers map[string]any
+	Source  string
+	At      time.Time
+}
+
+// rendezvous registers pending AwaitAdvance / AwaitInput calls.
+// The model resolves them when the user advances or a PromptCell
+// submits; Stop drains them with Source: "cancelled" so no caller
+// goroutine is left blocked.
+//
+// All channels are buffered cap 1 so resolveX never blocks even
+// if the awaiter has already returned via a different select arm
+// (e.g. deadline timer fired first).
+type rendezvous struct {
+	mu       sync.Mutex
+	advances []chan AdvanceResponse
+	inputs   map[CellID]chan InputResponse
+}
+
+func newRendezvous() *rendezvous {
+	return &rendezvous{inputs: map[CellID]chan InputResponse{}}
+}
+
+// registerAdvance enrols a new pending advance and returns its
+// resolution channel. FIFO: resolveAdvance pops the first.
+func (r *rendezvous) registerAdvance() chan AdvanceResponse {
+	ch := make(chan AdvanceResponse, 1)
+	r.mu.Lock()
+	r.advances = append(r.advances, ch)
+	r.mu.Unlock()
+	return ch
+}
+
+// removeAdvance unenrols ch (used when the deadline timer fired
+// or Stop closed the global stop channel before any user advance).
+func (r *rendezvous) removeAdvance(ch chan AdvanceResponse) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, w := range r.advances {
+		if w == ch {
+			r.advances = append(r.advances[:i], r.advances[i+1:]...)
+			return
+		}
+	}
+}
+
+// resolveAdvance hands the next pending awaiter its response.
+// Returns true if there was one to resolve. Send is non-blocking
+// because the chan is buffered cap 1.
+func (r *rendezvous) resolveAdvance(source string) bool {
+	r.mu.Lock()
+	if len(r.advances) == 0 {
+		r.mu.Unlock()
+		return false
+	}
+	ch := r.advances[0]
+	r.advances = r.advances[1:]
+	r.mu.Unlock()
+	select {
+	case ch <- AdvanceResponse{Source: source, At: time.Now()}:
+	default:
+	}
+	return true
+}
+
+// registerInput enrols a waiter keyed by the prompt cell's ID.
+func (r *rendezvous) registerInput(id CellID) chan InputResponse {
+	ch := make(chan InputResponse, 1)
+	r.mu.Lock()
+	r.inputs[id] = ch
+	r.mu.Unlock()
+	return ch
+}
+
+// removeInput drops the waiter for id without resolving it.
+func (r *rendezvous) removeInput(id CellID) {
+	r.mu.Lock()
+	delete(r.inputs, id)
+	r.mu.Unlock()
+}
+
+// resolveInput hands the waiter for id (if any) its response.
+func (r *rendezvous) resolveInput(id CellID, answers map[string]any, source string) bool {
+	r.mu.Lock()
+	ch, ok := r.inputs[id]
+	if ok {
+		delete(r.inputs, id)
+	}
+	r.mu.Unlock()
+	if !ok {
+		return false
+	}
+	select {
+	case ch <- InputResponse{Answers: answers, Source: source, At: time.Now()}:
+	default:
+	}
+	return true
+}
+
+// cancelAll resolves every pending advance and input with
+// Source: "cancelled". Called from Stop.
+func (r *rendezvous) cancelAll() {
+	r.mu.Lock()
+	advances := r.advances
+	r.advances = nil
+	inputs := r.inputs
+	r.inputs = map[CellID]chan InputResponse{}
+	r.mu.Unlock()
+
+	for _, ch := range advances {
+		select {
+		case ch <- AdvanceResponse{Source: "cancelled", At: time.Now()}:
+		default:
+		}
+	}
+	for _, ch := range inputs {
+		select {
+		case ch <- InputResponse{Source: "cancelled", At: time.Now()}:
+		default:
+		}
+	}
+}
+
+// --- Notebook public API ---
+
+// AwaitAdvance blocks until the user advances (Enter in
+// SelectMode), the deadline fires, or Stop is called.
+//
+// A zero deadline (time.Time{}) means no auto-advance — the call
+// blocks until a user advance or Stop. Otherwise the call returns
+// with Source: "auto-advance" when the deadline elapses.
+func (nb *Notebook) AwaitAdvance(deadline time.Time) AdvanceResponse {
+	ch := nb.rdv.registerAdvance()
+	var timerC <-chan time.Time
+	if !deadline.IsZero() {
+		t := time.NewTimer(time.Until(deadline))
+		defer t.Stop()
+		timerC = t.C
+	}
+	select {
+	case resp := <-ch:
+		return resp
+	case <-timerC:
+		nb.rdv.removeAdvance(ch)
+		return AdvanceResponse{Source: "auto-advance", At: time.Now()}
+	case <-nb.stopped:
+		nb.rdv.removeAdvance(ch)
+		return AdvanceResponse{Source: "cancelled", At: time.Now()}
+	}
+}
+
+// AwaitInputBy blocks until the cell with cellID emits a
+// PromptSubmittedMsg, the cell is Removed, or Stop is called.
+// The caller is responsible for having Appended the prompt cell.
+// Use AwaitInput for the convenience that builds + appends the
+// cell via the configured PromptFactory.
+func (nb *Notebook) AwaitInputBy(cellID CellID) InputResponse {
+	ch := nb.rdv.registerInput(cellID)
+	select {
+	case resp := <-ch:
+		return resp
+	case <-nb.stopped:
+		nb.rdv.removeInput(cellID)
+		return InputResponse{Source: "cancelled", At: time.Now()}
+	}
+}
+
+// PromptFactory builds a prompt cell from a list of Inputs. The
+// notebook package can't reference its own notebook/cells
+// subpackage (cells imports notebook), so consumers wire a factory
+// at construction time — cells.PromptFactory() returns one for the
+// built-in PromptCell.
+type PromptFactory func(id CellID, inputs []Input) Cell
+
+// AwaitInput is the convenience that builds a prompt cell from
+// the configured PromptFactory, Appends it, and waits for the
+// user to submit. Panics if no factory was configured.
+func (nb *Notebook) AwaitInput(inputs []Input) InputResponse {
+	if nb.promptFactory == nil {
+		panic("notebook: AwaitInput requires WithPromptFactory(...) at New() — use AwaitInputBy for caller-supplied cells")
+	}
+	id := nb.nextPromptID()
+	cell := nb.promptFactory(id, inputs)
+	if _, err := nb.Append(cell); err != nil {
+		// Duplicate ID — shouldn't happen because nextPromptID is
+		// monotonic per Notebook, but surface it via cancelled
+		// rather than blocking forever.
+		return InputResponse{Source: "cancelled", At: time.Now()}
+	}
+	return nb.AwaitInputBy(id)
+}

--- a/notebook/stream.go
+++ b/notebook/stream.go
@@ -1,0 +1,34 @@
+package notebook
+
+import "io"
+
+// outputBuffered is the optional interface a Cell implements when
+// it exposes an OutputBuffer for streaming writes. Stream(id) is
+// the supported entry point — it returns an io.Writer over the
+// buffer (or io.Discard if the cell is missing or doesn't buffer).
+//
+// The buffer's own RWMutex makes writes safe from any goroutine;
+// the model's repaint tick + the cell's render-time follow logic
+// make new content visible within one frame, with no extra
+// notification needed.
+type outputBuffered interface {
+	Buffer() *OutputBuffer
+}
+
+// Stream returns an io.Writer over the cell's OutputBuffer.
+// Writes are safe from any goroutine and become visible on the
+// next render tick. If the cell is missing or doesn't implement
+// outputBuffered, Stream returns io.Discard so the caller never
+// has to nil-check — a stream to a cell that was Removed mid-flight
+// silently drops chunks.
+func (nb *Notebook) Stream(id CellID) io.Writer {
+	c, ok := nb.store.get(id)
+	if !ok {
+		return io.Discard
+	}
+	ob, ok := c.(outputBuffered)
+	if !ok {
+		return io.Discard
+	}
+	return ob.Buffer()
+}


### PR DESCRIPTION
Phase 3b of 5 for issue 25. Adds the rendezvous primitives that caller goroutines block on, the Stream API, and the concurrency test suite. Pure addition to the notebook module; `tui/notebook/` untouched.

After this, the notebook is feature-complete for the demokit bridge (phase 4): a consumer can `Append` cells, `Stream` to them, and `AwaitAdvance` / `AwaitInput` against user input.

## What changes

- `notebook/rendezvous.go` — small registry of pending advance and input waiters under a single sync.Mutex; resolution channels are buffered cap 1. Plus the public `AwaitAdvance` and `AwaitInputBy` / `AwaitInput` methods.
- `notebook/stream.go` — `Stream(id) io.Writer`. Cells expose buffers via the unexported `outputBuffered` interface; missing or non-streaming cells return `io.Discard`.
- `notebook/notebook.go` — adds `stopped` channel + `rdv` field + `promptFactory` option (`WithPromptFactory`). `Stop` now closes `stopped` and calls `rdv.cancelAll`.
- `notebook/model.go` — Enter in SelectMode resolves a pending advance; `PromptSubmittedMsg` resolves a pending input and advances the cursor.
- `notebook/crud.go` — `Remove` cancels any pending `AwaitInputBy` on the removed cell.
- `notebook/cells/output.go` — `OnAppend` removed; its follow-mode scroll bump moved into `clampScroll`, which runs every render. Stream writes don't need a notification hook anymore — the 16ms tick + render-time follow logic surface new content within one frame.
- `notebook/cells/output_test.go` — adjusted to drive rendering (via a new `render` helper) instead of calling `OnAppend`.
- `notebook/concurrent_test.go` — 11 new tests, all green under `-race`.

## Reviewer's guide

Read in this order:

1. [notebook/rendezvous.go](https://github.com/panyam/demokit/pull/29/files#diff-d669687516b18fbcc53cf3579ad0a92e03d385c06a20175945b8ad250a76fb02) — the registry plus the three public methods. Buffered-cap-1 channels mean `resolveAdvance`/`resolveInput` are non-blocking even if the awaiter raced through a deadline-timer or `<-stopped` arm.
2. [notebook/stream.go](https://github.com/panyam/demokit/pull/29/files#diff-ee40cd24fbd8941afb857704d567030dd12b93a94185f65ea8b10bb71e9544f6) — short. Note the `outputBuffered` interface is unexported on purpose; cells opt in by implementing `Buffer()` on their own.
3. [notebook/notebook.go](https://github.com/panyam/demokit/pull/29/files#diff-fc8a0cfe266be065f6c84eeb5ac642087bdb6310393ffbd29d5bc1095da8b993) — see the `Stop` change (closes `stopped`, drains the registry) and the new `WithPromptFactory` option. `nextPromptID` is monotonic via `atomic.Uint64`.
4. [notebook/model.go](https://github.com/panyam/demokit/pull/29/files#diff-0d92338ba7adb1172045fae5f90be027b051e1302375bb8712fb50d02426fcb8) — Enter / PromptSubmittedMsg handlers. Both are intentionally narrow: Enter only resolves advance in SelectMode; PromptSubmittedMsg resolves input AND nudges the cursor.
5. [notebook/cells/output.go](https://github.com/panyam/demokit/pull/29/files#diff-1edf40065bd671db3324a14b35826460db8598822b4a850a8c525fbb788dbe22) — `clampScroll` now applies follow when on. `OnAppend` is gone.
6. [notebook/concurrent_test.go](https://github.com/panyam/demokit/pull/29/files#diff-8aaf784f595779830b3a1bf555f1f78c7de96fb60e82af6116ac9bc5019306b6) — acceptance. `waitForInputWaiter` / `waitForAdvanceWaiter` poll the registry briefly to avoid the obvious "did the await goroutine register yet?" race.

## Decision log

- **Stream doesn't `Send` per chunk.** BT's `Send` is unbuffered (verified in phase 3a), and per-chunk Sends would serialize streaming on the BT loop. The 16ms repaint tick + render-time follow logic make the output cell track the buffer end on every frame; Stream just returns an `io.Writer` over the buffer. Throughput unaffected.
- **OutputCell.OnAppend removed**, follow folded into `clampScroll`. With Stream as the consumer's writer (not the model's), an external "append happened" hook would have meant adding a mutex to OutputCell or routing every chunk through `program.Send`. Moving the logic to render-time avoids both: scrollOffset is mutated only by the BT goroutine (in `clampScroll` from `RenderRows`), so no new race surface.
- **AwaitInput is convenience; AwaitInputBy is the primitive.** The notebook package can't import its own cells subpackage (cycle), so `AwaitInput` needs a factory. `WithPromptFactory` accepts one; in real use `cells.PromptFactory()` (added in phase 4 wiring) returns the built-in. Tests use `AwaitInputBy` with their own stub cells, which keeps phase-3b tests free of the cells subpackage.
- **Resolution channels are buffered cap 1.** Means `resolveAdvance` / `resolveInput` are non-blocking even after the awaiter took a different select arm (deadline timer, `<-stopped`). The send becomes a harmless drop into a now-orphaned channel.
- **Remove cancels a pending AwaitInputBy** on the removed cell with `Source: "cancelled"`. Acceptance: `TestAwaitInputCancelledOnRemove`.
- **`waitForInputWaiter` / `waitForAdvanceWaiter` poll the registry** rather than using `time.Sleep` between goroutine launch and resolution. Tighter; sleep-based tests would flake under load.

## Risk / blast radius

- Pure addition to the notebook module; existing files in `cells/` modified only for the OnAppend removal.
- `make testall` passes; `go test -race ./...` within the notebook module passes (the `web` race that `make race` still flags is pre-existing — captureOutput stdout swap, issue 23).
- Be paranoid about: `Remove` cancelling input waiters means a consumer that "rotates" prompt cells (Remove old + Append new) needs to call `AwaitInputBy` on the NEW cell, not be still blocked on the old one. The cancelled response is the signal.
- `OnAppend` is an API removal in `notebook/cells`. The cells module isn't externally consumed yet (only by demokit's bridge, coming in phase 4), so the break is contained. Phase 2's tests were updated in this PR.

## Out of scope

- `notebook/examples/mathrepl` — built next, as the standalone non-demokit consumer
- Demokit bridge wiring — phase 4
- Deleting `tui/notebook/` + switching examples — phase 5
