### PR TITLE
feat(notebook): cell-first key routing + configurable KeyMap + arbitrary modes; drop AwaitAdvance

### DIFF
--- a/notebook/cell.go
+++ b/notebook/cell.go
@@ -1,78 +1,92 @@
 // Package notebook is a standalone cell-based TUI component built
 // on Bubble Tea. It has no dependency on demokit, events, or any
 // other consumer — callers drive it via Append/Update/Stream and
-// AwaitAdvance/AwaitInput. Bridges (e.g. demokit/notebookbridge)
-// translate domain events into these calls.
+// AwaitInput. Bridges (e.g. demokit/notebookbridge) translate
+// domain events into these calls.
 //
 // Rendering is range-based: the viewport asks each cell for just
 // the row window it intends to display, never the full cell body.
-// That contract is what unlocks lazy materialization without
-// touching the viewport code.
+//
+// Key dispatch is cell-first: every keystroke goes to the cursor
+// cell's Update before the notebook tries its own KeyMap. The
+// cell returns a `handled bool`; if false, the notebook tries
+// Global then current-mode bindings. See KeyMap for the
+// notebook-level binding surface.
 package notebook
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// Mode is the notebook's mode state. Hierarchical and vim-ish:
-// SelectMode (cursor navigates cells) wraps FocusedMode (focused
-// cell owns keystrokes), which in turn has ViewMode (today's
-// interactive defaults) and EditMode (reserved). Esc pops up one
-// level.
+// Mode is an opaque value identifying the notebook's current
+// interaction mode. The framework ships SelectMode and ViewMode as
+// convenient defaults but apps can define their own via NewMode
+// and register per-mode bindings in KeyMap.
 //
-// Encoded as a small interface rather than an enum so future modes
-// (Edit, Visual, Search) don't churn switch statements.
+// Cells receive the current Mode as a parameter to Update so they
+// can react contextually; cells do not store mode themselves.
 type Mode interface {
 	Name() string
 }
 
-type selectMode struct{}
-type viewMode struct{}
-type editMode struct{}
+// NewMode returns an opaque Mode value with the given short name
+// (shown in the status line / used for KeyMap keys). Two NewMode
+// calls with the same name produce different Mode values — modes
+// are compared by identity, not by name.
+func NewMode(name string) Mode {
+	return &mode{name: name}
+}
 
-func (selectMode) Name() string { return "SELECT" }
-func (viewMode) Name() string   { return "VIEW" }
-func (editMode) Name() string   { return "EDIT" }
+type mode struct{ name string }
 
-// SelectMode is the default outermost mode — the cell cursor moves
-// between cells; the focused cell, if any, does not receive keys.
-var SelectMode Mode = selectMode{}
+func (m *mode) Name() string { return m.name }
 
-// ViewMode is the inner interactive mode that owns keys when a cell
-// is focused.
-var ViewMode Mode = viewMode{}
+// SelectMode is the canonical "navigate between cells" mode used
+// by the DefaultKeyMap. Apps that don't use the defaults can
+// ignore it.
+var SelectMode = NewMode("SELECT")
 
-// EditMode is reserved for in-TUI authoring. Not wired into key
-// handling yet; declared so the Cell interface can already receive
-// it without a future signature change.
-var EditMode Mode = editMode{}
+// ViewMode is the canonical "focused-cell-owns-keys" mode used by
+// the DefaultKeyMap. Apps that don't use the defaults can ignore
+// it.
+var ViewMode = NewMode("VIEW")
 
 // Cell is the unit the notebook viewport navigates and renders.
-// Implementations own their content.
+// Implementations own their content; render is range-based.
 //
-// Rendering is range-based — viewport calls RenderRows(width, lo, hi)
-// for just the visible row window, never RenderAll.
+// The Update signature returns three values:
+//   - the (possibly mutated) Cell
+//   - an optional tea.Cmd for side effects
+//   - handled — true if the cell consumed this msg; false to let
+//     the notebook try its own KeyMap bindings on the same key
+//
+// The handled=false / cmd=nil combo is "I don't claim this" — the
+// notebook will look up the key in Global + current mode and
+// dispatch the matching Action. The rare handled=false / cmd!=nil
+// case means "I did something with side effects but still want the
+// notebook to also try its bindings" — useful for instrumentation
+// or chained handlers.
 type Cell interface {
 	// ID returns a stable identifier unique within the notebook.
-	// Insert rejects duplicate IDs; Remove/Get/IndexOf lookup by ID.
 	ID() string
 
-	// HeightHint reports the row count the cell would occupy at the
-	// given width. Must be cheap & deterministic — the viewport
-	// invokes it once per visible-window calculation. Implementations
-	// should cache (width → height) and invalidate on width change.
+	// HeightHint reports the row count the cell would occupy at
+	// the given width. Must be cheap & deterministic.
 	HeightHint(width int) int
 
 	// RenderRows returns the row slice for the half-open range
-	// [startRow, endRow) at the given width. Cells with large bodies
-	// compute only the requested window.
+	// [startRow, endRow) at the given width.
 	RenderRows(width, startRow, endRow int, focused bool, mode Mode) []string
 
-	// Update receives Bubble Tea messages only when the cell is the
-	// focused cell. Returns the updated cell and an optional command.
-	Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd)
+	// Update receives Bubble Tea messages. For tea.KeyMsg, the
+	// notebook always routes to the cursor cell first; the cell's
+	// returned `handled` bool determines whether the notebook
+	// continues with its own KeyMap. For other msg types the
+	// notebook handles routing differently (e.g. ClearCopyMsg is
+	// routed by cell ID).
+	Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd, bool)
 
-	// StatusHint returns the right-side status text shown when this
-	// cell is focused.
+	// StatusHint returns the right-side status text shown when
+	// this cell is focused.
 	StatusHint(mode Mode) string
 }

--- a/notebook/cells/header.go
+++ b/notebook/cells/header.go
@@ -101,9 +101,15 @@ func (c *HeaderCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 	return out
 }
 
-// Update implements notebook.Cell. HeaderCell is read-only.
-func (c *HeaderCell) Update(_ tea.Msg, _ notebook.Mode) (notebook.Cell, tea.Cmd) {
-	return c, nil
+// Update implements notebook.Cell. HeaderCell is read-only — it
+// never handles a key. Esc in ViewMode is the standard "release
+// focus" gesture; HeaderCell handles it so users can back out
+// after navigating into a header.
+func (c *HeaderCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
+	if k, ok := msg.(tea.KeyMsg); ok && k.String() == "esc" && mode == notebook.ViewMode {
+		return c, notebook.ReleaseFocus, true
+	}
+	return c, nil, false
 }
 
 // StatusHint implements notebook.Cell.

--- a/notebook/cells/note.go
+++ b/notebook/cells/note.go
@@ -125,15 +125,17 @@ func (c *NoteCell) RenderRows(width, startRow, endRow int, focused bool, _ noteb
 }
 
 // Update implements notebook.Cell. 'c' copies regardless of mode;
-// Enter in ViewMode signals cell-advance.
-func (c *NoteCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+// Enter in ViewMode signals cell-advance; Esc in ViewMode releases
+// focus. Other keys passthrough (handled=false) so notebook KeyMap
+// gets a turn.
+func (c *NoteCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
 	if cm, ok := msg.(notebook.ClearCopyMsg); ok && cm.CellID == c.id {
 		c.copyMsg = ""
-		return c, nil
+		return c, nil, true
 	}
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
-		return c, nil
+		return c, nil, false
 	}
 	if keyMsg.String() == "c" {
 		strategy, ok := c.clip(c.Body)
@@ -142,15 +144,18 @@ func (c *NoteCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.C
 		} else {
 			c.copyMsg = "(copy failed — no clipboard provider)"
 		}
-		return c, notebook.ClearCopyAfter(c.id)
+		return c, notebook.ClearCopyAfter(c.id), true
 	}
 	if mode != notebook.ViewMode {
-		return c, nil
+		return c, nil, false
 	}
-	if keyMsg.String() == "enter" {
-		return c, notebook.CellAdvance
+	switch keyMsg.String() {
+	case "enter":
+		return c, notebook.CellAdvance, true
+	case "esc":
+		return c, notebook.ReleaseFocus, true
 	}
-	return c, nil
+	return c, nil, false
 }
 
 // StatusHint implements notebook.Cell.

--- a/notebook/cells/output.go
+++ b/notebook/cells/output.go
@@ -194,15 +194,17 @@ func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 }
 
 // Update implements notebook.Cell. 'c' copies regardless of mode;
-// scroll keys require ViewMode.
-func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+// in ViewMode scroll keys (j/k/g/G/pgup/pgdown) move within the
+// buffer, Enter advances, Esc releases focus. Other keys
+// passthrough.
+func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
 	if cm, ok := msg.(notebook.ClearCopyMsg); ok && cm.CellID == c.id {
 		c.copyMsg = ""
-		return c, nil
+		return c, nil, true
 	}
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
-		return c, nil
+		return c, nil, false
 	}
 	if keyMsg.String() == "c" {
 		all := strings.Join(c.buf.AllLines(), "\n")
@@ -212,39 +214,47 @@ func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea
 		} else {
 			c.copyMsg = "(copy failed — no clipboard provider)"
 		}
