### PR TITLE
feat(notebook): DockedCells for chrome (Top/Bottom/After/Before) + CommandCell

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,21 +281,23 @@ demokit/                              module github.com/panyam/demokit
 
 | File | Responsibility |
 |---|---|
-| `notebook.go` | `Notebook` struct, `New`, `Run`, `Stop`, options (`WithKeyMap`, `WithMouseConfig`, `WithClipboard`, `WithPromptFactory`, `WithHeadless`, `WithSize`), `Snapshot` |
+| `notebook.go` | `Notebook` struct, `New`, `Run`, `Stop`, options (`WithKeyMap`, `WithMouseConfig`, `WithClipboard`, `WithPromptFactory`, `WithHeadless`, `WithSize`), `Snapshot`, dock CRUD (`SetDockedCell` / `ClearDocked` / `DockedCell` / `UpdateDocked`), `FocusDock` / `ReleaseDockFocus` |
 | `mouse.go` | `MouseConfig`, `MouseContext`, `MouseHandler`, `ClickActivate` / `ClickCursorOnly` / `WheelNavCursor` / `DefaultOnClick`, `DefaultMouseConfig` |
-| `model.go` | `tea.Model` — viewport, mode, key & mouse dispatch, render |
-| `store.go` | `store` — shared RWMutex-guarded cells + cursor + header |
+| `model.go` | `tea.Model` — viewport, mode, key & mouse dispatch, render, dock-aware layout (`edgeAllotments`, `bodyHeight`, `anchoredRowSpan`) |
+| `store.go` | `store` — shared RWMutex-guarded cells + cursor + header + docked-cell registry |
 | `crud.go` | `Append` / `Insert` / `Update` / `Remove` / `Get` / `IndexOf` / `Len` / `SetCursor` / `FocusCell` / `SetHeader` / `SetDone` |
+| `dock.go` | `Position` interface, `Top` / `Bottom` edges, `After(id)` / `Before(id)` cell-anchored positions, internal `positionKey` |
+| `status_cell.go` | Built-in `StatusCell` — the default Bottom dock, reproduces the legacy "MODE  cell N/M" line |
 | `rendezvous.go` | `AwaitInput` / `AwaitInputBy` (blocking primitives) + `InputResponse` |
 | `stream.go` | `Stream(id) io.Writer` over a cell's `OutputBuffer` |
-| `keymap.go` | `KeyMap`, `Action`, built-in actions (`Quit` / `NavUp` / `NavDown` / `EnterFocus` / `ExitFocus` / `SetMode`), `DefaultKeyMap` |
+| `keymap.go` | `KeyMap`, `Action`, built-in actions (`Quit` / `NavUp` / `NavDown` / `EnterFocus` / `ExitFocus` / `SetMode` / `FocusDock` / `ToggleBottomDockFocus`), `DefaultKeyMap` |
 | `keys.go` | `KeyEnter` / `KeyEsc` / `KeyCtrlC` / ... — canonical key-string constants |
 | `clipboard.go` | `Clipboard` type, `NoClipboard`, `OSC52Clipboard` (terminal-escape-based), `FileClipboard(dir)` (tmp-file fallback) |
 | `messages.go` | `ClearCopyMsg`, `CellAdvanceMsg`, `PromptSubmittedMsg`, `ReleaseFocusMsg`, `setModeMsg` + helpers |
 | `cell.go` | `Cell` interface, `Mode` interface, `NewMode`, `NavigationMode` / `CellActiveMode` |
 | `input.go` | `Input` interface + `StringInput` / `IntInput` / `ChoiceInput` |
 | `output_buffer.go` | `OutputBuffer` (line-indexed, RWMutex-guarded, `io.Writer`) |
-| `cells/` | `HeaderCell`, `NoteCell`, `VerbatimCell`, `OutputCell`, `PromptCell` + per-cell `*Style` types + `Theme` aggregator |
+| `cells/` | `HeaderCell`, `NoteCell`, `VerbatimCell`, `OutputCell`, `PromptCell`, `CommandCell` (+ `OpenCommandBar` helper) + per-cell `*Style` types + `Theme` aggregator |
 
 ### Cell-first key dispatch
 
