### PR TITLE
fix(notebookbridge): catch-up drain so pre-subscribe events render

### DIFF
--- a/notebookbridge/bridge.go
+++ b/notebookbridge/bridge.go
@@ -145,19 +145,35 @@ func (b *Bridge) ensureBridge() {
 func (b *Bridge) drainEvents() {
 	sub := b.queue.Subscribe()
 	defer sub.Close()
-	offset := 0
+	// Catch-up drain before waiting on Notify. demokit.Execute
+	// appends the Header (and usually the first StepStart +
+	// WaitForAdvance) before RenderHeader spawns this goroutine, so
+	// those events predate Subscribe. gocurrent's Notify only fires
+	// for post-subscribe activity — the backlog is reached via
+	// ReadFrom, not Notify — and the producer is already parked in
+	// AwaitResolution for that WaitForAdvance, so no further append
+	// will ever wake us. Without this read we deadlock with an empty
+	// notebook (#40). A post-subscribe append still leaves a pending
+	// Notify token, so the loop below never misses a wakeup.
+	offset := b.drainFrom(0)
 	for {
 		select {
 		case <-sub.Notify():
-			evs, newOff := b.queue.ReadFrom(offset)
-			for i, ev := range evs {
-				b.handleEvent(offset+i, ev)
-			}
-			offset = newOff
+			offset = b.drainFrom(offset)
 		case <-b.nbDone:
 			return
 		}
 	}
+}
+
+// drainFrom dispatches every event at [offset, end) and returns the
+// new offset to resume from.
+func (b *Bridge) drainFrom(offset int) int {
+	evs, newOff := b.queue.ReadFrom(offset)
+	for i, ev := range evs {
+		b.handleEvent(offset+i, ev)
+	}
+	return newOff
 }
 
 func (b *Bridge) handleEvent(off int, ev events.Event) {

--- a/notebookbridge/bridge_test.go
+++ b/notebookbridge/bridge_test.go
@@ -3,8 +3,10 @@ package notebookbridge
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/panyam/demokit/events"
+	"github.com/panyam/demokit/notebook"
 )
 
 func TestSlugifyNormalizesCommonShapes(t *testing.T) {
@@ -74,6 +76,48 @@ func TestBuildCellsFromStepStartProducesHeaderAndVerbatims(t *testing.T) {
 	}
 	if out[1].ID() != "refresh#0.verbatim0" {
 		t.Errorf("verbatim id = %q, want refresh#0.verbatim0", out[1].ID())
+	}
+}
+
+// Regression for #40. demokit.Execute appends the Header (and
+// usually the first StepStart) before RenderHeader spawns the
+// bridge's drain goroutine, so those events predate Subscribe().
+// gocurrent's Notify only fires for post-subscribe activity (see
+// gocurrent's TestLateSubscriberSeesAllPastEvents) — the backlog
+// is reached via ReadFrom, not Notify. With the producer parked
+// in AwaitResolution, no further append ever signals, so a drainer
+// that waits on Notify without an initial catch-up read never sees
+// the header and the notebook renders empty. Here every event is
+// appended before the drainer starts, so only a catch-up drain can
+// surface them.
+func TestDrainDeliversEventsAppendedBeforeSubscribe(t *testing.T) {
+	q := events.NewQueue()
+	q.Append(events.Header{Title: "Cave of Cards", Description: "an adventure"})
+	q.Append(events.StepStart{Visit: 1, StepID: "entrance", Title: "The Entrance"})
+
+	b := New()
+	b.queue = q
+	b.outCellByVisit = map[int]notebook.CellID{}
+	b.nbDone = make(chan struct{})
+	nb := notebook.New(notebook.WithHeadless(), notebook.WithSize(60, 20))
+	b.nb = nb
+	go nb.Run()
+	defer nb.Stop()
+	defer close(b.nbDone)
+
+	go b.drainEvents()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		snap := nb.Snapshot()
+		if strings.Contains(snap, "Cave of Cards") && strings.Contains(snap, "The Entrance") {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("header/step never rendered — events appended before Subscribe were dropped:\n%s", snap)
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
The bridge's drainEvents subscribed and then waited on Notify without an initial ReadFrom. demokit.Execute appends Header (and usually the first StepStart + WaitForAdvance) before RenderHeader spawns the drain goroutine, so those events predate Subscribe. gocurrent's Notify only fires for post-subscribe activity (the backlog is reached via ReadFrom, by design), and the producer is parked in AwaitResolution for that WaitForAdvance, so no further append ever wakes the drainer. Result: an empty notebook showing only the default StatusCell.

Drain once from offset 0 right after Subscribe, then loop on Notify. A post-subscribe append still leaves a pending Notify token, so no wakeup is missed and nothing is double-dispatched.

Fixes dungeon 'make note'. All three examples (dungeon, graph, basic) share this path. Regression test exercises the pre-subscribe ordering against a headless notebook.

Refs issue 40.