-		return c, notebook.ClearCopyAfter(c.id)
+		return c, notebook.ClearCopyAfter(c.id), true
 	}
 	if mode != notebook.ViewMode {
-		return c, nil
+		return c, nil, false
 	}
 	switch keyMsg.String() {
 	case "enter":
-		return c, notebook.CellAdvance
+		return c, notebook.CellAdvance, true
+	case "esc":
+		return c, notebook.ReleaseFocus, true
 	case "j", "down":
 		c.follow = false
 		c.scrollOffset++
 		c.clampScroll()
+		return c, nil, true
 	case "k", "up":
 		c.follow = false
 		c.scrollOffset--
 		c.clampScroll()
+		return c, nil, true
 	case "pgdown":
 		c.follow = false
 		c.scrollOffset += c.maxBody
 		c.clampScroll()
+		return c, nil, true
 	case "pgup":
 		c.follow = false
 		c.scrollOffset -= c.maxBody
 		c.clampScroll()
+		return c, nil, true
 	case "g":
 		c.follow = false
 		c.scrollOffset = 0
+		return c, nil, true
 	case "G":
 		c.follow = true
 		c.scrollOffset = c.buf.LineCount()
 		c.clampScroll()
+		return c, nil, true
 	}
-	return c, nil
+	return c, nil, false
 }
 
 // StatusHint implements notebook.Cell.

--- a/notebook/cells/prompt.go
+++ b/notebook/cells/prompt.go
@@ -85,15 +85,32 @@ func NewPrompt(id string, inputs []notebook.Input) *PromptCell {
 		}
 		fields[i] = ti
 	}
-	if len(fields) > 0 {
-		fields[0].Focus()
-	}
+	// Intentionally NOT calling fields[0].Focus() — textinput's
+	// blinking cursor is the cell's "I'm focused" manifestation,
+	// and the cell isn't focused at construction. syncFieldFocus
+	// in RenderRows turns it on when (focused && ViewMode).
 	return &PromptCell{
 		id:     id,
 		inputs: inputs,
 		fields: fields,
 		errors: errs,
 		Style:  DefaultPromptStyle(),
+	}
+}
+
+// syncFieldFocus drives the textinput Focus state from the
+// cell's render-time (focused, mode) so the cursor only blinks
+// when the cell itself is focused AND the notebook is in
+// ViewMode. Idempotent — safe to call every render.
+func (c *PromptCell) syncFieldFocus(focused bool, mode notebook.Mode) {
+	wantFocused := focused && mode == notebook.ViewMode && !c.done
+	for i := range c.fields {
+		on := wantFocused && i == c.active
+		if on && !c.fields[i].Focused() {
+			c.fields[i].Focus()
+		} else if !on && c.fields[i].Focused() {
+			c.fields[i].Blur()
+		}
 	}
 }
 
@@ -120,7 +137,9 @@ func (c *PromptCell) HeightHint(_ int) int {
 }
 
 // RenderRows implements notebook.Cell.