@@ -339,6 +341,35 @@ Mouse routing follows the same shape as keys: cells see wheel events first (cell
 - Release events are ignored
 
 Mouse is intentionally **NOT** routed cell-first: clicks are geometric (the Y identifies the target, which may not be the focused cell), so the notebook owns dispatch. Future per-cell mouse handling (textinput cursor positioning, clicking verbatim-cell variant tabs) can hook in at `cellAtRow` before the navigation fallback.
+
+### Docked cells
+
+The notebook ships positioned cell slots for chrome that lives outside the cursor-navigable main list: vim-style command bars, status rows, breadcrumbs, per-cell annotations. Same `Cell` interface, separate registry.
+
+**Positions (v1):**
+
+| Family | Examples | Layout |
+|---|---|---|
+| Edges | `Top`, `Bottom` | Viewport-pinned chrome above / below the body. Claim layout space; body shrinks by that many rows. |
+| Cell-anchored | `After(id)`, `Before(id)` | Annotations that travel with a main cell. Render adjacent to the anchor in the body flow; scroll with it. Auto-unregister when `Remove(id)` fires on the anchor. |
+
+`Left` / `Right` and a floating overlay layer are deferred to a v2 PR — column-split rendering and a Z-order engine are out of scope for the issue 36 ship.
+
+**One Cell per Position.** `SetDockedCell` replaces any prior occupant at the same position. Apps composing richer chrome put multiple lines into a single Cell that knows how to render multiple regions.
+
+**Architectural commitment:** docks live in their own registry, NOT in `cells[]`. The invariant `cells[N] is the N-th cursor-navigable cell` holds; main-list iteration is dock-free. The model walks dock keys explicitly in `View`, `cellRowSpan`, `cellAtRow`, and `edgeAllotments`.
+
+**Default Bottom dock = `StatusCell`.** `New()` auto-installs a built-in `StatusCell` at `Bottom` that renders the legacy "MODE  cell N/M" line. Apps replace it with `SetDockedCell(Bottom, custom)` and can restore it via `SetDockedCell(Bottom, NewStatusCell(nb))`. `ClearDocked(Bottom)` truly empties — no auto-restore.
+
+**Focus model.** Docked cells receive keystrokes when they're the focus target. Tracking is one `atomic.Pointer[positionKey]` on the notebook: nil = main list focused, set = that dock is focused. `FocusDock(pos)` / `ReleaseDockFocus()` are the goroutine-safe entry points; `ToggleBottomDockFocus` is the default `Ctrl+W` binding (vim/tmux-style window-switch shortcut). When a docked cell emits `ReleaseFocusMsg` (the standard Esc convention), the model clears the dock-focus pointer AND drops to `NavigationMode` — symmetric to how main cells release.
+
+The `safeSend` helper guards mode-change Sends on dock APIs: when the BT program isn't running yet (tests, setup-before-Run paths), Sends are dropped instead of deadlocking on the unbuffered `tea.Program.Send`. Store mutations (the dock registry itself) remain Send-free and pick up via the repaint tick.
+
+**Auto-grow + clamp + tail rendering.** Edge docks report a desired height via `HeightHint(width)` that can grow with content (a `CommandCell` wraps as you type). `edgeAllotments` enforces "body always has at least 1 row" by yielding rows from Bottom first, then Top. When a dock is clamped below its desired height, `View` renders the **tail** for `Bottom` (where the command cursor lives) and the **head** for `Top` (logo / breadcrumb reads left-to-right, top-first).
+
+**Cell-anchored interleaving.** `Before(id)` and `After(id)` participate in body row math: `cellRowSpan` includes the `Before` height in the cursor's row span (so scrolling brings both into view) and skips `After` rows from the cursor span (they trail). Clicks on anchored-dock rows resolve to the anchor cell — they're not cursor-targetable, matching the "one cursor" principle.
+
+**`OpenCommandBar` convenience (`cells` package).** Apps that want a vim-style `:command` bar wire it in one line: bind their trigger key to `cells.OpenCommandBar(nb, ":", onSubmit)`. The helper snapshots the current Bottom occupant, installs a `CommandCell`, focuses the dock, and on Enter / Esc restores the **same instance** that was there before — so a stateful status bar keeps its state across the show/hide cycle. The trigger key is entirely app policy; the framework ships no opinion about which key opens which dock.
 
 ### Snapshot for headless tests
 

--- a/notebook/cells/command.go
+++ b/notebook/cells/command.go
@@ -1,0 +1,283 @@
+package cells
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// CommandStyle is CommandCell's per-cell styling. A vim-style
+// command bar is single-line, no border — apps that want chrome
+// (border, padding) wrap the cell themselves.
+type CommandStyle struct {
+	PromptColor color.Color
+	TextColor   color.Color
+	CursorColor color.Color
+}
+
+// DarkCommandStyle returns the dark-terminal defaults.
+func DarkCommandStyle() CommandStyle {
+	return CommandStyle{
+		PromptColor: lipgloss.Color("#7D56F4"),
+		TextColor:   lipgloss.Color("#FAFAFA"),
+		CursorColor: lipgloss.Color("#FF6B6B"),
+	}
+}
+
+// LightCommandStyle returns the light-terminal defaults.
+func LightCommandStyle() CommandStyle {
+	return CommandStyle{
+		PromptColor: lipgloss.Color("#5A3FCE"),
+		TextColor:   lipgloss.Color("#1A1A1A"),
+		CursorColor: lipgloss.Color("#D34545"),
+	}
+}
+
+// DefaultCommandStyle returns the package default — Dark.
+func DefaultCommandStyle() CommandStyle { return DarkCommandStyle() }
+
+// CommandCell is a single-line text input designed for vim-style
+// command bars at the Bottom dock. It captures every keystroke
+// while focused: Enter invokes the onSubmit callback with the
+// buffered text and emits notebook.ReleaseFocus; Esc invokes
+// onCancel and emits notebook.ReleaseFocus; Backspace edits the
+// buffer; printable runes append.
+//
+// CommandCell is deliberately framework-agnostic about teardown:
+// it doesn't ClearDocked itself, doesn't restore the default
+// status bar. Apps either do that in onSubmit/onCancel, or use
+// the OpenCommandBar convenience which wraps the full lifecycle.
+type CommandCell struct {
+	Prompt string
+	Style  CommandStyle
+
+	id       string
+	buf      string
+	onSubmit func(string)
+	onCancel func()
+}
+
+// NewCommandCell builds a CommandCell with the given prompt and
+// callbacks. Either callback may be nil — Enter / Esc still
+// release focus but no app code fires.
+//
+// The cell's ID is fixed ("notebook.command") so apps can
+// reference it via nb.DockedCell(notebook.Bottom) without
+// guessing.
+func NewCommandCell(prompt string, onSubmit func(string), onCancel func()) *CommandCell {
+	return &CommandCell{
+		id:       "notebook.command",
+		Prompt:   prompt,
+		Style:    DefaultCommandStyle(),
+		onSubmit: onSubmit,
+		onCancel: onCancel,
+	}
+}
+
+// ID implements notebook.Cell.
+func (c *CommandCell) ID() string { return c.id }
+
+// Text returns the current buffer. Useful for tests and for apps
+// that want to peek at the partial input.
+func (c *CommandCell) Text() string { return c.buf }
+
+// HeightHint implements notebook.Cell. CommandCell auto-grows as
+// the buffer wraps past width: a short ":ls" stays 1 row; a long
+// shell pipeline expands until the dock would crowd the body, at
+// which point the notebook clamps the dock and the cell scrolls
+// to its tail on render.
+//
+// HeightHint factors in the focused-cursor rune so the height
+// doesn't jiggle when focus toggles on/off at a wrap boundary.
+func (c *CommandCell) HeightHint(width int) int {
+	rows := c.wrappedRows(width, true)
+	if len(rows) < 1 {
+		return 1
+	}
+	return len(rows)
+}
+
+// RenderRows implements notebook.Cell. Returns the row window
+// [startRow, endRow). When the docked allotment is smaller than
+// HeightHint, the notebook passes a startRow > 0 — the cell
+// happily yields the head and renders the tail (where the cursor
+// lives) so the user always sees what they're typing.
+func (c *CommandCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
+	rows := c.wrappedRows(width, focused)
+	if len(rows) == 0 {
+		rows = []string{""}
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > len(rows) {
+		endRow = len(rows)
+	}
+	if startRow >= endRow {
+		return nil
+	}
+
+	promptStyle := lipgloss.NewStyle().Foreground(c.Style.PromptColor)
+	textStyle := lipgloss.NewStyle().Foreground(c.Style.TextColor)
+	cursorStyle := lipgloss.NewStyle().Foreground(c.Style.CursorColor)
+	promptRunes := []rune(c.Prompt + " ")
+	promptLen := len(promptRunes)
+	lastIdx := len(rows) - 1
+
+	out := make([]string, 0, endRow-startRow)
+	for i := startRow; i < endRow; i++ {
+		runes := []rune(rows[i])
+		var sb strings.Builder
+		for ri, r := range runes {
+			isCursor := focused && i == lastIdx && ri == len(runes)-1 && r == '█'
+			isPrompt := i == 0 && ri < promptLen
+			switch {
+			case isCursor:
+				sb.WriteString(cursorStyle.Render(string(r)))
+			case isPrompt:
+				sb.WriteString(promptStyle.Render(string(r)))
+			default:
+				sb.WriteString(textStyle.Render(string(r)))
+			}
+		}
+		out = append(out, sb.String())
+	}
+	return out
+}
+
+// wrappedRows returns the buffer (with cursor when focused)
+// wrapped to width-rune chunks. Rune-based so multi-byte UTF-8
+// doesn't split mid-codepoint — column-aware wrapping (full-width
+// CJK, ANSI) is left to a v2 if/when the use case shows up.
+func (c *CommandCell) wrappedRows(width int, focused bool) []string {
+	text := c.Prompt + " " + c.buf
+	if focused {
+		text += "█"
+	}
+	if width <= 0 {
+		return []string{text}
+	}
+	runes := []rune(text)
+	var rows []string
+	for len(runes) > width {
+		rows = append(rows, string(runes[:width]))
+		runes = runes[width:]
+	}
+	if len(runes) > 0 || len(rows) == 0 {
+		rows = append(rows, string(runes))
+	}
+	return rows
+}
+
+// Update implements notebook.Cell. Captures every key while
+// focused — handled=true on every keystroke so notebook KeyMap
+// bindings don't fire underneath it (otherwise typing 'j' in the
+// command buffer would also nav-down).
+//
+// In NavigationMode (cell not focused) the cell ignores keys so
+// global bindings like Ctrl+W still work to focus it.
+func (c *CommandCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return c, nil, false
+	}
+	if mode != notebook.CellActiveMode {
+		return c, nil, false
+	}
+	switch keyMsg.String() {
+	case "enter":
+		text := c.buf
+		c.buf = ""
+		if c.onSubmit != nil {
+			c.onSubmit(text)
+		}
+		return c, notebook.ReleaseFocus, true
+	case "esc":
+		c.buf = ""
+		if c.onCancel != nil {
+			c.onCancel()
+		}
+		return c, notebook.ReleaseFocus, true
+	case "backspace":
+		if len(c.buf) > 0 {
+			// Strip a UTF-8 rune off the end, not a byte.
+			r := []rune(c.buf)
+			c.buf = string(r[:len(r)-1])
+		}
+		return c, nil, true
+	case "ctrl+u":
+		c.buf = ""
+		return c, nil, true
+	}
+	// Printable input — concatenate runes.
+	if len(keyMsg.Runes) > 0 {
+		c.buf += string(keyMsg.Runes)
+		return c, nil, true
+	}
+	// Modifier-only / unhandled control keys: passthrough so global
+	// bindings (Ctrl+C quit) still work.
+	return c, nil, false
+}
+
+// StatusHint implements notebook.Cell.
+func (c *CommandCell) StatusHint(_ notebook.Mode) string {
+	return "Enter run · Esc cancel"
+}
+
+// OpenCommandBar is the one-liner apps use to wire a vim-style
+// command bar. It:
+//
+//  1. Snapshots whatever Cell is currently at Bottom (typically
+//     the default StatusCell or an app's custom status bar).
+//  2. Builds a CommandCell with the given prompt and a cleanup
+//     wrapper that restores the SAME instance on Enter / Esc —
+//     so a stateful status bar keeps its state across the show /
+//     hide cycle (apps that want a fresh instance pre-stash one
+//     and ClearDocked manually).
+//  3. Installs the cell at the Bottom dock and focuses it.
+//
+// Returns the tea.Cmd that flips the notebook into CellActiveMode.
+// Apps using OpenCommandBar from a KeyMap action return the cmd
+// directly:
+//
+//	km := notebook.DefaultKeyMap()
+//	km.Modes[notebook.NavigationMode][":"] = func(nb *notebook.Notebook) tea.Cmd {
+//	    return cells.OpenCommandBar(nb, ":", onColon)
+//	}
+//	nb := notebook.New(notebook.WithKeyMap(km), ...)
+//
+// (Returning the cmd is required for the mode flip to reach the
+// BT loop — Sending from inside the action would deadlock.)
+//
+// onSubmit may be nil to make the bar non-functional (still
+// dismisses on Esc / Enter). onSubmit receives the buffer with
+// trailing whitespace trimmed; leading whitespace is preserved
+// so commands like ":  echo hi" can be inspected as typed.
+func OpenCommandBar(nb *notebook.Notebook, prompt string, onSubmit func(string)) tea.Cmd {
+	prior, hadPrior := nb.DockedCell(notebook.Bottom)
+	restore := func() {
+		if hadPrior {
+			nb.SetDockedCell(notebook.Bottom, prior)
+		} else {
+			nb.ClearDocked(notebook.Bottom)
+		}
+	}
+	cell := NewCommandCell(prompt,
+		func(text string) {
+			if onSubmit != nil {
+				onSubmit(strings.TrimRight(text, " "))
+			}
+			restore()
+		},
+		restore,
+	)
+	nb.SetDockedCell(notebook.Bottom, cell)
+	if !nb.FocusDock(notebook.Bottom) {
+		return nil
+	}
+	return notebook.ModeCmd(notebook.CellActiveMode)
+}

--- a/notebook/cells/command.go
+++ b/notebook/cells/command.go
@@ -180,6 +180,15 @@ func (c *CommandCell) wrappedRows(width int, focused bool) []string {
 //
 // In NavigationMode (cell not focused) the cell ignores keys so
 // global bindings like Ctrl+W still work to focus it.
+//
+// Enter and Esc DON'T invoke the onSubmit / onCancel callbacks
+// directly: those run as a tea.Cmd in a separate goroutine. The
+// indirection is required because Update is invoked under the
+// store's write lock (see store.update / store.updateDock), and a
+// callback that calls back into nb.SetDockedCell — exactly what
+// OpenCommandBar's restore() does — would deadlock the same lock.
+// Returning a Cmd defers the callback until tea processes it,
+// which happens after Update has returned and the lock is free.
 func (c *CommandCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea.Cmd, bool) {
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
@@ -192,16 +201,28 @@ func (c *CommandCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, te
 	case "enter":
 		text := c.buf
 		c.buf = ""
-		if c.onSubmit != nil {
-			c.onSubmit(text)
-		}
-		return c, notebook.ReleaseFocus, true
+		submit := c.onSubmit
+		return c, tea.Batch(
+			func() tea.Msg {
+				if submit != nil {
+					submit(text)
+				}
+				return nil
+			},
+			notebook.ReleaseFocus,
+		), true
 	case "esc":
 		c.buf = ""
-		if c.onCancel != nil {
-			c.onCancel()
-		}
-		return c, notebook.ReleaseFocus, true
+		cancel := c.onCancel
+		return c, tea.Batch(
+			func() tea.Msg {
+				if cancel != nil {
+					cancel()
+				}
+				return nil
+			},
+			notebook.ReleaseFocus,
+		), true
 	case "backspace":
 		if len(c.buf) > 0 {
 			// Strip a UTF-8 rune off the end, not a byte.

--- a/notebook/cells/command_test.go
+++ b/notebook/cells/command_test.go
@@ -1,0 +1,151 @@
+package cells
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// stripAnsi removes ANSI escape sequences from s. Tests assert on
+// rendered text; the per-rune lipgloss styling embeds escape
+// codes that would otherwise split substrings.
+func stripAnsi(s string) string { return ansi.Strip(s) }
+
+func TestCommandCell_ShortInputStaysOneRow(t *testing.T) {
+	c := NewCommandCell(":", nil, nil)
+	c.Update(runesKey("l"), notebook.CellActiveMode)
+	c.Update(runesKey("s"), notebook.CellActiveMode)
+	if got := c.HeightHint(80); got != 1 {
+		t.Errorf("short input HeightHint = %d, want 1", got)
+	}
+	rows := c.RenderRows(80, 0, 1, true, notebook.CellActiveMode)
+	if len(rows) != 1 || !strings.Contains(stripAnsi(rows[0]), "ls") {
+		t.Errorf("RenderRows = %v, want one row containing 'ls'", rows)
+	}
+}
+
+func TestCommandCell_LongInputWrapsAndGrowsHeight(t *testing.T) {
+	c := NewCommandCell("$", nil, nil)
+	// Width 10 → "$ " (2 chars) prefix + buffer + cursor. 25 chars
+	// of buffer pushes past one row at width 10.
+	for _, r := range strings.Repeat("a", 25) {
+		c.Update(runesKey(string(r)), notebook.CellActiveMode)
+	}
+	h := c.HeightHint(10)
+	if h < 3 {
+		t.Errorf("HeightHint(10) = %d, want >=3 for 25-char buffer at width 10", h)
+	}
+	rows := c.RenderRows(10, 0, h, true, notebook.CellActiveMode)
+	if len(rows) != h {
+		t.Errorf("RenderRows returned %d rows, want %d", len(rows), h)
+	}
+}
+
+func TestCommandCell_RenderWindowClippedToTail(t *testing.T) {
+	c := NewCommandCell("$", nil, nil)
+	for _, r := range strings.Repeat("x", 60) {
+		c.Update(runesKey(string(r)), notebook.CellActiveMode)
+	}
+	h := c.HeightHint(10)
+	// Ask for the last 2 rows only — the cell should hand them back.
+	rows := c.RenderRows(10, h-2, h, true, notebook.CellActiveMode)
+	if len(rows) != 2 {
+		t.Fatalf("RenderRows tail = %d rows, want 2", len(rows))
+	}
+}
+
+func TestCommandCell_EnterFiresOnSubmitAndReleases(t *testing.T) {
+	var got string
+	c := NewCommandCell(":", func(s string) { got = s }, nil)
+	c.Update(runesKey("h"), notebook.CellActiveMode)
+	c.Update(runesKey("i"), notebook.CellActiveMode)
+	_, cmd, handled := c.Update(tea.KeyMsg{Type: tea.KeyEnter}, notebook.CellActiveMode)
+	if !handled {
+		t.Error("Enter not handled")
+	}
+	if got != "hi" {
+		t.Errorf("onSubmit received %q, want %q", got, "hi")
+	}
+	if cmd == nil {
+		t.Fatal("Enter returned nil cmd; expected ReleaseFocus")
+	}
+	if _, ok := cmd().(notebook.ReleaseFocusMsg); !ok {
+		t.Errorf("Enter cmd = %T, want ReleaseFocusMsg", cmd())
+	}
+}
+
+func TestCommandCell_EscFiresOnCancelAndReleases(t *testing.T) {
+	cancelled := false
+	c := NewCommandCell(":", nil, func() { cancelled = true })
+	c.Update(runesKey("x"), notebook.CellActiveMode)
+	_, cmd, handled := c.Update(tea.KeyMsg{Type: tea.KeyEsc}, notebook.CellActiveMode)
+	if !handled {
+		t.Error("Esc not handled")
+	}
+	if !cancelled {
+		t.Error("onCancel not fired on Esc")
+	}
+	if _, ok := cmd().(notebook.ReleaseFocusMsg); !ok {
+		t.Errorf("Esc cmd = %T, want ReleaseFocusMsg", cmd())
+	}
+	if c.Text() != "" {
+		t.Errorf("buffer not cleared on Esc: %q", c.Text())
+	}
+}
+
+func TestCommandCell_BackspaceTrimsLastRune(t *testing.T) {
+	c := NewCommandCell(":", nil, nil)
+	c.Update(runesKey("a"), notebook.CellActiveMode)
+	c.Update(runesKey("b"), notebook.CellActiveMode)
+	c.Update(tea.KeyMsg{Type: tea.KeyBackspace}, notebook.CellActiveMode)
+	if c.Text() != "a" {
+		t.Errorf("after backspace, Text = %q, want %q", c.Text(), "a")
+	}
+}
+
+func TestCommandCell_NavigationModeIgnoresKeys(t *testing.T) {
+	c := NewCommandCell(":", nil, nil)
+	_, _, handled := c.Update(runesKey("j"), notebook.NavigationMode)
+	if handled {
+		t.Error("CommandCell claimed key in NavigationMode — must passthrough so nav still works")
+	}
+}
+
+func TestOpenCommandBar_InstallsAndFocuses(t *testing.T) {
+	nb := notebook.New()
+	notebook.NewStatusCell(nb) // satisfy import for tests
+	OpenCommandBar(nb, ":", nil)
+	got, ok := nb.DockedCell(notebook.Bottom)
+	if !ok {
+		t.Fatal("Bottom dock missing after OpenCommandBar")
+	}
+	if _, isCmd := got.(*CommandCell); !isCmd {
+		t.Errorf("Bottom dock = %T, want *CommandCell", got)
+	}
+}
+
+func TestOpenCommandBar_RestoresPriorDockOnEsc(t *testing.T) {
+	nb := notebook.New()
+	priorBefore, _ := nb.DockedCell(notebook.Bottom)
+	OpenCommandBar(nb, ":", nil)
+	// Get the cell and simulate Esc.
+	cmdCell, _ := nb.DockedCell(notebook.Bottom)
+	cmdCell.Update(tea.KeyMsg{Type: tea.KeyEsc}, notebook.CellActiveMode)
+	// Esc fires onCancel which calls restore — but the restore
+	// happens synchronously inside Update, so by now Bottom should
+	// point at the original cell again.
+	got, _ := nb.DockedCell(notebook.Bottom)
+	if got != priorBefore {
+		t.Errorf("after Esc, Bottom = %v, want prior instance %v", got, priorBefore)
+	}
+}
+
+// runesKey is the common-case constructor for a single-rune key
+// msg — every CommandCell input test wants this shape.
+func runesKey(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}

--- a/notebook/cells/command_test.go
+++ b/notebook/cells/command_test.go
@@ -67,14 +67,18 @@ func TestCommandCell_EnterFiresOnSubmitAndReleases(t *testing.T) {
 	if !handled {
 		t.Error("Enter not handled")
 	}
+	if cmd == nil {
+		t.Fatal("Enter returned nil cmd")
+	}
+	sawRelease, sawSubmit := drainBatch(cmd)
+	if !sawSubmit {
+		t.Error("onSubmit not invoked from the Enter batch")
+	}
 	if got != "hi" {
 		t.Errorf("onSubmit received %q, want %q", got, "hi")
 	}
-	if cmd == nil {
-		t.Fatal("Enter returned nil cmd; expected ReleaseFocus")
-	}
-	if _, ok := cmd().(notebook.ReleaseFocusMsg); !ok {
-		t.Errorf("Enter cmd = %T, want ReleaseFocusMsg", cmd())
+	if !sawRelease {
+		t.Error("Enter batch missing ReleaseFocusMsg child")
 	}
 }
 
@@ -86,15 +90,45 @@ func TestCommandCell_EscFiresOnCancelAndReleases(t *testing.T) {
 	if !handled {
 		t.Error("Esc not handled")
 	}
+	if cmd == nil {
+		t.Fatal("Esc returned nil cmd")
+	}
+	sawRelease, _ := drainBatch(cmd)
 	if !cancelled {
 		t.Error("onCancel not fired on Esc")
 	}
-	if _, ok := cmd().(notebook.ReleaseFocusMsg); !ok {
-		t.Errorf("Esc cmd = %T, want ReleaseFocusMsg", cmd())
+	if !sawRelease {
+		t.Error("Esc batch missing ReleaseFocusMsg child")
 	}
 	if c.Text() != "" {
 		t.Errorf("buffer not cleared on Esc: %q", c.Text())
 	}
+}
+
+// drainBatch invokes the cmd as if tea were dispatching it,
+// recursively drains tea.BatchMsg children, and reports whether
+// any branch yielded a ReleaseFocusMsg (sawRelease) and whether
+// any branch yielded a nil msg from a non-empty Cmd (sawSubmit —
+// the submit/cancel callback path returns nil after firing its
+// side effect).
+func drainBatch(cmd tea.Cmd) (sawRelease bool, sawSubmit bool) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	switch m := msg.(type) {
+	case tea.BatchMsg:
+		for _, child := range m {
+			r, s := drainBatch(child)
+			sawRelease = sawRelease || r
+			sawSubmit = sawSubmit || s
+		}
+	case notebook.ReleaseFocusMsg:
+		sawRelease = true
+	case nil:
+		sawSubmit = true
+	}
+	return
 }
 
 func TestCommandCell_BackspaceTrimsLastRune(t *testing.T) {
@@ -132,12 +166,11 @@ func TestOpenCommandBar_RestoresPriorDockOnEsc(t *testing.T) {
 	nb := notebook.New()
 	priorBefore, _ := nb.DockedCell(notebook.Bottom)
 	OpenCommandBar(nb, ":", nil)
-	// Get the cell and simulate Esc.
+	// Esc returns a tea.Batch whose first child fires onCancel
+	// (which calls restore) — drain it the same way tea would.
 	cmdCell, _ := nb.DockedCell(notebook.Bottom)
-	cmdCell.Update(tea.KeyMsg{Type: tea.KeyEsc}, notebook.CellActiveMode)
-	// Esc fires onCancel which calls restore — but the restore
-	// happens synchronously inside Update, so by now Bottom should
-	// point at the original cell again.
+	_, cmd, _ := cmdCell.Update(tea.KeyMsg{Type: tea.KeyEsc}, notebook.CellActiveMode)
+	drainBatch(cmd)
 	got, _ := nb.DockedCell(notebook.Bottom)
 	if got != priorBefore {
 		t.Errorf("after Esc, Bottom = %v, want prior instance %v", got, priorBefore)

--- a/notebook/dock.go
+++ b/notebook/dock.go
@@ -1,0 +1,113 @@
+package notebook
+
+// Docked cells are positioned slots that reuse the Cell interface
+// but live OUTSIDE the cursor-navigable main list. They're how
+// apps add vim-style command bars, status rows, breadcrumbs, and
+// per-cell annotations without forking the cell type or
+// duplicating the input-handling story.
+//
+// v1 ships two families of Position:
+//
+//   - Edges (Top, Bottom) — viewport-pinned chrome. Always visible,
+//     screen-relative; render outside the body window.
+//   - Cell-anchored (After(id), Before(id)) — annotations that
+//     belong to a specific main cell; participate in the body row
+//     flow and scroll with their anchor. Auto-unregister when
+//     Remove(id) fires on the anchor.
+//
+// One Cell per Position: a second SetDockedCell at the same
+// Position replaces the first. Apps that want richer chrome (e.g.
+// multiple status segments) compose them into a single Cell that
+// renders multiple lines.
+//
+// Architectural commitment: docked cells live in a separate
+// registry, NOT in the main cells[] slice. This preserves the
+// invariant that cells[N] is always the N-th cursor-navigable
+// cell. Iteration over the main list stays linear and dock-free.
+
+// Position identifies a docked-cell slot. Construct one via the
+// package-level Top / Bottom values or the After / Before
+// functions; Position values are comparable and used as map keys
+// inside the notebook's dock registry.
+type Position interface {
+	// positionKey returns the registry key for this Position.
+	// Unexported so external packages can't fabricate Positions —
+	// they must go through the package-provided constructors.
+	positionKey() positionKey
+}
+
+// positionKey is the comparable value the dock registry maps from.
+// edge=0 means cell-anchored (cellID + before/after); edge!=0
+// means an edge position (cellID is ignored).
+type positionKey struct {
+	edge   edge
+	rel    anchorRel
+	cellID CellID
+}
+
+type edge int
+
+const (
+	edgeNone edge = iota
+	edgeTop
+	edgeBottom
+)
+
+type anchorRel int
+
+const (
+	relNone anchorRel = iota
+	relAfter
+	relBefore
+)
+
+// edgePosition implements Position for viewport-pinned chrome.
+type edgePosition struct{ e edge }
+
+func (p edgePosition) positionKey() positionKey { return positionKey{edge: p.e} }
+
+// cellAnchor implements Position for cell-anchored docks. Two
+// anchors on the same cell with different rel produce different
+// keys; the same (rel, cellID) pair always produces equal keys.
+type cellAnchor struct {
+	rel    anchorRel
+	cellID CellID
+}
+
+func (p cellAnchor) positionKey() positionKey {
+	return positionKey{rel: p.rel, cellID: p.cellID}
+}
+
+// Top is the viewport-pinned slot above the body. Apps use it for
+// breadcrumbs, tabs, or persistent banners. No default occupant —
+// the slot is empty until SetDockedCell(Top, ...) is called.
+var Top Position = edgePosition{edgeTop}
+
+// Bottom is the viewport-pinned slot below the body. The notebook
+// installs a built-in StatusCell here at construction so the
+// existing "MODE  cell N/M" line keeps working without app code.
+// Apps replace it via SetDockedCell(Bottom, ...) and can restore
+// the default with SetDockedCell(Bottom, NewStatusCell()).
+var Bottom Position = edgePosition{edgeBottom}
+
+// After returns the Position immediately following the cell with
+// the given ID in the body flow. Auto-unregisters when the anchor
+// cell is removed via nb.Remove(id).
+func After(id CellID) Position { return cellAnchor{rel: relAfter, cellID: id} }
+
+// Before returns the Position immediately preceding the cell with
+// the given ID in the body flow. Auto-unregisters when the anchor
+// cell is removed via nb.Remove(id).
+func Before(id CellID) Position { return cellAnchor{rel: relBefore, cellID: id} }
+
+// isEdge reports whether p is one of the viewport-pinned slots.
+func isEdge(p Position) bool {
+	k := p.positionKey()
+	return k.edge != edgeNone
+}
+
+// isCellAnchored reports whether p tracks a specific cell ID.
+func isCellAnchored(p Position) bool {
+	k := p.positionKey()
+	return k.rel != relNone
+}

--- a/notebook/dock_test.go
+++ b/notebook/dock_test.go
@@ -1,0 +1,372 @@
+package notebook
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- Registry: Set / Get / Clear ---
+
+func TestDock_SetGetClearRoundtrip(t *testing.T) {
+	nb := New()
+	d := newTestCell("d", 1)
+	nb.SetDockedCell(Top, d)
+	got, ok := nb.DockedCell(Top)
+	if !ok || got != d {
+		t.Errorf("DockedCell(Top) = (%v, %v), want (d, true)", got, ok)
+	}
+	if !nb.ClearDocked(Top) {
+		t.Error("ClearDocked(Top) returned false on existing dock")
+	}
+	if _, ok := nb.DockedCell(Top); ok {
+		t.Error("DockedCell(Top) still reports present after Clear")
+	}
+}
+
+func TestDock_DefaultBottomIsStatusCell(t *testing.T) {
+	nb := New()
+	got, ok := nb.DockedCell(Bottom)
+	if !ok {
+		t.Fatal("DockedCell(Bottom) not present after New — expected default StatusCell")
+	}
+	if _, isStatus := got.(*StatusCell); !isStatus {
+		t.Errorf("default Bottom dock = %T, want *StatusCell", got)
+	}
+}
+
+func TestDock_ClearBottomTrulyEmpties(t *testing.T) {
+	nb := New()
+	if !nb.ClearDocked(Bottom) {
+		t.Fatal("ClearDocked(Bottom) returned false on default-installed dock")
+	}
+	if _, ok := nb.DockedCell(Bottom); ok {
+		t.Error("Bottom dock still present after Clear — default should NOT auto-restore")
+	}
+}
+
+func TestDock_ReplaceBottomWithCustomThenRestoreDefault(t *testing.T) {
+	nb := New()
+	custom := newTestCell("custom", 1)
+	nb.SetDockedCell(Bottom, custom)
+	if got, _ := nb.DockedCell(Bottom); got != custom {
+		t.Errorf("after Set, Bottom = %v, want custom", got)
+	}
+	nb.SetDockedCell(Bottom, NewStatusCell(nb))
+	if got, _ := nb.DockedCell(Bottom); got == custom {
+		t.Error("after restoring default, Bottom still points at custom")
+	}
+}
+
+// --- Cell-anchored docks: After / Before ---
+
+func TestDock_AfterAndBeforeStoreDistinctly(t *testing.T) {
+	nb := New()
+	nb.Append(newTestCell("x", 1))
+	a := newTestCell("a", 1)
+	b := newTestCell("b", 1)
+	nb.SetDockedCell(After("x"), a)
+	nb.SetDockedCell(Before("x"), b)
+	if got, _ := nb.DockedCell(After("x")); got != a {
+		t.Errorf("After(x) = %v, want a", got)
+	}
+	if got, _ := nb.DockedCell(Before("x")); got != b {
+		t.Errorf("Before(x) = %v, want b", got)
+	}
+}
+
+func TestDock_AfterAutoUnregistersOnAnchorRemoval(t *testing.T) {
+	nb := New()
+	nb.Append(newTestCell("x", 1))
+	nb.SetDockedCell(After("x"), newTestCell("a", 1))
+	nb.SetDockedCell(Before("x"), newTestCell("b", 1))
+	if !nb.Remove("x") {
+		t.Fatal("Remove(x) returned false")
+	}
+	if _, ok := nb.DockedCell(After("x")); ok {
+		t.Error("After(x) dock still present after anchor removal")
+	}
+	if _, ok := nb.DockedCell(Before("x")); ok {
+		t.Error("Before(x) dock still present after anchor removal")
+	}
+}
+
+func TestDock_RemoveOnlyAffectsMatchingAnchor(t *testing.T) {
+	nb := New()
+	nb.Append(newTestCell("x", 1))
+	nb.Append(newTestCell("y", 1))
+	keepA := newTestCell("ka", 1)
+	keepB := newTestCell("kb", 1)
+	nb.SetDockedCell(After("y"), keepA)
+	nb.SetDockedCell(Before("y"), keepB)
+	nb.SetDockedCell(After("x"), newTestCell("xa", 1))
+	nb.Remove("x")
+	if got, _ := nb.DockedCell(After("y")); got != keepA {
+		t.Errorf("After(y) lost during Remove(x): got %v want %v", got, keepA)
+	}
+	if got, _ := nb.DockedCell(Before("y")); got != keepB {
+		t.Errorf("Before(y) lost during Remove(x): got %v want %v", got, keepB)
+	}
+}
+
+// --- bodyHeight & layout ---
+
+func TestDock_TopReducesBodyHeight(t *testing.T) {
+	m, st := newSizedModel(t, 40, 10)
+	// Default has Bottom dock (1 row); body = 9.
+	if got := m.bodyHeight(st.snapshot()); got != 9 {
+		t.Fatalf("default bodyHeight = %d, want 9", got)
+	}
+	st.setDock(Top.positionKey(), newTestCell("top", 2))
+	if got := m.bodyHeight(st.snapshot()); got != 7 {
+		t.Errorf("with Top(h=2) bodyHeight = %d, want 7", got)
+	}
+}
+
+func TestDock_BodyHeightClampsToOne(t *testing.T) {
+	m, st := newSizedModel(t, 40, 3)
+	st.setDock(Top.positionKey(), newTestCell("top", 5))
+	if got := m.bodyHeight(st.snapshot()); got != 1 {
+		t.Errorf("oversubscribed bodyHeight = %d, want 1 (clamp)", got)
+	}
+}
+
+func TestDock_AfterAnchorAppearsInView(t *testing.T) {
+	m, st := newSizedModel(t, 40, 12)
+	st.insert(-1, newTestCell("x", 1))
+	st.setDock((cellAnchor{rel: relAfter, cellID: "x"}).positionKey(), newTestCell("a", 1))
+	out := m.View()
+	if !strings.Contains(out, "x/0") {
+		t.Errorf("View missing anchor x:\n%s", out)
+	}
+	if !strings.Contains(out, "a/0") {
+		t.Errorf("View missing After(x) dock body 'a/0':\n%s", out)
+	}
+	// Order: x must appear before a in the rendered output.
+	if strings.Index(out, "x/0") > strings.Index(out, "a/0") {
+		t.Errorf("After(x) dock rendered BEFORE anchor:\n%s", out)
+	}
+}
+
+func TestDock_BeforeAnchorAppearsBeforeCell(t *testing.T) {
+	m, st := newSizedModel(t, 40, 12)
+	st.insert(-1, newTestCell("x", 1))
+	st.setDock((cellAnchor{rel: relBefore, cellID: "x"}).positionKey(), newTestCell("b", 1))
+	out := m.View()
+	if strings.Index(out, "b/0") > strings.Index(out, "x/0") {
+		t.Errorf("Before(x) dock rendered AFTER anchor:\n%s", out)
+	}
+}
+
+// --- Focus routing ---
+
+func TestDock_FocusDockReceivesKeys(t *testing.T) {
+	m, st := newSizedModel(t, 40, 12)
+	main := newTestCell("main", 1)
+	dock := newTestCell("dock", 1)
+	st.insert(-1, main)
+	st.setDock(Bottom.positionKey(), dock)
+
+	// Simulate FocusDock: set focus key directly (no tea.Program in this helper).
+	k := Bottom.positionKey()
+	m.nb.dockFocusKey.Store(&k)
+
+	// Pre-focus updates baseline.
+	mainBefore := main.updates
+	dockBefore := dock.updates
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+
+	if dock.updates == dockBefore {
+		t.Error("dock cell did not receive key while focused")
+	}
+	if main.updates != mainBefore {
+		t.Errorf("main cursor cell received key while dock focused (updates went %d → %d)",
+			mainBefore, main.updates)
+	}
+}
+
+func TestDock_FocusDockReturnsFalseWhenAbsent(t *testing.T) {
+	nb := New()
+	if nb.FocusDock(Top) {
+		t.Error("FocusDock(Top) returned true with no Top dock installed")
+	}
+}
+
+func TestDock_ReleaseFocusReturnsToMainList(t *testing.T) {
+	m, st := newSizedModel(t, 40, 12)
+	main := newTestCell("main", 1)
+	dock := newTestCell("dock", 1)
+	st.insert(-1, main)
+	st.setDock(Bottom.positionKey(), dock)
+	k := Bottom.positionKey()
+	m.nb.dockFocusKey.Store(&k)
+
+	// Emit ReleaseFocusMsg directly (cells return ReleaseFocus cmd
+	// in real flows; we shortcut by sending the msg).
+	m.Update(ReleaseFocusMsg{})
+
+	if cur := m.nb.dockFocusKey.Load(); cur != nil {
+		t.Errorf("dockFocusKey not cleared after ReleaseFocusMsg: %v", cur)
+	}
+
+	mainBefore := main.updates
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	if main.updates == mainBefore {
+		t.Error("main cell did not receive key after release")
+	}
+}
+
+func TestDock_CtrlWTogglesBottomFocus(t *testing.T) {
+	nb := New()
+	// Default Bottom dock present.
+	cmd := ToggleBottomDockFocus(nb)
+	if cmd == nil {
+		t.Fatal("ToggleBottomDockFocus returned nil cmd; want CellActiveMode cmd")
+	}
+	if _, ok := cmd().(setModeMsg); !ok {
+		t.Errorf("first toggle cmd msg type %T, want setModeMsg", cmd())
+	}
+	if cur := nb.dockFocusKey.Load(); cur == nil || *cur != Bottom.positionKey() {
+		t.Errorf("after first toggle, dockFocusKey = %v, want Bottom", cur)
+	}
+	cmd2 := ToggleBottomDockFocus(nb)
+	if cmd2 == nil {
+		t.Fatal("second toggle returned nil cmd; want NavigationMode cmd")
+	}
+	if cur := nb.dockFocusKey.Load(); cur != nil {
+		t.Errorf("after second toggle, dockFocusKey = %v, want nil", cur)
+	}
+}
+
+func TestDock_CtrlWNoopWhenBottomCleared(t *testing.T) {
+	nb := New()
+	nb.ClearDocked(Bottom)
+	cmd := ToggleBottomDockFocus(nb)
+	if cmd != nil {
+		t.Errorf("Ctrl+W with empty Bottom returned cmd %v, want nil", cmd)
+	}
+	if cur := nb.dockFocusKey.Load(); cur != nil {
+		t.Error("Ctrl+W focused a non-existent Bottom dock")
+	}
+}
+
+// --- StatusCell ---
+
+func TestStatusCell_RendersLegacyFormat(t *testing.T) {
+	nb := New()
+	nb.Append(newTestCell("a", 1))
+	nb.Append(newTestCell("b", 1))
+	nb.Append(newTestCell("c", 1))
+	cell, _ := nb.DockedCell(Bottom)
+	rows := cell.RenderRows(40, 0, 1, false, NavigationMode)
+	if len(rows) != 1 {
+		t.Fatalf("RenderRows returned %d rows, want 1", len(rows))
+	}
+	want := "NAV  cell 1/3"
+	if rows[0] != want {
+		t.Errorf("StatusCell row = %q, want %q", rows[0], want)
+	}
+}
+
+func TestStatusCell_EmptyShowsDash(t *testing.T) {
+	nb := New()
+	cell, _ := nb.DockedCell(Bottom)
+	rows := cell.RenderRows(40, 0, 1, false, NavigationMode)
+	if rows[0] != "NAV  cell —" {
+		t.Errorf("empty StatusCell = %q, want 'NAV  cell —'", rows[0])
+	}
+}
+
+// --- View height invariant ---
+
+func TestDock_ViewHasExactHeight(t *testing.T) {
+	m, st := newSizedModel(t, 40, 8)
+	for i := 0; i < 3; i++ {
+		st.insert(-1, newTestCell("c"+string(rune('0'+i)), 2))
+	}
+	st.setDock(Top.positionKey(), newTestCell("top", 1))
+	out := m.View()
+	got := strings.Count(out, "\n") + 1
+	if got != 8 {
+		t.Errorf("View produced %d rows, want 8 (h=8 with Top+Bottom)", got)
+	}
+}
+
+// --- Auto-grow / clamp / tail behavior ---
+
+// hugeCell reports HeightHint(width)=H regardless of width; used
+// to exercise the layout clamp.
+type hugeCell struct {
+	*testCell
+	h int
+}
+
+func (c *hugeCell) HeightHint(int) int { return c.h }
+func (c *hugeCell) RenderRows(_ int, startRow, endRow int, _ bool, _ Mode) []string {
+	rows := make([]string, 0, c.h)
+	for i := 0; i < c.h; i++ {
+		rows = append(rows, fmt.Sprintf("%s/%d", c.id, i))
+	}
+	if startRow < 0 {
+		startRow = 0
+	}
+	if endRow > len(rows) {
+		endRow = len(rows)
+	}
+	if startRow >= endRow {
+		return nil
+	}
+	return rows[startRow:endRow]
+}
+
+func TestDock_BottomYieldsToBodyWhenOversubscribed(t *testing.T) {
+	m, st := newSizedModel(t, 40, 10)
+	st.insert(-1, newTestCell("main", 1))
+	st.setDock(Bottom.positionKey(), &hugeCell{
+		testCell: newTestCell("bot", 1),
+		h:        100,
+	})
+	_, _, botH, bodyH := m.edgeAllotments(st.snapshot())
+	if bodyH < 1 {
+		t.Errorf("body starved (h=%d) — must always have >=1 row", bodyH)
+	}
+	if botH > 9 {
+		t.Errorf("Bottom claimed %d rows of 10 — must yield at least 1 for body", botH)
+	}
+}
+
+func TestDock_BottomRendersTailWhenClamped(t *testing.T) {
+	m, st := newSizedModel(t, 40, 5)
+	st.insert(-1, newTestCell("main", 1))
+	st.setDock(Bottom.positionKey(), &hugeCell{
+		testCell: newTestCell("bot", 1),
+		h:        10,
+	})
+	out := m.View()
+	// Tail rows are the highest-indexed; we expect "bot/9" (last row)
+	// in the output and NOT "bot/0" (first row).
+	if !strings.Contains(out, "bot/9") {
+		t.Errorf("tail of clamped Bottom dock missing — expected 'bot/9' in:\n%s", out)
+	}
+	if strings.Contains(out, "bot/0") {
+		t.Errorf("head of clamped Bottom dock rendered — expected tail-only:\n%s", out)
+	}
+}
+
+func TestDock_TopRendersHeadWhenClamped(t *testing.T) {
+	m, st := newSizedModel(t, 40, 5)
+	st.insert(-1, newTestCell("main", 1))
+	st.setDock(Top.positionKey(), &hugeCell{
+		testCell: newTestCell("top", 1),
+		h:        10,
+	})
+	out := m.View()
+	if !strings.Contains(out, "top/0") {
+		t.Errorf("head of clamped Top dock missing — expected 'top/0' in:\n%s", out)
+	}
+	if strings.Contains(out, "top/9") {
+		t.Errorf("tail of clamped Top dock rendered — expected head-only:\n%s", out)
+	}
+}

--- a/notebook/examples/cmdshell/README.md
+++ b/notebook/examples/cmdshell/README.md
@@ -33,6 +33,35 @@ arbitrary output at it — `ls`, `ps aux`, `find /`, `tail -f`,
 - `clear` removes every cmd cell (start fresh).
 - `q` or `quit` exits.
 
+## Vim-style `:` command bar
+
+Press `:` from navigation mode (Esc out of the prompt first if
+the cursor is sitting in it) to open a `CommandCell` docked at
+the viewport bottom. Type a shell command and Enter — same
+plumbing as the prompt path, but the input lives outside the
+main list. Esc cancels.
+
+The command bar **grows as you type**: short commands stay one
+row, long pipelines wrap and push the bar up. When the bar
+would oversubscribe the screen it's clamped and its tail (where
+the cursor is) keeps rendering.
+
+`":"` is wired in `main.go` via:
+
+```go
+km := notebook.DefaultKeyMap()
+km.Modes[notebook.NavigationMode][":"] = func(nb *notebook.Notebook) tea.Cmd {
+    cells.OpenCommandBar(nb, ":", repl.runFromCommandBar)
+    return nil
+}
+```
+
+`cells.OpenCommandBar` installs the command cell at
+`notebook.Bottom`, focuses it, restores the prior dock (the
+default `StatusCell`) on Enter / Esc. Apps with their own status
+bar get that bar back automatically — `OpenCommandBar` snapshots
+whatever was there at open time, not "the default."
+
 ## Cells used
 
 | Cell | Role |
@@ -41,7 +70,10 @@ arbitrary output at it — `ls`, `ps aux`, `find /`, `tail -f`,
 | `cells.NewNote` | one intro cell with usage hints |
 | `cells.NewPrompt` (via `AwaitInput`) | the `$` prompt |
 | `cells.NewOutput` (via `Stream`) | per-command output, one per cmd |
+| `cells.CommandCell` (via `OpenCommandBar`) | `:` vim-style command bar at the Bottom dock |
 
-Plus the `OSC52Clipboard` for `c`-to-copy when a cell is focused.
+Plus the `OSC52Clipboard` for `c`-to-copy when a cell is focused
+and the built-in `StatusCell` (auto-installed at `notebook.Bottom`
+on `New`).
 
-All wiring lives in a single ~100-line `main.go`.
+All wiring lives in a single ~140-line `main.go`.

--- a/notebook/examples/cmdshell/go.mod
+++ b/notebook/examples/cmdshell/go.mod
@@ -2,14 +2,16 @@ module github.com/panyam/demokit/notebook/examples/cmdshell
 
 go 1.26.2
 
-require github.com/panyam/demokit/notebook v0.0.1
+require (
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/panyam/demokit/notebook v0.0.1
+)
 
 require (
 	charm.land/lipgloss/v2 v2.0.3 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/bubbles v1.0.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect

--- a/notebook/examples/cmdshell/main.go
+++ b/notebook/examples/cmdshell/main.go
@@ -9,6 +9,17 @@
 // Useful for stress-testing scrolling, mouse-wheel + drag-select
 // copy, viewport resize, etc.
 //
+// Two ways to drive the shell:
+//
+//  1. PromptCell at the bottom of the main list (the default REPL
+//     loop) — types a command and runs it.
+//  2. Vim-style ":" — press ":" in navigation mode to open a
+//     CommandCell docked at the viewport bottom; Enter runs the
+//     command, Esc cancels. Demonstrates the DockedCell API. The
+//     command runs synchronously, so during long jobs the ":"
+//     prompt won't accept new input — switch back to the main
+//     PromptCell for parallel work.
+//
 // Built-in non-shell commands:
 //
 //	q | quit       — exit
@@ -25,31 +36,78 @@ import (
 	"strings"
 	"sync"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/panyam/demokit/notebook"
 	"github.com/panyam/demokit/notebook/cells"
 )
 
 func main() {
+	repl := &shellState{}
+	km := notebook.DefaultKeyMap()
+	// ":" in navigation mode opens a vim-style command bar at the
+	// Bottom dock. Apps choose the trigger key — the framework
+	// only ships the OpenCommandBar convenience.
+	km.Modes[notebook.NavigationMode][":"] = func(nb *notebook.Notebook) tea.Cmd {
+		return cells.OpenCommandBar(nb, ":", func(src string) {
+			repl.runFromCommandBar(nb, src)
+		})
+	}
+
 	nb := notebook.New(
 		notebook.WithPromptFactory(cells.PromptFactory()),
 		notebook.WithClipboard(notebook.OSC52Clipboard()),
+		notebook.WithKeyMap(km),
 	)
+	repl.nb = nb
 
-	go runREPL(nb)
+	go runREPL(nb, repl)
 	if err := nb.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
-func runREPL(nb *notebook.Notebook) {
-	nb.SetHeader("cmdshell", "type a shell command · q quits · clear wipes history")
+// shellState holds the bits the ":" command-bar handler needs to
+// share with the prompt-driven REPL loop. The REPL goroutine
+// owns the command counter; the command-bar handler bumps it
+// under a mutex.
+type shellState struct {
+	nb     *notebook.Notebook
+	mu     sync.Mutex
+	n      int
+	cmdIDs []notebook.CellID
+}
+
+// runFromCommandBar handles a single ":<cmd>" submission from the
+// docked CommandCell. Same lifecycle as the prompt path but
+// triggered out-of-band so the REPL doesn't have to know about
+// the dock.
+func (s *shellState) runFromCommandBar(nb *notebook.Notebook, src string) {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return
+	}
+	s.mu.Lock()
+	s.n++
+	n := s.n
+	s.mu.Unlock()
+	id := runCommand(nb, n, src)
+	s.mu.Lock()
+	s.cmdIDs = append(s.cmdIDs, id)
+	s.mu.Unlock()
+}
+
+func runREPL(nb *notebook.Notebook, repl *shellState) {
+	nb.SetHeader("cmdshell", "type a shell command · : opens command bar · q quits · clear wipes history")
 	nb.Append(cells.NewNote("intro", "Try", introBody()))
 
-	cmdIDs := []notebook.CellID{}
-	n := 0
 	for {
-		n++
+		repl.mu.Lock()
+		repl.n++
+		n := repl.n
+		repl.mu.Unlock()
+
 		resp := nb.AwaitInput([]notebook.Input{
 			notebook.NewStringInput("cmd", "$", nil),
 		})
@@ -66,13 +124,18 @@ func runREPL(nb *notebook.Notebook) {
 			nb.Stop()
 			return
 		case src == "clear":
-			for _, id := range cmdIDs {
+			repl.mu.Lock()
+			ids := repl.cmdIDs
+			repl.cmdIDs = repl.cmdIDs[:0]
+			repl.mu.Unlock()
+			for _, id := range ids {
 				nb.Remove(id)
 			}
-			cmdIDs = cmdIDs[:0]
 		default:
 			id := runCommand(nb, n, src)
-			cmdIDs = append(cmdIDs, id)
+			repl.mu.Lock()
+			repl.cmdIDs = append(repl.cmdIDs, id)
+			repl.mu.Unlock()
 		}
 	}
 }
@@ -136,5 +199,9 @@ func introBody() string {
 		"OutputCells default to top/bottom borders only — drag-select",
 		"the body and your terminal copies just the content. Wheel-scroll",
 		"within a cell when the buffer overflows; q to quit.",
+		"",
+		"Press ':' (in navigation mode — press Esc to leave the prompt",
+		"first) to open the vim-style command bar at the bottom. The",
+		"command bar grows as you type. Enter runs, Esc cancels.",
 	}, "\n")
 }

--- a/notebook/examples/cmdshell/main.go
+++ b/notebook/examples/cmdshell/main.go
@@ -50,7 +50,12 @@ func main() {
 	// only ships the OpenCommandBar convenience.
 	km.Modes[notebook.NavigationMode][":"] = func(nb *notebook.Notebook) tea.Cmd {
 		return cells.OpenCommandBar(nb, ":", func(src string) {
-			repl.runFromCommandBar(nb, src)
+			// onSubmit runs in the deferred tea.Cmd goroutine, so
+			// the BT loop is already free — but we still don't
+			// want to block the cmd goroutine on a long-running
+			// shell command, so kick off the work in its own
+			// goroutine and return.
+			go repl.runFromCommandBar(nb, src)
 		})
 	}
 

--- a/notebook/go.mod
+++ b/notebook/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/x/ansi v0.11.7
 )
 
 require (
@@ -14,7 +15,6 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/notebook/keymap.go
+++ b/notebook/keymap.go
@@ -41,6 +41,10 @@ type KeyMap struct {
 // DefaultKeyMap returns the canonical bindings:
 //
 //   - Ctrl+C → Quit (Global)
+//   - Ctrl+W → ToggleBottomDockFocus (Global) — vim/tmux-style
+//     window-switch shortcut: cycles focus between the main list
+//     and the Bottom dock when a Bottom dock is present.
+//     Apps that don't want it remove or rebind via WithKeyMap.
 //   - NavigationMode: ↑/k NavUp, ↓/j NavDown, enter/s/f EnterFocus
 //   - CellActiveMode: none (cells own everything)
 //
@@ -51,6 +55,7 @@ func DefaultKeyMap() KeyMap {
 	return KeyMap{
 		Global: map[string]Action{
 			"ctrl+c": Quit,
+			"ctrl+w": ToggleBottomDockFocus,
 		},
 		Modes: map[Mode]map[string]Action{
 			NavigationMode: {
@@ -122,4 +127,35 @@ func SetMode(m Mode) Action {
 	return func(*Notebook) tea.Cmd {
 		return func() tea.Msg { return setModeMsg{mode: m} }
 	}
+}
+
+// FocusDock returns an Action that focuses the dock at pos AND
+// switches the notebook to CellActiveMode so the dock's cell sees
+// keys without notebook bindings interfering. No-op if no dock
+// is installed at pos when the action fires.
+//
+//	km.Modes[notebook.NavigationMode]["ctrl+b"] = notebook.FocusDock(notebook.Bottom)
+func FocusDock(pos Position) Action {
+	return func(nb *Notebook) tea.Cmd {
+		if !nb.FocusDock(pos) {
+			return nil
+		}
+		return ModeCmd(CellActiveMode)
+	}
+}
+
+// ToggleBottomDockFocus is the default Ctrl+W binding: if the
+// Bottom dock isn't focused, focus it (and switch to
+// CellActiveMode); if it is, release (and drop to NavigationMode).
+// No-op when Bottom is empty. Exposed as a standalone Action so
+// apps can rebind it onto a different key.
+func ToggleBottomDockFocus(nb *Notebook) tea.Cmd {
+	if cur := nb.dockFocusKey.Load(); cur != nil && *cur == Bottom.positionKey() {
+		nb.ReleaseDockFocus()
+		return ModeCmd(NavigationMode)
+	}
+	if !nb.FocusDock(Bottom) {
+		return nil
+	}
+	return ModeCmd(CellActiveMode)
 }

--- a/notebook/model.go
+++ b/notebook/model.go
@@ -1,7 +1,6 @@
 package notebook
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
@@ -77,6 +76,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mode = msg.mode
 		return m, nil
 	case ReleaseFocusMsg:
+		// A docked cell emitting ReleaseFocus also drops dock focus
+		// so subsequent keys land on the main cursor cell.
+		m.nb.dockFocusKey.Store(nil)
 		m.mode = NavigationMode
 		return m, nil
 	case CellAdvanceMsg:
@@ -99,7 +101,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mode = NavigationMode
 		return m, nil
 	case ClearCopyMsg:
-		cmd, _ := m.routeToCell(msg.CellID, msg)
+		// Try main cells first; if no main cell claims the ID, try
+		// docked cells too so dock-resident copy toasts also clear.
+		if _, ok := m.nb.store.get(msg.CellID); ok {
+			cmd, _ := m.routeToCell(msg.CellID, msg)
+			return m, cmd
+		}
+		cmd, _ := m.routeMsgToDockByID(msg.CellID, msg)
 		return m, cmd
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -183,46 +191,59 @@ func (m model) routeMouseToCursor(msg tea.MouseMsg) (tea.Cmd, bool) {
 }
 
 // cellAtRow translates an absolute terminal Y row into a cell
-// index, accounting for the header row + the current viewport
-// offset. Returns (-1, false) when the click landed outside the
-// body (header / status row / past last cell).
+// index, accounting for the header row, the Top dock, and the
+// current viewport offset. Returns (-1, false) when the click
+// landed outside the body (header / Top dock / Bottom dock / past
+// last cell). Clicks landing on Before/After anchored docks
+// resolve to their anchor cell — they're not cursor-targetable.
 func (m model) cellAtRow(y int) (int, bool) {
 	snap := m.nb.store.snapshot()
 	bodyStart := 0
 	if snap.header != "" {
-		bodyStart = 1
+		bodyStart++
+	}
+	if top, ok := snap.docks[edgePosition{edgeTop}.positionKey()]; ok {
+		bodyStart += top.HeightHint(m.width)
 	}
 	if y < bodyStart {
 		return -1, false
 	}
-	bodyEnd := bodyStart + m.bodyHeight()
+	bodyEnd := bodyStart + m.bodyHeight(snap)
 	if y >= bodyEnd {
 		return -1, false
 	}
 	logicalRow := (y - bodyStart) + m.viewportOffset
 	row := 0
 	for i, c := range snap.cells {
+		before, after := m.anchoredRowSpan(snap, c)
+		row += before
 		h := c.HeightHint(m.width)
-		if logicalRow < row+h {
+		if logicalRow < row+h+after {
 			return i, true
 		}
-		row += h
+		row += h + after
 	}
 	return -1, false
 }
 
-// handleKey routes a keystroke cell-first. The cursor cell sees
-// every key via cell.Update before the notebook tries its KeyMap.
-// If the cell returns handled=true the notebook stops; otherwise
-// the notebook looks the key up in Global then current-mode
-// bindings.
+// handleKey routes a keystroke focus-first. The focused target
+// (a docked cell if one is focused, otherwise the cursor cell)
+// sees every key via Update before the notebook tries its KeyMap.
+// If it returns handled=true the notebook stops; otherwise the
+// notebook looks the key up in Global then current-mode bindings.
 //
 // The rare cell-cmd-with-handled=false case is honored: if the
-// cell returned a side-effect cmd AND a KeyMap action also fires,
-// the action's cmd takes precedence (cell's cmd is dropped). If
+// target returned a side-effect cmd AND a KeyMap action also fires,
+// the action's cmd takes precedence (target's cmd is dropped). If
 // only one fires, that one's cmd is used.
 func (m model) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
-	cellCmd, handled := m.routeKeyToCursor(key)
+	var cellCmd tea.Cmd
+	var handled bool
+	if dockKey, ok := m.nb.focusedDockKey(); ok {
+		cellCmd, handled = m.routeKeyToDock(dockKey, key)
+	} else {
+		cellCmd, handled = m.routeKeyToCursor(key)
+	}
 	if handled {
 		return m, cellCmd
 	}
@@ -258,13 +279,49 @@ func (m model) routeToCell(id CellID, msg tea.Msg) (tea.Cmd, bool) {
 	return cmd, handled
 }
 
+// routeKeyToDock delivers a msg to the docked cell at k, writes
+// the (possibly new) cell back into the registry, and returns the
+// cell's cmd and handled flag. Mirrors routeToCell but for docks.
+func (m model) routeKeyToDock(k positionKey, msg tea.Msg) (tea.Cmd, bool) {
+	var cmd tea.Cmd
+	var handled bool
+	m.nb.store.updateDock(k, func(c Cell) Cell {
+		updated, c2, h := c.Update(msg, m.mode)
+		cmd = c2
+		handled = h
+		return updated
+	})
+	return cmd, handled
+}
+
+// routeMsgToDockByID finds the dock whose Cell.ID matches the given
+// ID and delivers msg to it. Used for ID-keyed routings like
+// ClearCopyMsg where the sender knows its own ID but not its
+// dock position.
+func (m model) routeMsgToDockByID(id CellID, msg tea.Msg) (tea.Cmd, bool) {
+	snap := m.nb.store.snapshot()
+	for k, c := range snap.docks {
+		if c.ID() == id {
+			return m.routeKeyToDock(k, msg)
+		}
+	}
+	return nil, false
+}
+
 // View implements tea.Model. Range-based render: each cell is
 // asked only for the row window the viewport will display.
+//
+// Layout (top to bottom): optional header banner, Top dock if any,
+// the body window (main cells interleaved with their After/Before
+// anchored docks), Bottom dock if any. Top and Bottom claim layout
+// space; the body's height is what's left.
 func (m model) View() string {
 	if m.width == 0 || m.height == 0 {
 		return ""
 	}
 	snap := m.nb.store.snapshot()
+	focusedDockKey, dockFocused := m.nb.focusedDockKey()
+	_, topH, bottomH, bodyRows := m.edgeAllotments(snap)
 
 	var lines []string
 	if snap.header != "" {
@@ -274,22 +331,35 @@ func (m model) View() string {
 		}
 		lines = append(lines, banner)
 	}
-	bodyStart := len(lines)
-	bodyRows := m.bodyHeight()
 
-	rowCursor := 0
+	// Top dock — claims topH rows. If the dock wanted more
+	// (HeightHint > topH), we show the HEAD; tabs/breadcrumbs read
+	// left-to-right, top-first, so head-truncation is the right
+	// default. Apps that want different semantics swap the dock.
+	if topH > 0 {
+		topKey := edgePosition{edgeTop}.positionKey()
+		focused := dockFocused && focusedDockKey == topKey
+		lines = append(lines, snap.docks[topKey].RenderRows(m.width, 0, topH, focused, m.mode)...)
+	}
+
+	bodyStart := len(lines)
 	windowStart := m.viewportOffset
 	windowEnd := m.viewportOffset + bodyRows
-	for i, c := range snap.cells {
-		focused := i == snap.cursor
+
+	// renderSegment appends the visible slice of segment c (with
+	// the given focused flag) given a rolling rowCursor, returning
+	// the new rowCursor.
+	rowCursor := 0
+	renderSegment := func(c Cell, focused bool) {
 		h := c.HeightHint(m.width)
 		cellEnd := rowCursor + h
 		if cellEnd <= windowStart {
 			rowCursor = cellEnd
-			continue
+			return
 		}
 		if rowCursor >= windowEnd {
-			break
+			rowCursor = cellEnd
+			return
 		}
 		lo, hi := 0, h
 		if rowCursor < windowStart {
@@ -300,10 +370,27 @@ func (m model) View() string {
 		}
 		lines = append(lines, c.RenderRows(m.width, lo, hi, focused, m.mode)...)
 		rowCursor = cellEnd
-		if len(lines)-bodyStart >= bodyRows {
+	}
+
+	// Body: for each main cell, interleave Before / cell / After
+	// anchored docks. Cursor focus only fires when a docked cell
+	// isn't taking focus.
+	for i, c := range snap.cells {
+		if rowCursor >= windowEnd {
 			break
 		}
+		if before, ok := snap.docks[(cellAnchor{rel: relBefore, cellID: c.ID()}).positionKey()]; ok {
+			focused := dockFocused && focusedDockKey == (cellAnchor{rel: relBefore, cellID: c.ID()}).positionKey()
+			renderSegment(before, focused)
+		}
+		renderSegment(c, !dockFocused && i == snap.cursor)
+		if after, ok := snap.docks[(cellAnchor{rel: relAfter, cellID: c.ID()}).positionKey()]; ok {
+			focused := dockFocused && focusedDockKey == (cellAnchor{rel: relAfter, cellID: c.ID()}).positionKey()
+			renderSegment(after, focused)
+		}
 	}
+
+	// Pad/truncate body to exactly bodyRows.
 	target := bodyStart + bodyRows
 	if len(lines) > target {
 		lines = lines[:target]
@@ -311,48 +398,126 @@ func (m model) View() string {
 	for len(lines) < target {
 		lines = append(lines, "")
 	}
-	lines = append(lines, m.statusLine(snap))
+
+	// Bottom dock — claims bottomH rows. If desired > bottomH the
+	// dock yielded — render its TAIL so the cursor and most-recent
+	// content stay visible. Command bars and tail-style status
+	// readouts get the right behavior for free; cells that want
+	// head-truncation pass an explicit anchored top-style cell.
+	if bottomH > 0 {
+		botKey := edgePosition{edgeBottom}.positionKey()
+		desired := m.dockDesiredHeight(snap, botKey)
+		startRow := 0
+		endRow := desired
+		if desired > bottomH {
+			startRow = desired - bottomH
+		} else {
+			endRow = bottomH
+		}
+		focused := dockFocused && focusedDockKey == botKey
+		lines = append(lines, snap.docks[botKey].RenderRows(m.width, startRow, endRow, focused, m.mode)...)
+	}
+
 	return strings.Join(lines, "\n")
 }
 
-// statusLine builds the bottom row: mode + cursor position.
-func (m model) statusLine(snap snapshot) string {
-	mode := m.mode.Name()
-	pos := "—"
-	if len(snap.cells) > 0 {
-		pos = strconv.Itoa(snap.cursor+1) + "/" + strconv.Itoa(len(snap.cells))
+// edgeAllotments returns the row counts actually allotted to the
+// header, Top dock, and Bottom dock, plus the body height. Edge
+// docks report a "desired" via HeightHint but auto-grow content
+// (vim-style command bars, multi-line status) can ask for more
+// than the terminal has room for — so the layout enforces:
+//
+//  1. Body always gets at least 1 row (chrome can't starve the body).
+//  2. When desired Top + Bottom + header would oversubscribe, Bottom
+//     yields first (command bars scroll their own tail), then Top.
+//
+// Returned allotments are what View should actually render; cells
+// that wanted more handle the truncation in RenderRows by drawing
+// only their visible window.
+func (m model) edgeAllotments(snap snapshot) (headerH, topH, bottomH, bodyH int) {
+	if snap.header != "" {
+		headerH = 1
 	}
-	return mode + "  cell " + pos
+	desiredTop := 0
+	if top, ok := snap.docks[edgePosition{edgeTop}.positionKey()]; ok {
+		desiredTop = top.HeightHint(m.width)
+	}
+	desiredBot := 0
+	if bot, ok := snap.docks[edgePosition{edgeBottom}.positionKey()]; ok {
+		desiredBot = bot.HeightHint(m.width)
+	}
+	available := m.height - headerH
+	if available < 1 {
+		return headerH, 0, 0, 1
+	}
+	const minBody = 1
+	topH = desiredTop
+	bottomH = desiredBot
+	for topH+bottomH > available-minBody {
+		if bottomH > 0 {
+			bottomH--
+			continue
+		}
+		if topH > 0 {
+			topH--
+			continue
+		}
+		break
+	}
+	bodyH = available - topH - bottomH
+	if bodyH < minBody {
+		bodyH = minBody
+	}
+	return
 }
 
-// bodyHeight is the row count available for cells: total height
-// minus the status row and (if present) the header row.
-func (m model) bodyHeight() int {
-	reserved := 1 // status row
-	m.nb.store.mu.RLock()
-	hasHeader := m.nb.store.header != ""
-	m.nb.store.mu.RUnlock()
-	if hasHeader {
-		reserved++
-	}
-	body := m.height - reserved
-	if body < 1 {
-		body = 1
-	}
+// bodyHeight is the row count available for the body. Wraps
+// edgeAllotments for callers that only need the body figure.
+func (m model) bodyHeight(snap snapshot) int {
+	_, _, _, body := m.edgeAllotments(snap)
 	return body
 }
 
-// cellRowSpan returns the [start, end) absolute row range of cell
-// idx, given the current width.
-func (m model) cellRowSpan(cells []Cell, idx int) (int, int) {
-	start := 0
-	for i := 0; i < idx && i < len(cells); i++ {
-		start += cells[i].HeightHint(m.width)
+// dockDesiredHeight returns the dock's reported HeightHint (not
+// the clamped allotment) — used by View to decide whether to
+// render the head or the tail of an oversubscribed dock.
+func (m model) dockDesiredHeight(snap snapshot, k positionKey) int {
+	if c, ok := snap.docks[k]; ok {
+		return c.HeightHint(m.width)
 	}
-	if idx < 0 || idx >= len(cells) {
+	return 0
+}
+
+// anchoredRowSpan returns the row span of any anchored docks for
+// cells[i] in {Before, After} order — used by cellRowSpan and
+// cellAtRow to walk the body in render order.
+func (m model) anchoredRowSpan(snap snapshot, c Cell) (beforeH, afterH int) {
+	if d, ok := snap.docks[(cellAnchor{rel: relBefore, cellID: c.ID()}).positionKey()]; ok {
+		beforeH = d.HeightHint(m.width)
+	}
+	if d, ok := snap.docks[(cellAnchor{rel: relAfter, cellID: c.ID()}).positionKey()]; ok {
+		afterH = d.HeightHint(m.width)
+	}
+	return
+}
+
+// cellRowSpan returns the [start, end) absolute body-row range of
+// cells[idx] including the Before-anchored dock space that
+// precedes it. End is just past the cell itself (After-anchored
+// rows are NOT in the span — they trail and aren't part of the
+// cell's own scroll target).
+func (m model) cellRowSpan(snap snapshot, idx int) (int, int) {
+	start := 0
+	for i := 0; i < idx && i < len(snap.cells); i++ {
+		before, after := m.anchoredRowSpan(snap, snap.cells[i])
+		start += before + snap.cells[i].HeightHint(m.width) + after
+	}
+	if idx < 0 || idx >= len(snap.cells) {
 		return start, start
 	}
-	return start, start + cells[idx].HeightHint(m.width)
+	before, _ := m.anchoredRowSpan(snap, snap.cells[idx])
+	start += before
+	return start, start + snap.cells[idx].HeightHint(m.width)
 }
 
 // ensureCursorVisible nudges viewportOffset so the focused cell is
@@ -366,8 +531,8 @@ func (m *model) ensureCursorVisible() {
 		m.viewportOffset = 0
 		return
 	}
-	body := m.bodyHeight()
-	start, end := m.cellRowSpan(snap.cells, snap.cursor)
+	body := m.bodyHeight(snap)
+	start, end := m.cellRowSpan(snap, snap.cursor)
 	if start < m.viewportOffset {
 		m.viewportOffset = start
 		return

--- a/notebook/notebook.go
+++ b/notebook/notebook.go
@@ -37,6 +37,13 @@ type Notebook struct {
 
 	promptSeq atomic.Uint64
 
+	// dockFocusKey points at the positionKey of the currently
+	// focused dock, or nil when focus is on the main list. Reads
+	// from the BT goroutine (key dispatch) and writes from any
+	// goroutine (FocusDock / ReleaseDockFocus) — atomic.Pointer
+	// keeps it lock-free and easy to swap.
+	dockFocusKey atomic.Pointer[positionKey]
+
 	startOnce sync.Once
 	stopOnce  sync.Once
 	blockIn   *blockingReader
@@ -156,6 +163,12 @@ func New(opts ...Option) *Notebook {
 		)
 	}
 	nb.program = tea.NewProgram(m, progOpts...)
+	// The Bottom dock has a built-in default — the StatusCell that
+	// reproduces the legacy status row ("NAV  cell N/M"). Apps that
+	// want vim-style command bars or richer chrome replace it via
+	// SetDockedCell(Bottom, ...). Apps that want NO bottom row at
+	// all call ClearDocked(Bottom).
+	nb.store.setDock(Bottom.positionKey(), NewStatusCell(nb))
 	return nb
 }
 
@@ -173,6 +186,134 @@ func (nb *Notebook) Run() error {
 // goroutine — internally Sends a tea.Msg that the model applies.
 func (nb *Notebook) SetMode(m Mode) {
 	nb.program.Send(setModeMsg{mode: m})
+}
+
+// SetDockedCell installs c at pos, replacing any prior occupant.
+// Docked cells live in a separate registry from the main cell
+// list — they don't appear in nb.Get / IndexOf / Len and the main
+// cursor never steps onto them. Use FocusDock(pos) to route keys
+// to a docked cell.
+//
+// SetDockedCell auto-wires the configured clipboard into cells
+// that implement SetClipboard, matching Append's behavior.
+//
+// Cell-anchored Positions (After / Before) automatically
+// unregister when the anchor cell is removed via nb.Remove.
+func (nb *Notebook) SetDockedCell(pos Position, c Cell) {
+	nb.injectClipboard(c)
+	nb.store.setDock(pos.positionKey(), c)
+}
+
+// ClearDocked removes the dock at pos. Returns true if a dock was
+// present. Note: ClearDocked(Bottom) truly empties the slot — the
+// default StatusCell is NOT auto-restored. Re-install it with
+// SetDockedCell(Bottom, NewStatusCell(nb)) if you want it back.
+//
+// If the focused dock is being cleared, the dock-focus pointer
+// drops back to nil (main list). The notebook's Mode is NOT
+// changed — callers that need to drop from CellActiveMode emit
+// notebook.ReleaseFocus from a cell or return notebook.ModeCmd
+// from an action. (Sending here would deadlock when called from
+// inside a keymap action; see safeSend's doc.)
+func (nb *Notebook) ClearDocked(pos Position) bool {
+	k := pos.positionKey()
+	if cur := nb.dockFocusKey.Load(); cur != nil && *cur == k {
+		nb.dockFocusKey.Store(nil)
+	}
+	return nb.store.clearDock(k)
+}
+
+// DockedCell returns the cell at pos, if any. The bool reports
+// presence.
+func (nb *Notebook) DockedCell(pos Position) (Cell, bool) {
+	return nb.store.getDock(pos.positionKey())
+}
+
+// UpdateDocked replaces the dock at pos by fn(old). Returns false
+// if no dock is present at pos. fn runs under the store lock — it
+// must be quick and must not call back into the Notebook.
+func (nb *Notebook) UpdateDocked(pos Position, fn func(Cell) Cell) bool {
+	return nb.store.updateDock(pos.positionKey(), fn)
+}
+
+// FocusDock routes subsequent keystrokes to the docked cell at
+// pos. Returns false if no dock is installed at pos. The main
+// cursor stays where it is; ReleaseDockFocus / a ReleaseFocusMsg
+// from the docked cell returns focus to the main list.
+//
+// FocusDock also flips the notebook into CellActiveMode so the
+// docked cell behaves like a focused main cell: it sees every
+// keystroke, KeyMap.Modes[NavigationMode] bindings (j/k/enter)
+// don't fire underneath it.
+// FocusDock points the notebook's dock-focus marker at pos so
+// subsequent keystrokes route to that docked cell instead of the
+// main cursor cell. Returns false if no dock is installed at pos.
+//
+// FocusDock does NOT change Mode — callers compose that:
+//
+//   - From a KeyMap Action: return notebook.ModeCmd(CellActiveMode)
+//     alongside the FocusDock call. The action constructor
+//     notebook.FocusDock(pos) bundles both.
+//   - From a non-BT goroutine: call nb.SetMode(CellActiveMode)
+//     after FocusDock.
+//
+// Splitting them this way avoids deadlock — Send-from-inside-an-
+// action blocks because the BT goroutine is the same one that
+// drains the channel.
+func (nb *Notebook) FocusDock(pos Position) bool {
+	k := pos.positionKey()
+	if _, ok := nb.store.getDock(k); !ok {
+		return false
+	}
+	nb.dockFocusKey.Store(&k)
+	return true
+}
+
+// ReleaseDockFocus clears the dock-focus marker so subsequent
+// keystrokes route to the main cursor cell. Does NOT change Mode
+// — for the same deadlock-avoidance reasons as FocusDock. Idempotent.
+func (nb *Notebook) ReleaseDockFocus() {
+	nb.dockFocusKey.Store(nil)
+}
+
+// ModeCmd returns a tea.Cmd that switches the notebook into mode
+// m. Use from KeyMap actions and convenience helpers that run on
+// the BT goroutine — Sending directly would deadlock.
+func ModeCmd(m Mode) tea.Cmd {
+	return func() tea.Msg { return setModeMsg{mode: m} }
+}
+
+// focusedDockKey returns the currently focused dock's key and
+// whether a dock is focused. Used by the model on the BT goroutine.
+func (nb *Notebook) focusedDockKey() (positionKey, bool) {
+	p := nb.dockFocusKey.Load()
+	if p == nil {
+		return positionKey{}, false
+	}
+	return *p, true
+}
+
+// safeSend Sends msg to the BT program loop iff it is up and
+// draining. Mutations from caller goroutines that need to trigger
+// a model-side state change (mode flip, focus shift) go through
+// safeSend; the model's repaint tick picks up store changes
+// without a Send.
+//
+// Without this guard, callers that exercise the public API before
+// (or without) Run — unit tests, fast-fail paths — would deadlock
+// on tea.Program.Send (which is unbuffered; see ARCHITECTURE.md
+// § Concurrency model). With the program nil or its loop not yet
+// live, safeSend silently drops; mode state doesn't matter
+// without a running renderer anyway.
+func (nb *Notebook) safeSend(msg tea.Msg) {
+	if nb.program == nil {
+		return
+	}
+	select {
+	case <-nb.ready:
+		nb.program.Send(msg)
+	default:
+	}
 }
 
 // Stop signals the program to quit and drains any pending

--- a/notebook/notebook_test.go
+++ b/notebook/notebook_test.go
@@ -251,7 +251,8 @@ func TestStopUnblocksRun(t *testing.T) {
 // newSizedModel constructs a model with a sized store for
 // viewport tests. Wires up the minimum scaffolding (a Notebook
 // with store + rendezvous + DefaultKeyMap + DefaultMouseConfig,
-// no tea.Program).
+// no tea.Program). Installs the default Bottom StatusCell so
+// body math reflects what New() produces in real consumers.
 func newSizedModel(t *testing.T, width, height int) (*model, *store) {
 	t.Helper()
 	nb := &Notebook{
@@ -262,6 +263,7 @@ func newSizedModel(t *testing.T, width, height int) (*model, *store) {
 		ready:       make(chan struct{}),
 		stopped:     make(chan struct{}),
 	}
+	nb.store.setDock(Bottom.positionKey(), NewStatusCell(nb))
 	m := newModel(nb, width, height)
 	return &m, nb.store
 }
@@ -274,9 +276,10 @@ func TestEnsureCursorVisibleScrollsDownToFocused(t *testing.T) {
 	st.moveCursor(+4) // cursor on c4
 	m.ensureCursorVisible()
 	// c4 ends at row 15; viewport end must be >= 15.
-	if m.viewportOffset+m.bodyHeight() < 15 {
+	snap := st.snapshot()
+	if m.viewportOffset+m.bodyHeight(snap) < 15 {
 		t.Errorf("viewport [%d, %d) does not reach c4's end (15)",
-			m.viewportOffset, m.viewportOffset+m.bodyHeight())
+			m.viewportOffset, m.viewportOffset+m.bodyHeight(snap))
 	}
 }
 
@@ -291,10 +294,11 @@ func TestRemoveAtTopAdjustsViewport(t *testing.T) {
 	st.remove("c0")
 	m.ensureCursorVisible()
 	// c4 (now idx 3) span [9,12); viewport must contain it.
-	start, end := m.cellRowSpan(st.snapshot().cells, st.cursorPos())
-	if start < m.viewportOffset || end > m.viewportOffset+m.bodyHeight() {
+	snap := st.snapshot()
+	start, end := m.cellRowSpan(snap, st.cursorPos())
+	if start < m.viewportOffset || end > m.viewportOffset+m.bodyHeight(snap) {
 		t.Errorf("cell span [%d,%d) not in viewport [%d,%d) after top removal",
-			start, end, m.viewportOffset, m.viewportOffset+m.bodyHeight())
+			start, end, m.viewportOffset, m.viewportOffset+m.bodyHeight(snap))
 	}
 }
 

--- a/notebook/status_cell.go
+++ b/notebook/status_cell.go
@@ -1,0 +1,79 @@
+package notebook
+
+import (
+	"strconv"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// StatusCell is the built-in single-row Cell installed at the
+// Bottom dock by New(). It reproduces the legacy status line:
+//
+//	NAV  cell 3/7
+//
+// Apps that want richer chrome (vim-style command bar, multi-
+// segment status, themed colors) replace this via
+// SetDockedCell(Bottom, customCell). The default lives in package
+// notebook (not in notebook/cells) so the package can self-install
+// at New() without an import cycle.
+//
+// StatusCell reads its content from the notebook's store at render
+// time, so callers never need to mutate it; mode and cursor
+// position pick up automatically.
+type StatusCell struct {
+	nb *Notebook
+}
+
+// NewStatusCell returns the StatusCell bound to nb. Apps that
+// removed the default Bottom dock can reinstall it with:
+//
+//	nb.SetDockedCell(notebook.Bottom, notebook.NewStatusCell(nb))
+func NewStatusCell(nb *Notebook) *StatusCell { return &StatusCell{nb: nb} }
+
+// ID implements Cell. Stable identifier; nothing in the framework
+// looks it up but custom keymap actions could.
+func (s *StatusCell) ID() string { return "notebook.status" }
+
+// HeightHint implements Cell. One row — matches the legacy status
+// line. Width is ignored (the status line never wraps).
+func (s *StatusCell) HeightHint(int) int { return 1 }
+
+// RenderRows implements Cell. Single row: "<MODE>  cell <pos>".
+// focused / mode are ignored — the cell reads the current mode
+// from the notebook directly so status reflects the GLOBAL mode
+// even when some other cell or dock is focused.
+func (s *StatusCell) RenderRows(_ int, startRow, endRow int, _ bool, mode Mode) []string {
+	if startRow >= 1 || endRow <= 0 {
+		return nil
+	}
+	return []string{s.line(mode)}
+}
+
+// Update implements Cell. StatusCell is read-only — it never
+// claims a key. handled=false keeps the notebook's KeyMap in
+// charge of bindings that fire while the status cell is focused.
+func (s *StatusCell) Update(tea.Msg, Mode) (Cell, tea.Cmd, bool) {
+	return s, nil, false
+}
+
+// StatusHint implements Cell. Status row has no right-side hint of
+// its own.
+func (s *StatusCell) StatusHint(Mode) string { return "" }
+
+// line builds the rendered string. Matches the legacy
+// model.statusLine output character-for-character so existing
+// tests (and apps doing substring assertions) keep working.
+func (s *StatusCell) line(mode Mode) string {
+	name := "NAV"
+	if mode != nil {
+		name = mode.Name()
+	}
+	pos := "—"
+	if s.nb != nil {
+		count := s.nb.store.count()
+		if count > 0 {
+			pos = strconv.Itoa(s.nb.store.cursorPos()+1) + "/" + strconv.Itoa(count)
+		}
+	}
+	return name + "  cell " + pos
+}

--- a/notebook/store.go
+++ b/notebook/store.go
@@ -11,10 +11,10 @@ import (
 type CellID = string
 
 // store is the shared, RWMutex-guarded notebook state: the cell
-// list, the focused-cell cursor, and the header. The Notebook's
-// CRUD methods mutate it from caller goroutines; the model reads
-// it from the Bubble Tea goroutine. One mutex covers everything
-// mutated from more than one goroutine.
+// list, the focused-cell cursor, the header, and the docked-cell
+// registry. The Notebook's CRUD methods mutate it from caller
+// goroutines; the model reads it from the Bubble Tea goroutine.
+// One mutex covers everything mutated from more than one goroutine.
 //
 // viewport/width/height/mode are NOT here — only the BT goroutine
 // touches those, so they live on the model without a lock.
@@ -25,20 +25,22 @@ type store struct {
 	header     string
 	headerDesc string
 	done       bool
+	docks      map[positionKey]Cell
 }
 
-func newStore() *store { return &store{} }
+func newStore() *store { return &store{docks: map[positionKey]Cell{}} }
 
 // snapshot is an immutable point-in-time copy the model renders
 // from, so View doesn't hold the lock across a full render. The
-// cells slice is copied (cheap — pointers); the cells themselves
-// are shared.
+// cells slice and docks map are copied (cheap — pointers); the
+// cells themselves are shared.
 type snapshot struct {
 	cells  []Cell
 	cursor int
 	header string
 	desc   string
 	done   bool
+	docks  map[positionKey]Cell
 }
 
 func (s *store) snapshot() snapshot {
@@ -46,7 +48,11 @@ func (s *store) snapshot() snapshot {
 	defer s.mu.RUnlock()
 	cp := make([]Cell, len(s.cells))
 	copy(cp, s.cells)
-	return snapshot{cp, s.cursor, s.header, s.headerDesc, s.done}
+	dk := make(map[positionKey]Cell, len(s.docks))
+	for k, v := range s.docks {
+		dk[k] = v
+	}
+	return snapshot{cp, s.cursor, s.header, s.headerDesc, s.done, dk}
 }
 
 // insert places c at index (index < 0 or past the end appends).
@@ -99,6 +105,15 @@ func (s *store) remove(id CellID) bool {
 		s.cursor--
 	}
 	s.clampCursorLocked()
+	// Cell-anchored docks travel with their anchor; once the
+	// anchor is gone the dock can't render anywhere meaningful.
+	// Apps that want to re-anchor the same instance kept their
+	// own ref and call SetDockedCell with a fresh anchor.
+	for k := range s.docks {
+		if k.rel != relNone && k.cellID == id {
+			delete(s.docks, k)
+		}
+	}
 	return true
 }
 
@@ -189,4 +204,46 @@ func (s *store) clampCursorLocked() {
 	if s.cursor < 0 {
 		s.cursor = 0
 	}
+}
+
+// setDock installs c at the given key, replacing any prior occupant.
+func (s *store) setDock(k positionKey, c Cell) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docks[k] = c
+}
+
+// clearDock removes the dock at the given key. Returns true if a
+// dock was present.
+func (s *store) clearDock(k positionKey) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.docks[k]; !ok {
+		return false
+	}
+	delete(s.docks, k)
+	return true
+}
+
+// getDock returns the dock at the given key. The bool reports
+// presence.
+func (s *store) getDock(k positionKey) (Cell, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.docks[k]
+	return c, ok
+}
+
+// updateDock replaces the dock at k by fn(old). Returns false if
+// no dock is present at k. fn runs under the store lock — must be
+// quick and must not call back into the Notebook.
+func (s *store) updateDock(k positionKey, fn func(Cell) Cell) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.docks[k]
+	if !ok {
+		return false
+	}
+	s.docks[k] = fn(c)
+	return true
 }


### PR DESCRIPTION
## What changes

Adds `DockedCells` to the notebook component — positioned cell slots that live outside the cursor-navigable main list. Apps now have a clean way to drop in vim-style command bars, persistent status rows, breadcrumbs, and per-cell annotations, all using the existing `Cell` interface. Closes issue 36.

The hardcoded one-row status line at the bottom is now a built-in `StatusCell` docked at `notebook.Bottom`. Existing rendering is byte-for-byte unchanged in the default case; apps can replace the bottom row with anything that satisfies `Cell` (the worked example wires a `:` chord that drops a vim-style `CommandCell` there).

## Reviewer's guide

Read in this order:

1. [notebook/dock.go](https://github.com/panyam/demokit/pull/37/files#diff-3054a3b0b32cab7f45775620a1390db5c79a1b8a4bf5fcf465a188230ba011e9) — start here. The `Position` interface, the four ctors (`Top` / `Bottom` / `After(id)` / `Before(id)`), and the unexported `positionKey` that backs the registry. The doc comment explains the v1 scope and what's deferred.
2. [notebook/notebook.go](https://github.com/panyam/demokit/pull/37/files#diff-fc8a0cfe266be065f6c84eeb5ac642087bdb6310393ffbd29d5bc1095da8b993) — `SetDockedCell` / `ClearDocked` / `DockedCell` / `FocusDock` / `ReleaseDockFocus` / `ModeCmd`. Note the `safeSend` helper and its doc comment: dock methods MUST NOT `Send` (would deadlock from BT goroutine), mode changes ride as `tea.Cmd`.
3. [notebook/model.go](https://github.com/panyam/demokit/pull/37/files#diff-0d92338ba7adb1172045fae5f90be027b051e1302375bb8712fb50d02426fcb8) — the layout rewrite. `edgeAllotments` enforces the "body has >= 1 row" invariant; `View` interleaves Before/After anchored docks into the body flow and renders Top-head / Bottom-tail when clamped; `handleKey` routes to focused-dock first, falling back to the cursor cell.
4. [notebook/store.go](https://github.com/panyam/demokit/pull/37/files#diff-a75b2600994888b6a8b85c7f4915fe108b488875acbc131cebbb53f3381b74b8) — dock registry (`map[positionKey]Cell`) under the same RWMutex; `remove()` now also wipes any anchored docks for the removed cell.
5. [notebook/status_cell.go](https://github.com/panyam/demokit/pull/37/files#diff-55034caa16f337cbfd5b35328785a98aac58dae79a9fd4e90ba84bac6fd15922) — built-in default Bottom dock, reproduces the legacy status line exactly.
6. [notebook/cells/command.go](https://github.com/panyam/demokit/pull/37/files#diff-60f8ab57ba21d1e816526a8af2d132aacb6adbf15e10d0cdbd5abd415435d135) — `CommandCell` (auto-wrapping single-line input) and the `OpenCommandBar(nb, prompt, onSubmit)` convenience that handles the install / focus / restore cycle in one call.
7. [notebook/dock_test.go](https://github.com/panyam/demokit/pull/37/files#diff-fed3750111ac18c4853e118d3ebc6871571ff2526e9c8e8075b530e19fd89103) + [notebook/cells/command_test.go](https://github.com/panyam/demokit/pull/37/files#diff-744858887dd24cdca2fc52a75fc9effb1323389e457d1ee48dde519966bc3c94) — acceptance for everything above.
8. [notebook/examples/cmdshell/main.go](https://github.com/panyam/demokit/pull/37/files#diff-325b0c1421445c9b39ecf42556192005228f6be6b4ffb23c98eac0e3c4f0772d) + [notebook/examples/cmdshell/README.md](https://github.com/panyam/demokit/pull/37/files#diff-29b90a91d6575f08c42595ff88d6c6373f6769ec3ea56be048499474373cd81c) — worked example: binds `:` to `OpenCommandBar`, demonstrates dock path + prompt path coexisting.
9. [notebook/keymap.go](https://github.com/panyam/demokit/pull/37/files#diff-66ef16dae7adebc7c018b36584c8676f87117cd651c5139be05bfaf1c5392c96) — default `Ctrl+W` chord and the `FocusDock(pos) Action` constructor.
10. [notebook/notebook_test.go](https://github.com/panyam/demokit/pull/37/files#diff-ea552ac8e5b67402c1522b46d794121a1b3cacd969da9afb1555e106fb41053a) — `newSizedModel` helper updated to install the default Bottom dock so body math matches `New()`; two existing tests updated for the new `cellRowSpan` / `bodyHeight` signatures.
11. [ARCHITECTURE.md](https://github.com/panyam/demokit/pull/37/files#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfd) — new "Docked cells" subsection in the Notebook section.

Skim or skip: [notebook/go.mod](https://github.com/panyam/demokit/pull/37/files#diff-3561c18a3daafd45701069d94f1f448fe9fb5dcb60aeb3960e9744ccc18d4ec3) / [notebook/examples/cmdshell/go.mod](https://github.com/panyam/demokit/pull/37/files#diff-d4f714ffb7f7a31478fe92d96f34c733fd4e8f37518e499f86e5a47963e8ad0c) (mod tidy bumped `x/ansi` and `bubbletea` to direct deps).

## Decision log

- **One Cell per Position, not stacked.** The only real-world case for N-per-position is "different anchors on the same cell," which `After(X)` / `Before(X)` already separate. Within a single Position, compose multiple regions into one Cell. Saves a focus-disambiguation story and an N→0 cleanup invariant.
- **Default Bottom = StatusCell, ClearDocked truly empties.** `New()` installs the default; apps that explicitly clear it are opting out of all bottom chrome. Round-trip via `SetDockedCell(Bottom, NewStatusCell(nb))` if you want it back.
- **Top dock subsumes SetHeader? No.** Kept parallel for v1 — `SetHeader` continues to render the existing one-line banner above any Top dock. Subsuming would either silently break apps that call `SetHeader` after replacing Top, or force precedence rules nobody needs yet.
- **App trigger keys are app policy.** The framework ships `SetDockedCell` / `FocusDock` / one default `Ctrl+W` chord. Which key opens which dock (vim's `:`, `?` for help, `g` for goto, etc.) is entirely on the app — usually one line in `KeyMap.Modes[NavigationMode]`. The `cells.OpenCommandBar` convenience packages the common `:command` UX in one call.
- **Left / Right / floating deferred to v2.** Column-split rendering and a Z-order engine are out of scope; the worked example (cmdshell command bar) uses Bottom only. The Position interface is forward-compatible — adding new ctors later is a few-line change.
- **FocusDock / ClearDocked / ReleaseDockFocus do NOT call `program.Send`.** Calling `Send` from inside a KeyMap action deadlocks the BT goroutine. Mode changes return as `tea.Cmd` (see `notebook.ModeCmd`); the action constructor `FocusDock(pos)` and `ToggleBottomDockFocus` bundle the mode flip into their return. Caught this during cmdshell smoke testing — `:` froze the terminal until we removed the `Send` calls.
- **Bottom dock renders TAIL when clamped, Top renders HEAD.** Command bars and tail-style status readouts need the cursor visible (tail). Breadcrumbs / logos read top-first (head). Matches user expectations for each chrome family.

## Risk / blast radius

- **Affects:** every `notebook` consumer — the mathrepl example, the cmdshell example, and the demokit bridge (via `notebookbridge/`). All compile, all tests pass.
- **Tests covering this:** all of `notebook/dock_test.go` (registry, layout, focus, clamp/tail), `notebook/cells/command_test.go` (input, wrap, lifecycle), plus the existing `notebook/notebook_test.go` viewport tests adapted to the new signatures.
- **Be paranoid about:** viewport row accounting when both Top and Bottom are set AND multiple anchored docks are present; mutating an anchored cell from a goroutine while its anchor is being removed (the auto-unregister is atomic under the store lock, but the cell instance itself is app-owned).

## Before / after

Default Bottom is the built-in `StatusCell` — identical output to the prior hardcoded row:

```
$ NAV  cell 1/3
```

In cmdshell, pressing `:` now opens a vim-style command bar at the viewport bottom (grows as you type):

```
: find . -name '*.go' -not -path '*/node_modules/*'█
```

Enter runs the command (stream into a fresh OutputCell); Esc cancels. Status row restored either way.

## Out of scope (deferred)

- `Left` / `Right` edge docks → follow-up issue once a real consumer needs column-split chrome
- Floating overlay (`FloatingAt` / `FloatingNear` / `FloatingCentered` / `FloatingModal`) — needs the Z-order + dismissal engine
- `At(n)` / `AfterActive` / `BeforeActive` — covered redundantly by edges + cell-anchored; defer indefinitely per the issue
- Per-dock-cell mouse handling (click-to-focus on docked rows) — clicks on anchored docks currently resolve to the anchor cell; basic geometry is in place