-func (c *PromptCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
+func (c *PromptCell) RenderRows(width, startRow, endRow int, focused bool, mode notebook.Mode) []string {
+	c.syncFieldFocus(focused, mode)
+
 	border := c.Style.BorderColor
 	if focused {
 		border = c.Style.FocusBorderColor

--- a/notebook/cells/prompt.go
+++ b/notebook/cells/prompt.go
@@ -180,35 +180,40 @@ func (c *PromptCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 }
 
 // Update implements notebook.Cell. Routes keys to the active
-// textinput; Enter / Tab / Shift+Tab control navigation and
-// submission.
-func (c *PromptCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+// textinput; Enter / Tab / Shift+Tab control submission /
+// navigation; Esc releases focus without submitting. In ViewMode
+// the cell claims every key (typing into the textinput counts);
+// in other modes or once submitted, keys passthrough.
+func (c *PromptCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
 	if c.done {
-		return c, nil
+		return c, nil, false
 	}
 	if mode != notebook.ViewMode {
-		return c, nil
+		return c, nil, false
 	}
 	keyMsg, isKey := msg.(tea.KeyMsg)
 	if !isKey {
-		return c, nil
+		return c, nil, false
 	}
 	switch keyMsg.String() {
 	case "tab":
 		c.advance(+1)
-		return c, nil
+		return c, nil, true
 	case "shift+tab":
 		c.advance(-1)
-		return c, nil
+		return c, nil, true
+	case "esc":
+		return c, notebook.ReleaseFocus, true
 	case "enter":
-		return c.trySubmit()
+		cell, cmd := c.trySubmit()
+		return cell, cmd, true
 	}
 	if len(c.fields) == 0 {
-		return c, nil
+		return c, nil, true
 	}
 	var cmd tea.Cmd
 	c.fields[c.active], cmd = c.fields[c.active].Update(msg)
-	return c, cmd
+	return c, cmd, true
 }
 
 // StatusHint implements notebook.Cell.

--- a/notebook/cells/prompt_test.go
+++ b/notebook/cells/prompt_test.go
@@ -12,7 +12,7 @@ import (
 // PromptSubmittedMsg if one was emitted, or nil.
 func submitMsg(t *testing.T, c *PromptCell) *notebook.PromptSubmittedMsg {
 	t.Helper()
-	_, cmd := c.Update(tea.KeyMsg{Type: tea.KeyEnter}, notebook.ViewMode)
+	_, cmd, _ := c.Update(tea.KeyMsg{Type: tea.KeyEnter}, notebook.ViewMode)
 	if cmd == nil {
 		return nil
 	}

--- a/notebook/cells/verbatim.go
+++ b/notebook/cells/verbatim.go
@@ -157,15 +157,16 @@ func (c *VerbatimCell) RenderRows(width, startRow, endRow int, focused bool, _ n
 }
 
 // Update implements notebook.Cell. 'c' copies regardless of mode;
-// other keys require ViewMode.
-func (c *VerbatimCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd) {
+// in ViewMode Enter advances, Tab / Shift+Tab cycle variants,
+// '1'..'9' jump, Esc releases focus. Other keys passthrough.
+func (c *VerbatimCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
 	if cm, ok := msg.(notebook.ClearCopyMsg); ok && cm.CellID == c.id {
 		c.copyMsg = ""
-		return c, nil
+		return c, nil, true
 	}
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
-		return c, nil
+		return c, nil, false
 	}
 	if keyMsg.String() == "c" {
 		v := c.Variants[c.Active]
@@ -180,29 +181,33 @@ func (c *VerbatimCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, t
 		} else {
 			c.copyMsg = "(copy failed — no clipboard provider)"
 		}
-		return c, notebook.ClearCopyAfter(c.id)
+		return c, notebook.ClearCopyAfter(c.id), true
 	}
 	if mode != notebook.ViewMode {
-		return c, nil
+		return c, nil, false
 	}
 	switch keyMsg.String() {
 	case "enter":
-		return c, notebook.CellAdvance
+		return c, notebook.CellAdvance, true
+	case "esc":
+		return c, notebook.ReleaseFocus, true
 	case "tab":
 		c.cycle(+1)
+		return c, nil, true
 	case "shift+tab":
 		c.cycle(-1)
-	default:
-		s := keyMsg.String()
-		if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
-			idx := int(s[0] - '1')
-			if idx < len(c.Variants) {
-				c.Active = idx
-				c.cachedLines = nil
-			}
-		}
+		return c, nil, true
 	}
-	return c, nil
+	s := keyMsg.String()
+	if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
+		idx := int(s[0] - '1')
+		if idx < len(c.Variants) {
+			c.Active = idx
+			c.cachedLines = nil
+		}
+		return c, nil, true
+	}
+	return c, nil, false
 }
 
 // StatusHint implements notebook.Cell.

--- a/notebook/clipboard.go
+++ b/notebook/clipboard.go
@@ -1,5 +1,11 @@
 package notebook
 
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
 // Clipboard is the injection point cells call when the user presses
 // 'c'. Returns (strategy, ok) — strategy is a human-readable label
 // like "OSC52" or "pbcopy" that the cell displays in its toast;
@@ -14,3 +20,28 @@ type Clipboard func(content string) (strategy string, ok bool)
 // is injected — cells render a "(copy failed — no clipboard
 // provider)" toast.
 var NoClipboard Clipboard = func(string) (string, bool) { return "", false }
+
+// OSC52Clipboard returns a Clipboard that writes via the OSC 52
+// terminal escape sequence. The escape is consumed by the
+// terminal emulator (kitty, iTerm2, Alacritty, WezTerm, recent
+// Apple Terminal, tmux with config, etc.) and copies into the
+// system clipboard — no extra binaries or platform integration
+// needed.
+//
+// The escape is written to os.Stderr to keep it out of the
+// alt-screen buffer that bubbletea owns; terminals that don't
+// understand OSC 52 silently ignore it (no visible garbage in
+// well-behaved terminals).
+//
+// Use as a one-liner default:
+//
+//	nb := notebook.New(notebook.WithClipboard(notebook.OSC52Clipboard()))
+func OSC52Clipboard() Clipboard {
+	return func(content string) (string, bool) {
+		encoded := base64.StdEncoding.EncodeToString([]byte(content))
+		// \x1b]52;c;<base64>\x07 is the standard OSC 52 form
+		// for the "c" (clipboard) selection.
+		fmt.Fprintf(os.Stderr, "\x1b]52;c;%s\x07", encoded)
+		return "OSC52", true
+	}
+}

--- a/notebook/concurrent_test.go
+++ b/notebook/concurrent_test.go
@@ -28,8 +28,8 @@ func (c *streamCell) ID() string                { return c.id }
 func (c *streamCell) HeightHint(int) int        { return c.buf.LineCount() + 2 }
 func (c *streamCell) StatusHint(Mode) string    { return "" }
 func (c *streamCell) Buffer() *OutputBuffer     { return c.buf }
-func (c *streamCell) Update(tea.Msg, Mode) (Cell, tea.Cmd) {
-	return c, nil
+func (c *streamCell) Update(tea.Msg, Mode) (Cell, tea.Cmd, bool) {
+	return c, nil, false
 }
 
 func (c *streamCell) RenderRows(width, startRow, endRow int, _ bool, _ Mode) []string {
@@ -64,23 +64,6 @@ func waitForInputWaiter(t *testing.T, nb *Notebook, id CellID) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("no input waiter for %q after 200ms", id)
-}
-
-// waitForAdvanceWaiter spins until the rendezvous has at least
-// one registered advance waiter.
-func waitForAdvanceWaiter(t *testing.T, nb *Notebook) {
-	t.Helper()
-	deadline := time.Now().Add(200 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		nb.rdv.mu.Lock()
-		n := len(nb.rdv.advances)
-		nb.rdv.mu.Unlock()
-		if n > 0 {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatal("no advance waiter registered after 200ms")
 }
 
 // --- Stream ---
@@ -166,37 +149,6 @@ func TestPromptResolvesWithSubmittedAnswer(t *testing.T) {
 	}
 }
 
-func TestAwaitAdvanceResolvesOnEnter(t *testing.T) {
-	nb := New(WithHeadless(), WithSize(40, 10))
-	go nb.Run()
-	t.Cleanup(nb.Stop)
-
-	done := make(chan AdvanceResponse, 1)
-	go func() { done <- nb.AwaitAdvance(time.Time{}) }()
-	waitForAdvanceWaiter(t, nb)
-
-	nb.program.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	select {
-	case resp := <-done:
-		if resp.Source != "user-enter" {
-			t.Errorf("Source = %q, want user-enter", resp.Source)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("AwaitAdvance did not return within 1s")
-	}
-}
-
-func TestAwaitAdvanceDeadlineFiresAsAutoAdvance(t *testing.T) {
-	nb := New(WithHeadless(), WithSize(40, 10))
-	go nb.Run()
-	t.Cleanup(nb.Stop)
-
-	resp := nb.AwaitAdvance(time.Now().Add(30 * time.Millisecond))
-	if resp.Source != "auto-advance" {
-		t.Errorf("Source = %q, want auto-advance", resp.Source)
-	}
-}
-
 func TestAwaitInputCancelledOnRemove(t *testing.T) {
 	nb := New(WithHeadless(), WithSize(40, 10))
 	go nb.Run()
@@ -219,25 +171,6 @@ func TestAwaitInputCancelledOnRemove(t *testing.T) {
 }
 
 // --- Stop unblocks awaits ---
-
-func TestStopUnblocksAwaitAdvance(t *testing.T) {
-	nb := New(WithHeadless(), WithSize(40, 10))
-	go nb.Run()
-
-	done := make(chan AdvanceResponse, 1)
-	go func() { done <- nb.AwaitAdvance(time.Time{}) }()
-	waitForAdvanceWaiter(t, nb)
-
-	nb.Stop()
-	select {
-	case resp := <-done:
-		if resp.Source != "cancelled" {
-			t.Errorf("Source = %q, want cancelled", resp.Source)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("AwaitAdvance did not unblock after Stop")
-	}
-}
 
 func TestStopUnblocksAwaitInput(t *testing.T) {
 	nb := New(WithHeadless(), WithSize(40, 10))

--- a/notebook/crud.go
+++ b/notebook/crud.go
@@ -55,6 +55,31 @@ func (nb *Notebook) IndexOf(id CellID) (int, bool) { return nb.store.indexOf(id)
 // Len returns the current cell count.
 func (nb *Notebook) Len() int { return nb.store.count() }
 
+// SetCursor moves the cursor to the cell with the given ID and
+// returns true. Returns false (no-op) if no such cell.
+func (nb *Notebook) SetCursor(id CellID) bool {
+	idx, ok := nb.store.indexOf(id)
+	if !ok {
+		return false
+	}
+	nb.store.setCursorByIdx(idx)
+	return true
+}
+
+// FocusCell sets the cursor to the named cell AND switches to
+// ViewMode so the cell has focus immediately. Useful right after
+// Appending a prompt cell when you want the user to type into it
+// without manually navigating + entering focus first.
+//
+// Returns false if no such cell.
+func (nb *Notebook) FocusCell(id CellID) bool {
+	if !nb.SetCursor(id) {
+		return false
+	}
+	nb.SetMode(ViewMode)
+	return true
+}
+
 // SetHeader sets the notebook's top-of-screen title + subtitle.
 func (nb *Notebook) SetHeader(title, desc string) {
 	nb.store.setHeader(title, desc)

--- a/notebook/keymap.go
+++ b/notebook/keymap.go
@@ -1,0 +1,125 @@
+package notebook
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Action is the function the notebook runs when a key matches a
+// KeyMap binding. Receives *Notebook so the action can call
+// public mutation methods (MoveCursor, SetMode, Append, etc.).
+//
+// Actions can either:
+//   - Mutate the notebook synchronously via store methods that
+//     don't require model state (MoveCursor, SetCursor, store CRUD).
+//   - Return a tea.Cmd that emits a msg the model handles (e.g.
+//     setModeMsg for mode changes). Required for anything that
+//     mutates fields owned by the model goroutine.
+//
+// The two are equivalent in effect from the user's perspective —
+// both settle within one repaint tick.
+type Action func(nb *Notebook) tea.Cmd
+
+// KeyMap routes unhandled keys (keys the cursor cell returned
+// handled=false for) to notebook-level actions.
+//
+// Lookup order in handleKey:
+//
+//  1. Cursor cell sees the key first via cell.Update; if it
+//     returns handled=true the notebook stops.
+//  2. KeyMap.Global is checked next — these bindings apply
+//     regardless of current mode (Quit, app-level shortcuts).
+//  3. KeyMap.Modes[currentMode] is checked last — per-mode
+//     bindings (navigation, mode transitions).
+//
+// A mode with no entry in Modes means "no notebook-level
+// bindings for this mode" — every key falls through to the cell.
+// That's the natural setup for ViewMode: cells own everything
+// while focused.
+type KeyMap struct {
+	Global map[string]Action
+	Modes  map[Mode]map[string]Action
+}
+
+// DefaultKeyMap returns the canonical bindings:
+//
+//   - Ctrl+C → Quit (Global)
+//   - SelectMode: ↑/k NavUp, ↓/j NavDown, enter/s/f EnterFocus
+//   - ViewMode: none (cells own everything)
+//
+// 'q' is intentionally NOT in the defaults — q is a printable
+// character a cell might want. Apps that want q-to-quit add it
+// explicitly via WithKeyMap.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Global: map[string]Action{
+			"ctrl+c": Quit,
+		},
+		Modes: map[Mode]map[string]Action{
+			SelectMode: {
+				"up":    NavUp,
+				"k":     NavUp,
+				"down":  NavDown,
+				"j":     NavDown,
+				"enter": EnterFocus,
+				"s":     EnterFocus,
+				"f":     EnterFocus,
+			},
+		},
+	}
+}
+
+// lookup finds the Action for a key in the given mode, checking
+// Global first then the mode-specific bindings. Returns nil if no
+// match — caller treats that as "key was dropped."
+func (km KeyMap) lookup(mode Mode, key string) Action {
+	if action, ok := km.Global[key]; ok {
+		return action
+	}
+	if bindings, ok := km.Modes[mode]; ok {
+		if action, ok := bindings[key]; ok {
+			return action
+		}
+	}
+	return nil
+}
+
+// --- Built-in actions ---
+
+// Quit signals BT to quit.
+func Quit(*Notebook) tea.Cmd { return tea.Quit }
+
+// NavUp moves the cursor up by one cell.
+func NavUp(nb *Notebook) tea.Cmd {
+	nb.store.moveCursor(-1)
+	return nil
+}
+
+// NavDown moves the cursor down by one cell.
+func NavDown(nb *Notebook) tea.Cmd {
+	nb.store.moveCursor(+1)
+	return nil
+}
+
+// EnterFocus switches to ViewMode (cell-owns-keys). No-op if
+// there are no cells to focus.
+func EnterFocus(nb *Notebook) tea.Cmd {
+	if nb.store.count() == 0 {
+		return nil
+	}
+	return func() tea.Msg { return setModeMsg{mode: ViewMode} }
+}
+
+// ExitFocus switches to SelectMode. Equivalent to a cell
+// returning ReleaseFocus, but accessible as an Action.
+func ExitFocus(*Notebook) tea.Cmd {
+	return func() tea.Msg { return setModeMsg{mode: SelectMode} }
+}
+
+// SetMode returns an Action that switches to the given mode. Use
+// for app-defined modes:
+//
+//	commandMode := notebook.NewMode("COMMAND")
+//	km.Modes[notebook.SelectMode][":"] = notebook.SetMode(commandMode)
+func SetMode(m Mode) Action {
+	return func(*Notebook) tea.Cmd {
+		return func() tea.Msg { return setModeMsg{mode: m} }
+	}
+}

--- a/notebook/keymap_test.go
+++ b/notebook/keymap_test.go
@@ -1,0 +1,212 @@
+package notebook
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestKeyMapLookupGlobalFirstThenMode(t *testing.T) {
+	gAction := func(*Notebook) tea.Cmd { return nil }
+	mAction := func(*Notebook) tea.Cmd { return nil }
+	custom := NewMode("CUSTOM")
+	km := KeyMap{
+		Global: map[string]Action{"ctrl+c": gAction},
+		Modes: map[Mode]map[string]Action{
+			SelectMode: {"j": mAction},
+			custom:     {"x": mAction},
+		},
+	}
+	// Global matches in any mode.
+	if got := km.lookup(SelectMode, "ctrl+c"); got == nil {
+		t.Error("global ctrl+c missing in SelectMode")
+	}
+	if got := km.lookup(custom, "ctrl+c"); got == nil {
+		t.Error("global ctrl+c missing in custom mode")
+	}
+	// Mode-specific matches only in their mode.
+	if got := km.lookup(SelectMode, "j"); got == nil {
+		t.Error("SelectMode j missing")
+	}
+	if got := km.lookup(custom, "j"); got != nil {
+		t.Error("SelectMode j leaked into custom mode")
+	}
+	// Unknown keys return nil.
+	if got := km.lookup(SelectMode, "z"); got != nil {
+		t.Error("unknown key z should not match")
+	}
+}
+
+func TestDefaultKeyMapDoesNotBindQ(t *testing.T) {
+	km := DefaultKeyMap()
+	if km.lookup(SelectMode, "q") != nil {
+		t.Error("default KeyMap should NOT bind 'q' (apps add it explicitly)")
+	}
+	if km.lookup(SelectMode, "ctrl+c") == nil {
+		t.Error("default KeyMap MUST bind ctrl+c")
+	}
+}
+
+func TestNewModeProducesDistinctValues(t *testing.T) {
+	a := NewMode("X")
+	b := NewMode("X")
+	if a == b {
+		t.Error("two NewMode(\"X\") calls produced equal values; should be distinct")
+	}
+	if a.Name() != "X" || b.Name() != "X" {
+		t.Errorf("Name() = %q,%q; want X,X", a.Name(), b.Name())
+	}
+}
+
+// Cell that records every key and never claims any, used to
+// confirm the cell-first dispatch and the passthrough path.
+type fallthroughCell struct {
+	id      string
+	gotKeys []string
+}
+
+func (c *fallthroughCell) ID() string              { return c.id }
+func (c *fallthroughCell) HeightHint(int) int      { return 1 }
+func (c *fallthroughCell) StatusHint(Mode) string  { return "" }
+func (c *fallthroughCell) RenderRows(int, int, int, bool, Mode) []string {
+	return []string{c.id}
+}
+func (c *fallthroughCell) Update(msg tea.Msg, _ Mode) (Cell, tea.Cmd, bool) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		c.gotKeys = append(c.gotKeys, k.String())
+	}
+	return c, nil, false
+}
+
+// Cell that claims every KeyMsg (handled=true) — used to confirm
+// KeyMap is suppressed when the cell handles the key.
+type claimingCell struct{ fallthroughCell }
+
+func (c *claimingCell) Update(msg tea.Msg, _ Mode) (Cell, tea.Cmd, bool) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		c.gotKeys = append(c.gotKeys, k.String())
+		return c, nil, true
+	}
+	return c, nil, false
+}
+
+func TestCellFirstThenKeyMapWhenPassthrough(t *testing.T) {
+	m, st := newSizedModel(t, 40, 24)
+	cell := &fallthroughCell{id: "a"}
+	st.insert(-1, cell)
+
+	// 'j' in SelectMode: cell sees it (passthrough), then KeyMap
+	// fires NavDown — but only one cell, so cursor stays clamped.
+	// Better: add a second cell so NavDown has somewhere to go.
+	st.insert(-1, &fallthroughCell{id: "b"})
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if len(cell.gotKeys) != 1 || cell.gotKeys[0] != "j" {
+		t.Errorf("cell.gotKeys = %v, want [j]", cell.gotKeys)
+	}
+	if got := st.cursorPos(); got != 1 {
+		t.Errorf("cursor = %d, want 1 (j fell through to NavDown)", got)
+	}
+}
+
+func TestCellHandledSuppressesKeyMap(t *testing.T) {
+	m, st := newSizedModel(t, 40, 24)
+	cell := &claimingCell{fallthroughCell{id: "a"}}
+	st.insert(-1, cell)
+	st.insert(-1, &fallthroughCell{id: "b"})
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if len(cell.gotKeys) != 1 || cell.gotKeys[0] != "j" {
+		t.Errorf("cell.gotKeys = %v, want [j]", cell.gotKeys)
+	}
+	if got := st.cursorPos(); got != 0 {
+		t.Errorf("cursor = %d, want 0 (cell claimed j, NavDown suppressed)", got)
+	}
+}
+
+func TestReleaseFocusReturnsToSelectMode(t *testing.T) {
+	m, st := newSizedModel(t, 40, 24)
+	st.insert(-1, &fallthroughCell{id: "a"})
+	m.mode = ViewMode
+
+	next, _ := m.Update(ReleaseFocusMsg{})
+	got := next.(model)
+	if got.mode != SelectMode {
+		t.Errorf("mode after ReleaseFocusMsg = %v, want SelectMode", got.mode)
+	}
+}
+
+func TestSetModeMsgChangesMode(t *testing.T) {
+	m, _ := newSizedModel(t, 40, 24)
+	custom := NewMode("CUSTOM")
+	next, _ := m.Update(setModeMsg{mode: custom})
+	got := next.(model)
+	if got.mode != custom {
+		t.Errorf("mode after setModeMsg = %v, want CUSTOM", got.mode)
+	}
+}
+
+func TestCellAdvanceMovesCursorAndExits(t *testing.T) {
+	m, st := newSizedModel(t, 40, 24)
+	st.insert(-1, &fallthroughCell{id: "a"})
+	st.insert(-1, &fallthroughCell{id: "b"})
+	m.mode = ViewMode
+
+	next, _ := m.Update(CellAdvanceMsg{})
+	got := next.(model)
+	if got.mode != SelectMode {
+		t.Errorf("mode after CellAdvance = %v, want SelectMode", got.mode)
+	}
+	if got := st.cursorPos(); got != 1 {
+		t.Errorf("cursor after CellAdvance = %d, want 1", got)
+	}
+}
+
+func TestPromptSubmittedExitsViewModeWithoutMovingCursor(t *testing.T) {
+	m, st := newSizedModel(t, 40, 24)
+	st.insert(-1, &fallthroughCell{id: "a"})
+	st.insert(-1, &fallthroughCell{id: "b"})
+	m.mode = ViewMode
+	// Cursor at "a" (idx 0).
+	next, _ := m.Update(PromptSubmittedMsg{CellID: "a", Answers: map[string]any{}})
+	got := next.(model)
+	if got.mode != SelectMode {
+		t.Errorf("mode = %v, want SelectMode", got.mode)
+	}
+	if c := st.cursorPos(); c != 0 {
+		t.Errorf("cursor = %d, want 0 (PromptSubmitted must NOT move cursor)", c)
+	}
+}
+
+func TestCustomModeBindings(t *testing.T) {
+	custom := NewMode("CUSTOM")
+	fired := false
+	km := KeyMap{
+		Global: map[string]Action{"ctrl+c": Quit},
+		Modes: map[Mode]map[string]Action{
+			custom: {"x": func(*Notebook) tea.Cmd { fired = true; return nil }},
+		},
+	}
+	nb := &Notebook{
+		store:   newStore(),
+		rdv:     newRendezvous(),
+		keymap:  km,
+		ready:   make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	nb.store.insert(-1, &fallthroughCell{id: "a"})
+	m := newModel(nb, 40, 24)
+	m.mode = custom
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if !fired {
+		t.Error("custom mode binding for 'x' did not fire")
+	}
+	// Wrong mode: shouldn't fire.
+	fired = false
+	m.mode = SelectMode
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if fired {
+		t.Error("custom mode binding fired in wrong mode")
+	}
+}

--- a/notebook/keys.go
+++ b/notebook/keys.go
@@ -1,0 +1,34 @@
+package notebook
+
+// Canonical key-string constants for use in KeyMap bindings.
+// These match what tea.KeyMsg.String() returns, so they're safe
+// to use as map keys — same lookup as a raw string literal but
+// with autocomplete + spelling safety.
+//
+// Apps can still pass raw strings for combos not listed here
+// (e.g. "ctrl+alt+f4", "alt+shift+page"). The constants cover the
+// common cases; anything tea.KeyMsg can stringify works as a
+// binding key.
+const (
+	KeyEnter    = "enter"
+	KeyEsc      = "esc"
+	KeySpace    = " "
+	KeyTab      = "tab"
+	KeyShiftTab = "shift+tab"
+	KeyUp       = "up"
+	KeyDown     = "down"
+	KeyLeft     = "left"
+	KeyRight    = "right"
+	KeyHome     = "home"
+	KeyEnd      = "end"
+	KeyPgUp     = "pgup"
+	KeyPgDown   = "pgdown"
+	KeyBackspace = "backspace"
+	KeyDelete   = "delete"
+	KeyInsert   = "insert"
+	KeyCtrlC    = "ctrl+c"
+	KeyCtrlD    = "ctrl+d"
+	KeyCtrlZ    = "ctrl+z"
+	KeyCtrlR    = "ctrl+r"
+	KeyCtrlL    = "ctrl+l"
+)

--- a/notebook/messages.go
+++ b/notebook/messages.go
@@ -50,7 +50,31 @@ func CellAdvance() tea.Msg { return CellAdvanceMsg{} }
 // submits a valid answer set. The notebook routes it to the
 // pending AwaitInput call by CellID. Answers maps each input's
 // Name to its parsed value.
+//
+// Unlike CellAdvanceMsg, the notebook does NOT auto-move the
+// cursor on receipt — the caller (typically the AwaitInput
+// awaiter goroutine) decides what cursor / focus state should
+// follow a successful submit.
 type PromptSubmittedMsg struct {
 	CellID  string
 	Answers map[string]any
+}
+
+// ReleaseFocusMsg signals that a focused cell wants to give focus
+// back to the notebook (drop to SelectMode) without advancing the
+// cursor. Built-in cells emit it on Esc by convention; custom
+// cells decide their own release semantics.
+type ReleaseFocusMsg struct{}
+
+// ReleaseFocus is the tea.Cmd that emits ReleaseFocusMsg. Return
+// it from Cell.Update when the cell wants to exit ViewMode but
+// keep the cursor where it is.
+func ReleaseFocus() tea.Msg { return ReleaseFocusMsg{} }
+
+// setModeMsg is the internal msg used by NotebookActions and
+// AwaitInput to change the current Mode from outside the model.
+// Apps don't construct it directly — they call nb.SetMode(m) or
+// use a built-in Action like notebook.SetMode(m).
+type setModeMsg struct {
+	mode Mode
 }

--- a/notebook/model.go
+++ b/notebook/model.go
@@ -31,31 +31,27 @@ type snapshotMsg struct {
 // header live in the shared store; the model owns only the
 // BT-goroutine-local viewport, size, and mode.
 type model struct {
-	store          *store
-	rdv            *rendezvous
+	nb             *Notebook
 	viewportOffset int
 	width          int
 	height         int
 	mode           Mode
-	ready          chan struct{}
 }
 
-func newModel(s *store, rdv *rendezvous, ready chan struct{}, width, height int) model {
+func newModel(nb *Notebook, width, height int) model {
 	return model{
-		store:  s,
-		rdv:    rdv,
+		nb:     nb,
 		mode:   SelectMode,
 		width:  width,
 		height: height,
-		ready:  ready,
 	}
 }
 
-// Init implements tea.Model. The first batched cmd closes ready
-// once the program loop is live — Snapshot waits on it before
-// issuing a Send.
+// Init implements tea.Model. The first batched cmd closes the
+// ready channel once the program loop is live — Snapshot waits on
+// it before issuing a Send.
 func (m model) Init() tea.Cmd {
-	ready := m.ready
+	ready := m.nb.ready
 	return tea.Batch(
 		func() tea.Msg { close(ready); return nil },
 		repaintTick(),
@@ -77,94 +73,81 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ensureCursorVisible()
 		msg.reply <- m.View()
 		return m, nil
+	case setModeMsg:
+		m.mode = msg.mode
+		return m, nil
+	case ReleaseFocusMsg:
+		m.mode = SelectMode
+		return m, nil
 	case CellAdvanceMsg:
 		m.mode = SelectMode
-		m.store.moveCursor(+1)
+		m.nb.store.moveCursor(+1)
 		m.ensureCursorVisible()
 		return m, nil
 	case PromptSubmittedMsg:
-		// The PromptCell already updated itself; the model just
-		// resolves the pending AwaitInputBy and moves on like any
-		// other "this cell is done" event.
-		if m.rdv != nil {
-			m.rdv.resolveInput(msg.CellID, msg.Answers, "user-submitted")
+		// Resolve the pending AwaitInputBy (if any) and exit
+		// ViewMode. Cursor is NOT moved — the caller (typically
+		// the awaiter goroutine) decides what cursor position
+		// follows a successful submit.
+		if m.nb.rdv != nil {
+			m.nb.rdv.resolveInput(msg.CellID, msg.Answers, "user-submitted")
 		}
 		m.mode = SelectMode
-		m.store.moveCursor(+1)
-		m.ensureCursorVisible()
 		return m, nil
 	case ClearCopyMsg:
-		return m, m.routeToCell(msg.CellID, msg)
+		cmd, _ := m.routeToCell(msg.CellID, msg)
+		return m, cmd
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
 	return m, nil
 }
 
-// handleKey routes a keystroke. Global quit keys first, then
-// mode-specific navigation, then the focused cell. A cell sees
-// the key in both modes (so 'c'-copy works while navigating); the
-// cell itself gates behavior on mode.
+// handleKey routes a keystroke cell-first. The cursor cell sees
+// every key via cell.Update before the notebook tries its KeyMap.
+// If the cell returns handled=true the notebook stops; otherwise
+// the notebook looks the key up in Global then current-mode
+// bindings.
+//
+// The rare cell-cmd-with-handled=false case is honored: if the
+// cell returned a side-effect cmd AND a KeyMap action also fires,
+// the action's cmd takes precedence (cell's cmd is dropped). If
+// only one fires, that one's cmd is used.
 func (m model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch key.String() {
-	case "ctrl+c", "q":
-		return m, tea.Quit
+	cellCmd, handled := m.routeKeyToCursor(key)
+	if handled {
+		return m, cellCmd
 	}
-	if m.mode == SelectMode {
-		switch key.String() {
-		case "up", "k":
-			m.store.moveCursor(-1)
-			m.ensureCursorVisible()
-			return m, nil
-		case "down", "j":
-			m.store.moveCursor(+1)
-			m.ensureCursorVisible()
-			return m, nil
-		case "s", "f":
-			if m.store.count() > 0 {
-				m.mode = ViewMode
-			}
-			return m, nil
-		case "enter", " ":
-			// Resolve a pending AwaitAdvance, if any. If no
-			// advance is pending, Enter is a no-op in SelectMode.
-			if m.rdv != nil {
-				m.rdv.resolveAdvance("user-enter")
-			}
-			return m, nil
-		}
-		// Fall through: route other keys (notably 'c') to the
-		// focused cell even in SelectMode.
-		return m, m.routeKeyToCursor(key)
+	if action := m.nb.keymap.lookup(m.mode, key.String()); action != nil {
+		return m, action(m.nb)
 	}
-	// ViewMode.
-	if key.String() == "esc" {
-		m.mode = SelectMode
-		return m, nil
-	}
-	return m, m.routeKeyToCursor(key)
+	return m, cellCmd
 }
 
-// routeKeyToCursor delivers a key to the focused cell, applying
-// any cell mutation in place via store.update.
-func (m model) routeKeyToCursor(key tea.KeyMsg) tea.Cmd {
-	snap := m.store.snapshot()
+// routeKeyToCursor delivers a key to the focused cell. Returns
+// the cell's cmd and handled flag; (nil, false) when there's no
+// cell to route to.
+func (m model) routeKeyToCursor(key tea.KeyMsg) (tea.Cmd, bool) {
+	snap := m.nb.store.snapshot()
 	if snap.cursor < 0 || snap.cursor >= len(snap.cells) {
-		return nil
+		return nil, false
 	}
 	return m.routeToCell(snap.cells[snap.cursor].ID(), key)
 }
 
-// routeToCell delivers a message to the cell with the given ID
-// and writes the (possibly new) cell back into the store.
-func (m model) routeToCell(id CellID, msg tea.Msg) tea.Cmd {
+// routeToCell delivers a msg to the cell with the given ID,
+// writes the (possibly new) cell back into the store, and returns
+// the cell's cmd and handled flag.
+func (m model) routeToCell(id CellID, msg tea.Msg) (tea.Cmd, bool) {
 	var cmd tea.Cmd
-	m.store.update(id, func(c Cell) Cell {
-		updated, c2 := c.Update(msg, m.mode)
+	var handled bool
+	m.nb.store.update(id, func(c Cell) Cell {
+		updated, c2, h := c.Update(msg, m.mode)
 		cmd = c2
+		handled = h
 		return updated
 	})
-	return cmd
+	return cmd, handled
 }
 
 // View implements tea.Model. Range-based render: each cell is
@@ -173,7 +156,7 @@ func (m model) View() string {
 	if m.width == 0 || m.height == 0 {
 		return ""
 	}
-	snap := m.store.snapshot()
+	snap := m.nb.store.snapshot()
 
 	var lines []string
 	if snap.header != "" {
@@ -238,9 +221,9 @@ func (m model) statusLine(snap snapshot) string {
 // minus the status row and (if present) the header row.
 func (m model) bodyHeight() int {
 	reserved := 1 // status row
-	m.store.mu.RLock()
-	hasHeader := m.store.header != ""
-	m.store.mu.RUnlock()
+	m.nb.store.mu.RLock()
+	hasHeader := m.nb.store.header != ""
+	m.nb.store.mu.RUnlock()
 	if hasHeader {
 		reserved++
 	}
@@ -270,7 +253,7 @@ func (m *model) ensureCursorVisible() {
 	if m.width == 0 || m.height == 0 {
 		return
 	}
-	snap := m.store.snapshot()
+	snap := m.nb.store.snapshot()
 	if len(snap.cells) == 0 {
 		m.viewportOffset = 0
 		return

--- a/notebook/notebook.go
+++ b/notebook/notebook.go
@@ -29,6 +29,7 @@ type Notebook struct {
 	clip          Clipboard
 	rdv           *rendezvous
 	promptFactory PromptFactory
+	keymap        KeyMap
 
 	ready   chan struct{}
 	stopped chan struct{}
@@ -49,6 +50,7 @@ type notebookOpts struct {
 	height        int
 	clip          Clipboard
 	promptFactory PromptFactory
+	keymap        *KeyMap // nil = DefaultKeyMap
 }
 
 // WithHeadless runs the Bubble Tea program against a blocking
@@ -84,6 +86,13 @@ func WithPromptFactory(f PromptFactory) Option {
 	return func(o *notebookOpts) { o.promptFactory = f }
 }
 
+// WithKeyMap overrides the notebook-level key bindings. Without
+// it, DefaultKeyMap is used. Apps can start from the default and
+// extend, or define a completely custom map.
+func WithKeyMap(km KeyMap) Option {
+	return func(o *notebookOpts) { o.keymap = &km }
+}
+
 // New constructs a Notebook. The Bubble Tea program is wired up
 // but not started; call Run to start it (Run blocks).
 func New(opts ...Option) *Notebook {
@@ -95,11 +104,15 @@ func New(opts ...Option) *Notebook {
 		cfg.clip = NoClipboard
 	}
 
+	km := DefaultKeyMap()
+	if cfg.keymap != nil {
+		km = *cfg.keymap
+	}
+
 	st := newStore()
 	ready := make(chan struct{})
 	stopped := make(chan struct{})
 	rdv := newRendezvous()
-	m := newModel(st, rdv, ready, cfg.width, cfg.height)
 
 	progOpts := []tea.ProgramOption{}
 	nb := &Notebook{
@@ -107,9 +120,11 @@ func New(opts ...Option) *Notebook {
 		clip:          cfg.clip,
 		rdv:           rdv,
 		promptFactory: cfg.promptFactory,
+		keymap:        km,
 		ready:         ready,
 		stopped:       stopped,
 	}
+	m := newModel(nb, cfg.width, cfg.height)
 	if cfg.headless {
 		nb.blockIn = newBlockingReader()
 		progOpts = append(progOpts,
@@ -137,9 +152,15 @@ func (nb *Notebook) Run() error {
 	return err
 }
 
+// SetMode requests a mode change. Safe to call from any
+// goroutine — internally Sends a tea.Msg that the model applies.
+func (nb *Notebook) SetMode(m Mode) {
+	nb.program.Send(setModeMsg{mode: m})
+}
+
 // Stop signals the program to quit and drains any pending
-// AwaitAdvance / AwaitInput callers with Source: "cancelled".
-// Run returns shortly after. Idempotent.
+// AwaitInput callers with Source: "cancelled". Run returns
+// shortly after. Idempotent.
 func (nb *Notebook) Stop() {
 	nb.stopOnce.Do(func() {
 		close(nb.stopped)

--- a/notebook/notebook_test.go
+++ b/notebook/notebook_test.go
@@ -49,10 +49,14 @@ func (c *testCell) RenderRows(width, startRow, endRow int, focused bool, _ Mode)
 	return rows[startRow:endRow]
 }
 
-func (c *testCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd) {
+func (c *testCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd, bool) {
 	c.lastMode = mode
 	c.updates++
-	return c, nil
+	// Default: passthrough so KeyMap navigation still fires for
+	// nav keys. Tests that need the cell to claim a key can use
+	// a custom cell or assert on `updates` (which counts every
+	// dispatch regardless of handled).
+	return c, nil, false
 }
 
 // --- CRUD ---
@@ -245,13 +249,19 @@ func TestStopUnblocksRun(t *testing.T) {
 // --- Viewport (model-level, no program needed) ---
 
 // newSizedModel constructs a model with a sized store for
-// viewport tests. Returns the model and a function that swaps in
-// fresh cells.
+// viewport tests. Wires up the minimum scaffolding (a Notebook
+// with store + rendezvous + DefaultKeyMap, no tea.Program).
 func newSizedModel(t *testing.T, width, height int) (*model, *store) {
 	t.Helper()
-	st := newStore()
-	m := newModel(st, newRendezvous(), make(chan struct{}), width, height)
-	return &m, st
+	nb := &Notebook{
+		store:   newStore(),
+		rdv:     newRendezvous(),
+		keymap:  DefaultKeyMap(),
+		ready:   make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	m := newModel(nb, width, height)
+	return &m, nb.store
 }
 
 func TestEnsureCursorVisibleScrollsDownToFocused(t *testing.T) {

--- a/notebook/rendezvous.go
+++ b/notebook/rendezvous.go
@@ -5,17 +5,6 @@ import (
 	"time"
 )
 
-// AdvanceResponse is what AwaitAdvance returns.
-//
-// Source classifies how the wait ended:
-//   - "user-enter": the user pressed Enter in SelectMode.
-//   - "auto-advance": the deadline fired before any user input.
-//   - "cancelled": Stop was called while the wait was pending.
-type AdvanceResponse struct {
-	Source string
-	At     time.Time
-}
-
 // InputResponse is what AwaitInput / AwaitInputBy returns.
 //
 // Source classifies how the wait ended:
@@ -28,64 +17,21 @@ type InputResponse struct {
 	At      time.Time
 }
 
-// rendezvous registers pending AwaitAdvance / AwaitInput calls.
-// The model resolves them when the user advances or a PromptCell
-// submits; Stop drains them with Source: "cancelled" so no caller
-// goroutine is left blocked.
+// rendezvous registers pending AwaitInput / AwaitInputBy calls.
+// The model resolves them when a PromptCell submits; Stop drains
+// them with Source: "cancelled" so no caller goroutine is left
+// blocked.
 //
-// All channels are buffered cap 1 so resolveX never blocks even
-// if the awaiter has already returned via a different select arm
-// (e.g. deadline timer fired first).
+// All channels are buffered cap 1 so resolveInput never blocks
+// even if the awaiter has already returned via a different select
+// arm (e.g. <-stopped).
 type rendezvous struct {
-	mu       sync.Mutex
-	advances []chan AdvanceResponse
-	inputs   map[CellID]chan InputResponse
+	mu     sync.Mutex
+	inputs map[CellID]chan InputResponse
 }
 
 func newRendezvous() *rendezvous {
 	return &rendezvous{inputs: map[CellID]chan InputResponse{}}
-}
-
-// registerAdvance enrols a new pending advance and returns its
-// resolution channel. FIFO: resolveAdvance pops the first.
-func (r *rendezvous) registerAdvance() chan AdvanceResponse {
-	ch := make(chan AdvanceResponse, 1)
-	r.mu.Lock()
-	r.advances = append(r.advances, ch)
-	r.mu.Unlock()
-	return ch
-}
-
-// removeAdvance unenrols ch (used when the deadline timer fired
-// or Stop closed the global stop channel before any user advance).
-func (r *rendezvous) removeAdvance(ch chan AdvanceResponse) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for i, w := range r.advances {
-		if w == ch {
-			r.advances = append(r.advances[:i], r.advances[i+1:]...)
-			return
-		}
-	}
-}
-
-// resolveAdvance hands the next pending awaiter its response.
-// Returns true if there was one to resolve. Send is non-blocking
-// because the chan is buffered cap 1.
-func (r *rendezvous) resolveAdvance(source string) bool {
-	r.mu.Lock()
-	if len(r.advances) == 0 {
-		r.mu.Unlock()
-		return false
-	}
-	ch := r.advances[0]
-	r.advances = r.advances[1:]
-	r.mu.Unlock()
-	select {
-	case ch <- AdvanceResponse{Source: source, At: time.Now()}:
-	default:
-	}
-	return true
 }
 
 // registerInput enrols a waiter keyed by the prompt cell's ID.
@@ -122,22 +68,14 @@ func (r *rendezvous) resolveInput(id CellID, answers map[string]any, source stri
 	return true
 }
 
-// cancelAll resolves every pending advance and input with
+// cancelAll resolves every pending input waiter with
 // Source: "cancelled". Called from Stop.
 func (r *rendezvous) cancelAll() {
 	r.mu.Lock()
-	advances := r.advances
-	r.advances = nil
 	inputs := r.inputs
 	r.inputs = map[CellID]chan InputResponse{}
 	r.mu.Unlock()
 
-	for _, ch := range advances {
-		select {
-		case ch <- AdvanceResponse{Source: "cancelled", At: time.Now()}:
-		default:
-		}
-	}
 	for _, ch := range inputs {
 		select {
 		case ch <- InputResponse{Source: "cancelled", At: time.Now()}:
@@ -147,32 +85,6 @@ func (r *rendezvous) cancelAll() {
 }
 
 // --- Notebook public API ---
-
-// AwaitAdvance blocks until the user advances (Enter in
-// SelectMode), the deadline fires, or Stop is called.
-//
-// A zero deadline (time.Time{}) means no auto-advance — the call
-// blocks until a user advance or Stop. Otherwise the call returns
-// with Source: "auto-advance" when the deadline elapses.
-func (nb *Notebook) AwaitAdvance(deadline time.Time) AdvanceResponse {
-	ch := nb.rdv.registerAdvance()
-	var timerC <-chan time.Time
-	if !deadline.IsZero() {
-		t := time.NewTimer(time.Until(deadline))
-		defer t.Stop()
-		timerC = t.C
-	}
-	select {
-	case resp := <-ch:
-		return resp
-	case <-timerC:
-		nb.rdv.removeAdvance(ch)
-		return AdvanceResponse{Source: "auto-advance", At: time.Now()}
-	case <-nb.stopped:
-		nb.rdv.removeAdvance(ch)
-		return AdvanceResponse{Source: "cancelled", At: time.Now()}
-	}
-}
 
 // AwaitInputBy blocks until the cell with cellID emits a
 // PromptSubmittedMsg, the cell is Removed, or Stop is called.

--- a/notebook/store.go
+++ b/notebook/store.go
@@ -153,6 +153,14 @@ func (s *store) moveCursor(delta int) {
 	s.clampCursorLocked()
 }
 
+// setCursorByIdx sets the cursor to an absolute index, clamped.
+func (s *store) setCursorByIdx(idx int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cursor = idx
+	s.clampCursorLocked()
+}
+
 func (s *store) cursorPos() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
Slice A of the focus / key-management refactor. The architectural shift: notebook routes every key to the cursor cell first (cell.Update returns `handled bool`); only if the cell passes through does the notebook try its `KeyMap`. Modes are app-defined (`NewMode("CUSTOM")`); bindings are per-mode. `AwaitAdvance` is removed — that's a demokit concept, not a notebook one.

Slice B (next PR): `FocusCell` / `SetCursor` / `AwaitInput` auto-focus + mathrepl eval fix + `OutputCell.SetMaxBody`. Slice A is the API shape; Slice B is the UX wiring on top.

## What changes

- **Cell.Update signature**: now returns `(Cell, tea.Cmd, bool)`. `handled=true` stops the notebook; `handled=false` lets the notebook try its KeyMap. The "rare case" `handled=false + cmd!=nil` is honored.
- **`KeyMap` + `Action` + `WithKeyMap`**: app-configurable bindings. `Action = func(*Notebook) tea.Cmd` so bindings can read/mutate notebook state. `DefaultKeyMap` ships canonical bindings; apps override.
- **Arbitrary modes**: `Mode` is opaque; `NewMode("X")` for custom; `SelectMode` / `ViewMode` ship as defaults. Bindings live in `KeyMap.Modes[mode]`.
- **`ReleaseFocus` cmd / `ReleaseFocusMsg`**: cells emit to drop to SelectMode without advancing the cursor (Esc convention). `CellAdvance` still releases AND advances.
- **`PromptSubmittedMsg`** no longer auto-moves the cursor (Slice B's `AwaitInput` will manage focus instead — the cursor-stuck-on-old-prompt bug from mathrepl gets fully fixed in Slice B).
- **`AwaitAdvance` removed**: `AdvanceResponse`, advance channels, `AwaitAdvance` method, and the Enter-resolves-advance code in model.go are deleted. Walkthrough consumers will use `AwaitInput([])` (an empty-input prompt) or a custom advance cell when phase 4 wires the demokit bridge.
- **`notebook.Key*` constants**: `KeyEnter`/`KeyEsc`/`KeyCtrlC`/etc. — spelling-safe binding keys. Apps can still pass raw strings for combos not in the constant set.

## Reviewer's guide

Read in this order:

1. [notebook/cell.go](https://github.com/panyam/demokit/pull/31/files#diff-58467d95ab70136413e1529e553324e2f46e59792ef2e7996d8c54e356b2aee5) — start here. The new 3-value `Update` signature + the contract for `handled`.
2. [notebook/keymap.go](https://github.com/panyam/demokit/pull/31/files#diff-66ef16dae7adebc7c018b36584c8676f87117cd651c5139be05bfaf1c5392c96) — `KeyMap`, `Action`, `DefaultKeyMap`, the built-in actions (Quit/NavUp/NavDown/EnterFocus/ExitFocus/SetMode). `lookup` is Global-then-mode.
3. [notebook/model.go](https://github.com/panyam/demokit/pull/31/files#diff-0d92338ba7adb1172045fae5f90be027b051e1302375bb8712fb50d02426fcb8) — `handleKey` rewrite. Cell first, then KeyMap. Note `routeToCell` returns `(cmd, handled)`.
4. [notebook/messages.go](https://github.com/panyam/demokit/pull/31/files#diff-8a36622340a8c34ca99f6e98a52154e05f5edb002c4231ceecf2982c3c0c1af1) — `ReleaseFocusMsg`/`ReleaseFocus`, `setModeMsg`. Note the comment on `PromptSubmittedMsg` about not auto-moving the cursor.
5. `notebook/cells/*.go` — five built-in cells, all updated. Esc → `ReleaseFocus` is the convention; cells passthrough anything they don't claim.
6. [notebook/keymap_test.go](https://github.com/panyam/demokit/pull/31/files#diff-18d10ba35c9636eb3f7e0f2c149c1aba95d8e04da91b373e9fe5b516158de5ec) — acceptance for KeyMap lookup, cell-first dispatch, handled-true suppression, ReleaseFocus, custom modes, default-doesn't-bind-q.
7. [notebook/rendezvous.go](https://github.com/panyam/demokit/pull/31/files#diff-d669687516b18fbcc53cf3579ad0a92e03d385c06a20175945b8ad250a76fb02) — the deletion side: AwaitAdvance + AdvanceResponse + advance channels are gone; only InputResponse / AwaitInputBy / AwaitInput remain.

Skim: [notebook/keys.go](https://github.com/panyam/demokit/pull/31/files#diff-f9bad27791c38791a6ce23b03a9fbfcebc0de7ab537d6a7c9a4df4e2d82f72cd) (constants block), `notebook/cells/{header,note,output,verbatim,prompt}.go` (mechanical signature changes), test files for deletions.

## Diff groups

- **Production**: `cell.go`, `keymap.go`, `keys.go`, `messages.go`, `model.go`, `notebook.go`, `rendezvous.go` (deletions), `cells/*.go`
- **Tests**: `keymap_test.go` (new), `notebook_test.go` (testCell signature + helper rewrite), `concurrent_test.go` (deletions), `cells/prompt_test.go` (signature)

## Decision log

- **Cell-first, not notebook-first**. The cell owns its keystrokes when focused; even Esc and Ctrl+C flow through it. The notebook's only unconditional behavior is "ask the cell." Apps can build cells that count Esc presses, intercept Ctrl+C, etc.
- **3-value return, not a tea.Msg round-trip sentinel**. Sync dispatch; no async lag accumulating. The cost is a public Cell signature change, but the notebook is pre-1.0 and no external consumers exist.
- **`Action = func(*Notebook) tea.Cmd`**, not a tagged enum. Apps can write arbitrary Actions; built-in Actions are exported (Quit/NavUp/NavDown/EnterFocus/ExitFocus/SetMode). The `*Notebook` argument gives Actions access to store + mutation methods.
- **Mode mutations go via `setModeMsg`**. `SetMode(m)` Sends rather than mutating directly because mode lives on the model (BT goroutine only). Built-in EnterFocus / SetMode actions return cmds that emit setModeMsg.
- **Drop `q` from default Quit bindings**. q is a printable character a cell might want (textinput, search, etc.). Apps that want q-to-quit add it explicitly via `WithKeyMap`. Ctrl+C is the universal-quit convention.
- **Mode is opaque (`NewMode`)** rather than a string. Two `NewMode("X")` calls produce distinct values — Mode is identity-compared. Naming-collision bugs become "this binding never fires" rather than "this binding silently shadows another."

## Risk / blast radius

- The Cell signature change affects every existing Cell implementation. Built-ins updated in this PR; mathrepl's `ResultCell` + `PlotCell` will rebase against this and update in Slice B.
- `AwaitAdvance` is removed — public API deletion. No existing consumer uses it (phase 3b just landed; no bridge; mathrepl doesn't use it).
- `PromptSubmittedMsg` no longer moves the cursor. mathrepl's behavior is unchanged in practice (the old auto-cursor-move was a no-op there — clamped at end). Slice B's `AwaitInput` auto-focus is the real fix.
- `make testall` green; `go test -race` within the notebook module green. Other modules (demokit / tui / web / tui-notebook) unchanged.

## Out of scope (Slice B)

- `nb.FocusCell(id)` / `nb.SetCursor(id)` / `nb.FocusedCell()` accessors
- `AwaitInput` auto-`FocusCell` on the new prompt cell — fully fixes the mathrepl cursor bug
- `OutputCell.SetMaxBody` / `MaxBody` for app-defined resize bindings
- mathrepl: `expr.Compile` for strict undefined-name handling
