### PR TITLE
feat(notebook): stream partial lines + ANSI-aware wrap via LineSource

### DIFF
--- a/notebook/cells/output.go
+++ b/notebook/cells/output.go
@@ -83,7 +83,8 @@ type OutputCell struct {
 	Style OutputStyle
 
 	id           string
-	buf          *notebook.OutputBuffer
+	buf          *notebook.OutputBuffer // storage + streaming sink (Stream/Buffer)
+	layout       notebook.LineSource    // width→visual-rows view over buf; swappable impl
 	maxBody      int
 	clip         notebook.Clipboard
 	fallbackClip notebook.Clipboard
@@ -92,6 +93,7 @@ type OutputCell struct {
 	done         bool
 	copyMsg      string
 	lastCopy     string // payload retained after 'c' so 't' can replay it
+	lastWidth    int    // body width from the last render; scopes key/wheel scroll math to visual rows
 }
 
 // NewOutput builds an OutputCell over a fresh OutputBuffer.
@@ -101,9 +103,11 @@ func NewOutput(id string, maxBody int) *OutputCell {
 	if maxBody <= 0 {
 		maxBody = defaultMaxBody
 	}
+	buf := notebook.NewOutputBuffer()
 	return &OutputCell{
 		id:      id,
-		buf:     notebook.NewOutputBuffer(),
+		buf:     buf,
+		layout:  notebook.NewEagerLineSource(buf),
 		maxBody: maxBody,
 		Style:   DefaultOutputStyle(),
 		clip:    notebook.NoClipboard,
@@ -150,18 +154,39 @@ func (c *OutputCell) SetMaxBody(n int) {
 		return
 	}
 	c.maxBody = n
-	c.clampScroll()
+	c.clampScroll(c.rowCount())
 }
 
 // ID implements notebook.Cell.
 func (c *OutputCell) ID() string { return c.id }
 
+// bodyWidth is the usable text-column count inside the box at the
+// given outer width. innerWidth nets out the border budget and one
+// Padding(0,1); lipgloss's Width(inner) reserves that padding again
+// inside the box, so the real content area is two columns narrower.
+// Wrapping to anything wider lets lipgloss re-wrap and desync the
+// row count against HeightHint.
+func (c *OutputCell) bodyWidth(width int) int {
+	return max(innerWidth(width, c.Style.Edges)-2, 1)
+}
+
+// rowCount reports the total visual-row count at the last rendered
+// width. Before the first render (lastWidth == 0) it falls back to
+// the logical line count — a safe proxy for the "does the buffer
+// overflow maxBody?" checks until a real width is known.
+func (c *OutputCell) rowCount() int {
+	if c.lastWidth <= 0 {
+		return c.buf.LineCount()
+	}
+	return c.layout.RowCount(c.lastWidth)
+}
+
 // HeightHint implements notebook.Cell. Box = (top border?) +
 // title + body + status + (bottom border?). An empty buffer
 // still reserves one body row for the "(no output yet)"
 // placeholder. Chrome shrinks when Style.Edges turns sides off.
-func (c *OutputCell) HeightHint(_ int) int {
-	bodyRows := c.buf.LineCount()
+func (c *OutputCell) HeightHint(width int) int {
+	bodyRows := c.layout.RowCount(c.bodyWidth(width))
 	if bodyRows == 0 {
 		bodyRows = 1
 	}
@@ -177,27 +202,18 @@ func (c *OutputCell) HeightHint(_ int) int {
 
 // RenderRows implements notebook.Cell.
 func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ notebook.Mode) []string {
-	c.clampScroll()
+	inner := innerWidth(width, c.Style.Edges)
+	c.lastWidth = c.bodyWidth(width)
+	totalRows := c.layout.RowCount(c.lastWidth)
+	c.clampScroll(totalRows)
 
 	border := c.Style.BorderColor
 	if focused {
 		border = c.Style.FocusBorderColor
 	}
 
-	totalLines := c.buf.LineCount()
-	bodyRows := min(totalLines, c.maxBody)
-	body := c.buf.Lines(c.scrollOffset, c.scrollOffset+bodyRows)
-	// Hard-truncate long lines so lipgloss doesn't wrap them: a
-	// wrap would push the box past HeightHint and desync viewport
-	// row math.
-	inner := innerWidth(width, c.Style.Edges)
-	for i, line := range body {
-		line = strings.TrimRight(line, "\r")
-		if len(line) > inner {
-			line = line[:inner]
-		}
-		body[i] = line
-	}
+	bodyRows := min(totalRows, c.maxBody)
+	body := c.layout.Rows(c.lastWidth, c.scrollOffset, c.scrollOffset+bodyRows)
 
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(c.Style.TitleColor)
 	dim := lipgloss.NewStyle().Foreground(c.Style.DimColor)
@@ -213,7 +229,7 @@ func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 	if bodyText == "" {
 		bodyText = dim.Render("(no output yet)")
 	}
-	status := dim.Render(c.statusLine(totalLines))
+	status := dim.Render(c.statusLine(totalRows))
 	content := title + "\n" + bodyText + "\n" + status
 
 	boxStyle := lipgloss.NewStyle().
@@ -226,22 +242,22 @@ func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 		Padding(0, 1).
 		Width(inner)
 	rendered := boxStyle.Render(content)
-	rows := strings.Split(rendered, "\n")
+	boxRows := strings.Split(rendered, "\n")
 	if c.copyMsg != "" {
-		rows = append(rows, "  "+c.copyMsg)
+		boxRows = append(boxRows, "  "+c.copyMsg)
 	}
 
 	if startRow < 0 {
 		startRow = 0
 	}
-	if endRow > len(rows) {
-		endRow = len(rows)
+	if endRow > len(boxRows) {
+		endRow = len(boxRows)
 	}
 	if startRow >= endRow {
 		return nil
 	}
 	out := make([]string, endRow-startRow)
-	copy(out, rows[startRow:endRow])
+	copy(out, boxRows[startRow:endRow])
 	return out
 }
 
@@ -266,19 +282,19 @@ func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea
 		if mode != notebook.CellActiveMode {
 			return c, nil, false
 		}
-		if c.buf.LineCount() <= c.maxBody {
+		if c.rowCount() <= c.maxBody {
 			return c, nil, false
 		}
 		switch mouse.Button {
 		case tea.MouseButtonWheelUp:
 			c.follow = false
 			c.scrollOffset--
-			c.clampScroll()
+			c.clampScroll(c.rowCount())
 			return c, nil, true
 		case tea.MouseButtonWheelDown:
 			c.follow = false
 			c.scrollOffset++
-			c.clampScroll()
+			c.clampScroll(c.rowCount())
 			return c, nil, true
 		}
 		return c, nil, false
@@ -328,22 +344,22 @@ func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea
 	case "j", "down":
 		c.follow = false
 		c.scrollOffset++
-		c.clampScroll()
+		c.clampScroll(c.rowCount())
 		return c, nil, true
 	case "k", "up":
 		c.follow = false
 		c.scrollOffset--
-		c.clampScroll()
+		c.clampScroll(c.rowCount())
 		return c, nil, true
 	case "pgdown":
 		c.follow = false
 		c.scrollOffset += c.maxBody
-		c.clampScroll()
+		c.clampScroll(c.rowCount())
 		return c, nil, true
 	case "pgup":
 		c.follow = false
 		c.scrollOffset -= c.maxBody
-		c.clampScroll()
+		c.clampScroll(c.rowCount())
 		return c, nil, true
 	case "g":
 		c.follow = false
@@ -351,8 +367,8 @@ func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea
 		return c, nil, true
 	case "G":
 		c.follow = true
-		c.scrollOffset = c.buf.LineCount()
-		c.clampScroll()
+		c.scrollOffset = c.rowCount()
+		c.clampScroll(c.rowCount())
 		return c, nil, true
 	}
 	return c, nil, false
@@ -360,22 +376,23 @@ func (c *OutputCell) Update(msg tea.Msg, mode notebook.Mode) (notebook.Cell, tea
 
 // StatusHint implements notebook.Cell.
 func (c *OutputCell) StatusHint(_ notebook.Mode) string {
-	if c.buf.LineCount() > c.maxBody {
+	if c.rowCount() > c.maxBody {
 		return "j/k scroll · g/G top/bot · c copy"
 	}
 	return "c copy"
 }
 
-// clampScroll updates scrollOffset for the current LineCount. When
-// follow is true, it sticks scrollOffset to the end of the buffer
-// so the latest maxBody lines stay visible (the "tail -f" behavior).
-// When follow is false, it just clamps the manually-set offset.
+// clampScroll keeps scrollOffset valid for a body of total visual
+// rows. When follow is true, it sticks the offset to the end so
+// the latest maxBody rows stay visible (the "tail -f" behavior);
+// when false, it just clamps the manually-set offset. total is the
+// visual-row count (logical lines after wrapping), so follow tails
+// the last wrapped row of the in-flight line, not just whole lines.
 //
 // Called at the top of RenderRows so every frame reflects the
 // current buffer state without an external "append happened"
 // hook — Stream writes to the buffer, the next render picks it up.
-func (c *OutputCell) clampScroll() {
-	total := c.buf.LineCount()
+func (c *OutputCell) clampScroll(total int) {
 	if c.follow {
 		c.scrollOffset = total - c.maxBody
 	}
@@ -388,7 +405,7 @@ func (c *OutputCell) clampScroll() {
 	}
 }
 
-// statusLine builds the "[ x-y / total ]" indicator.
+// statusLine builds the "[ x-y / total ]" indicator over visual rows.
 func (c *OutputCell) statusLine(total int) string {
 	end := min(c.scrollOffset+c.maxBody, total)
 	if total <= c.maxBody {

--- a/notebook/cells/output_wrap_test.go
+++ b/notebook/cells/output_wrap_test.go
@@ -1,0 +1,34 @@
+package cells
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/panyam/demokit/notebook"
+)
+
+// A logical line wider than the box wraps onto several visual rows
+// rather than being truncated: all of its content is rendered, and
+// no rendered row is wider than the inner width.
+func TestOutputCellWrapsLongLineInsteadOfTruncating(t *testing.T) {
+	c := NewOutput("o", 100)
+	c.Buffer().Append([]byte(strings.Repeat("x", 200) + "\n"))
+
+	joined := strings.Join(allRows(c, 40, false, notebook.CellActiveMode), "\n")
+	if got := strings.Count(joined, "x"); got != 200 {
+		t.Fatalf("wrapped render has %d x's, want all 200 (truncation drops content)", got)
+	}
+}
+
+// Bytes written without a trailing newline render immediately —
+// the in-flight partial line is visible, not buffered out of sight
+// until a '\n' arrives.
+func TestOutputCellShowsInFlightPartialLine(t *testing.T) {
+	c := NewOutput("o", 100)
+	c.Buffer().Append([]byte("streaming-token"))
+
+	joined := strings.Join(allRows(c, 80, false, notebook.CellActiveMode), "\n")
+	if !strings.Contains(joined, "streaming-token") {
+		t.Fatalf("partial line not rendered before newline:\n%s", joined)
+	}
+}

--- a/notebook/line_source.go
+++ b/notebook/line_source.go
@@ -1,0 +1,139 @@
+package notebook
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// LineSource is the width-parameterized row layout an OutputCell
+// renders from. It maps a buffer of logical lines onto the visual
+// rows that actually paint at a given column width — wrapping long
+// lines, accounting for ANSI/wide characters — and answers the two
+// queries a scrolling viewport needs:
+//
+//   - RowCount(width): how many visual rows at this width (height,
+//     scrollbar, follow/clamp math).
+//   - Rows(width, start, end): just the visible window [start, end).
+//
+// The cell programs against this interface, not against a concrete
+// buffer, so the layout implementation is swappable without
+// touching the cell. The default EagerLineSource re-wraps the whole
+// buffer on every call — correct and simple, fine for the dozens-
+// to-hundreds of rows a notebook cell holds. A large, continuously
+// growing scrollback (a streaming log/CLI tail) wants an indexed
+// implementation: keep per-line visual-row counts in a Fenwick tree
+// (binary indexed tree) so RowCount is a prefix sum and "which
+// logical line owns visual row R" is a prefix-sum lower-bound, both
+// O(log N), with O(log N) updates on append. That impl plugs in
+// here with no cell changes. See the design issue for the plan.
+type LineSource interface {
+	// RowCount returns the number of visual rows at width columns.
+	RowCount(width int) int
+	// Rows returns visual rows in the half-open range [start, end),
+	// clamped to the available range. Out-of-range returns nil.
+	Rows(width, start, end int) []string
+}
+
+// EagerLineSource is the no-cache LineSource: it wraps every logical
+// line in its backing OutputBuffer on each query. Storage stays in
+// the OutputBuffer (the io.Writer streaming sink); this type only
+// owns layout, so swapping it for an indexed source leaves the
+// write path untouched.
+type EagerLineSource struct {
+	buf *OutputBuffer
+}
+
+// NewEagerLineSource returns an EagerLineSource laying out buf.
+func NewEagerLineSource(buf *OutputBuffer) *EagerLineSource {
+	return &EagerLineSource{buf: buf}
+}
+
+// RowCount implements LineSource.
+func (s *EagerLineSource) RowCount(width int) int {
+	return len(s.rows(width))
+}
+
+// Rows implements LineSource.
+func (s *EagerLineSource) Rows(width, start, end int) []string {
+	rows := s.rows(width)
+	if start < 0 {
+		start = 0
+	}
+	if end > len(rows) {
+		end = len(rows)
+	}
+	if start >= end {
+		return nil
+	}
+	out := make([]string, end-start)
+	copy(out, rows[start:end])
+	return out
+}
+
+// rows wraps the buffer's logical lines to width visible columns.
+func (s *EagerLineSource) rows(width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	logical := s.buf.Lines(0, s.buf.LineCount())
+	rows := make([]string, 0, len(logical))
+	for _, line := range logical {
+		rows = append(rows, wrapANSILine(strings.TrimRight(line, "\r"), width)...)
+	}
+	return rows
+}
+
+// wrapANSILine hard-wraps one logical line to width visible columns,
+// carrying SGR color across row breaks. ansi.Hardwrap keeps escape
+// bytes where they sit but does not reopen the active style on the
+// next row, so a long colored run would lose its color after the
+// first break; we reopen the active SGR at the start of each
+// continuation row and close it at the end of the prior one.
+func wrapANSILine(line string, width int) []string {
+	rows := strings.Split(ansi.Hardwrap(line, width, false), "\n")
+	if len(rows) <= 1 {
+		return rows
+	}
+	active := ""
+	for i := range rows {
+		if i > 0 && active != "" {
+			rows[i] = active + rows[i]
+		}
+		active = activeSGRAfter(active, rows[i])
+		if i < len(rows)-1 && active != "" {
+			rows[i] += "\x1b[0m"
+		}
+	}
+	return rows
+}
+
+// activeSGRAfter returns the SGR escape sequences still in effect at
+// the end of s, given those active before it. A reset ("\x1b[0m" /
+// "\x1b[m") clears the set; any other SGR sequence is appended. It
+// tracks the running prefix rather than a full attribute model —
+// enough to reopen color/style on a wrapped continuation row.
+func activeSGRAfter(before, s string) string {
+	active := before
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && (s[j] < 0x40 || s[j] > 0x7e) {
+				j++
+			}
+			if j < len(s) {
+				if seq := s[i : j+1]; s[j] == 'm' {
+					if seq == "\x1b[0m" || seq == "\x1b[m" {
+						active = ""
+					} else {
+						active += seq
+					}
+				}
+				i = j + 1
+				continue
+			}
+		}
+		i++
+	}
+	return active
+}

--- a/notebook/line_source_test.go
+++ b/notebook/line_source_test.go
@@ -1,0 +1,56 @@
+package notebook
+
+import (
+	"strings"
+	"testing"
+)
+
+// A logical line wider than the layout width wraps onto several
+// visual rows; all content is preserved (no truncation) and no row
+// exceeds the width.
+func TestEagerLineSourceWrapsLongLine(t *testing.T) {
+	buf := NewOutputBuffer()
+	buf.Append([]byte(strings.Repeat("x", 200) + "\n"))
+	src := NewEagerLineSource(buf)
+
+	rows := src.Rows(40, 0, src.RowCount(40))
+	if len(rows) < 5 {
+		t.Fatalf("long line should wrap to several rows, got %d", len(rows))
+	}
+	if got := strings.Count(strings.Join(rows, ""), "x"); got != 200 {
+		t.Fatalf("wrapping dropped content: %d x's, want 200", got)
+	}
+}
+
+// Wrapping is ANSI-aware: a colored logical line that spills across
+// rows keeps its SGR color on every wrapped row (color isn't lost
+// after the first break, and escapes aren't split mid-sequence).
+func TestEagerLineSourceWrapPreservesAnsiColor(t *testing.T) {
+	const red = "\x1b[31m"
+	buf := NewOutputBuffer()
+	buf.Append([]byte(red + strings.Repeat("x", 200) + "\x1b[0m\n"))
+	src := NewEagerLineSource(buf)
+
+	rows := src.Rows(38, 0, src.RowCount(38))
+	if len(rows) < 2 {
+		t.Fatalf("expected the long line to wrap, got %d rows", len(rows))
+	}
+	for i, r := range rows {
+		if strings.Contains(r, "x") && !strings.Contains(r, "\x1b[3") {
+			t.Fatalf("wrapped row %d lost its color: %q", i, r)
+		}
+	}
+}
+
+// The in-flight partial line (no trailing '\n') is laid out like any
+// other line, so sub-line streaming is visible immediately.
+func TestEagerLineSourceShowsInFlightPartial(t *testing.T) {
+	buf := NewOutputBuffer()
+	buf.Append([]byte("streaming-token"))
+	src := NewEagerLineSource(buf)
+
+	rows := src.Rows(80, 0, src.RowCount(80))
+	if strings.Join(rows, "") != "streaming-token" {
+		t.Fatalf("partial line not laid out: %q", rows)
+	}
+}

--- a/notebook/output_buffer.go
+++ b/notebook/output_buffer.go
@@ -9,6 +9,14 @@ import (
 // reads from. Streaming chunks flow in via Append; the cell's
 // HeightHint reads LineCount; RenderRows reads Lines(start, end).
 //
+// '\n' splits the stream into logical lines but is NOT a
+// visibility gate: the in-flight trailing line (bytes written
+// since the last '\n') is surfaced by the readers as the last
+// logical line, so sub-line streaming — an agent emitting tokens,
+// a progress line with no newline yet — is visible immediately
+// instead of waiting for a '\n' to commit it. Once a '\n' arrives
+// that line is finalized and the next write starts a fresh one.
+//
 // Lives in the notebook package (not notebook/cells) so the
 // Notebook runtime can hand callers an io.Writer over a cell's
 // buffer via Stream() without importing the cells subpackage.
@@ -17,8 +25,8 @@ import (
 // Lines, AllLines) — readers take the RWMutex read lock.
 type OutputBuffer struct {
 	mu      sync.RWMutex
-	pending []byte   // partial line being assembled — not in lines[] yet
-	lines   []string // committed completed lines (no trailing \n)
+	pending []byte   // in-flight trailing line — surfaced as the last logical line
+	lines   []string // finalized lines (each had a terminating \n, stored without it)
 }
 
 // NewOutputBuffer returns an empty buffer ready to receive Append
@@ -56,41 +64,62 @@ func (b *OutputBuffer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// LineCount returns the number of committed lines. The in-flight
-// partial line (pending) is not counted — it becomes visible only
-// after a newline arrives.
+// LineCount returns the number of logical lines, including the
+// in-flight trailing line when one is being assembled (bytes
+// written since the last '\n'). Counts up the moment a partial
+// line has any content, so callers reserve a row for it.
 func (b *OutputBuffer) LineCount() int {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	return len(b.lines)
+	return b.lineCountLocked()
 }
 
-// Lines returns lines in the half-open range [start, end), clamped
-// to the available range. An out-of-range request returns nil
+func (b *OutputBuffer) lineCountLocked() int {
+	n := len(b.lines)
+	if len(b.pending) > 0 {
+		n++
+	}
+	return n
+}
+
+// Lines returns logical lines in the half-open range [start, end),
+// clamped to the available range. The in-flight trailing line is
+// included as the final line. An out-of-range request returns nil
 // rather than panicking.
 func (b *OutputBuffer) Lines(start, end int) []string {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+	total := b.lineCountLocked()
 	if start < 0 {
 		start = 0
 	}
-	if end > len(b.lines) {
-		end = len(b.lines)
+	if end > total {
+		end = total
 	}
 	if start >= end {
 		return nil
 	}
-	out := make([]string, end-start)
-	copy(out, b.lines[start:end])
+	out := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		if i < len(b.lines) {
+			out = append(out, b.lines[i])
+		} else {
+			out = append(out, string(b.pending))
+		}
+	}
 	return out
 }
 
-// AllLines returns a copy of every committed line. Intended for
-// the OutputCell "copy entire cell" action.
+// AllLines returns a copy of every logical line, including the
+// in-flight trailing line. Intended for the OutputCell "copy
+// entire cell" action.
 func (b *OutputBuffer) AllLines() []string {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	out := make([]string, len(b.lines))
-	copy(out, b.lines)
+	out := make([]string, 0, b.lineCountLocked())
+	out = append(out, b.lines...)
+	if len(b.pending) > 0 {
+		out = append(out, string(b.pending))
+	}
 	return out
 }

--- a/notebook/output_buffer_test.go
+++ b/notebook/output_buffer_test.go
@@ -1,0 +1,37 @@
+package notebook
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The in-flight trailing line (bytes since the last '\n') is a
+// visible logical line, not hidden until a newline commits it —
+// so sub-line streaming surfaces immediately.
+func TestOutputBufferSurfacesInFlightPartialLine(t *testing.T) {
+	b := NewOutputBuffer()
+
+	b.Append([]byte("Thinking"))
+	if got := b.LineCount(); got != 1 {
+		t.Fatalf("partial line: LineCount = %d, want 1", got)
+	}
+	if got := b.Lines(0, 1); !reflect.DeepEqual(got, []string{"Thinking"}) {
+		t.Fatalf("partial line: Lines = %q, want [Thinking]", got)
+	}
+
+	b.Append([]byte("... done\n"))
+	if got := b.LineCount(); got != 1 {
+		t.Fatalf("after newline: LineCount = %d, want 1 (line finalized in place)", got)
+	}
+	if got := b.Lines(0, 1); !reflect.DeepEqual(got, []string{"Thinking... done"}) {
+		t.Fatalf("after newline: Lines = %q, want [Thinking... done]", got)
+	}
+
+	b.Append([]byte("next"))
+	if got := b.LineCount(); got != 2 {
+		t.Fatalf("second partial: LineCount = %d, want 2", got)
+	}
+	if got := b.AllLines(); !reflect.DeepEqual(got, []string{"Thinking... done", "next"}) {
+		t.Fatalf("AllLines = %q, want [Thinking... done next]", got)
+	}
+}


### PR DESCRIPTION
## What changes

OutputCell streaming rendered line-by-line: a chunk with no trailing `\n` was buffered out of sight, and long lines were hard-truncated to the box width. So sub-line streaming (agent tokens, a progress line, a spinner) showed nothing until a newline arrived, and wide content was silently clipped.

Now: the in-flight partial line is visible immediately (`\n` delimits lines but no longer gates visibility), and long lines wrap (ANSI-aware) instead of truncating. The wrapping lives behind a new `LineSource` interface so the layout implementation is swappable without touching the cell.

## Reviewer's guide

Read in this order:
1. [notebook/output_buffer.go](https://github.com/panyam/demokit/pull/42/files#diff-d798349c3e5dfaa7fef7c02504ded0707a2199752e212dfbf95ca0cfa241fca9) — start here. The in-flight trailing line is now surfaced as the last logical line by `LineCount`/`Lines`/`AllLines` (storage change; `\n` no longer a visibility gate).
2. [notebook/line_source.go](https://github.com/panyam/demokit/pull/42/files#diff-62845729b5e3f2539b84d0a99abc8a0bfc6a6826c34b7baf5af4eb7ccf82a37a) — the new `LineSource` interface (`RowCount(width)`, `Rows(width, start, end)`) and the default `EagerLineSource`. This is where wrapping now lives: ANSI-aware width, no escape splitting, SGR color reopened on continuation rows. Note the doc comment on the Fenwick-backed future impl.
3. [notebook/cells/output.go](https://github.com/panyam/demokit/pull/42/files#diff-1edf40065bd671db3324a14b35826460db8598822b4a850a8c525fbb788dbe22) — the cell now programs against `LineSource`: scroll/follow/status/height operate on visual rows; `bodyWidth` wraps to the real content width (`inner-2`) so `HeightHint` matches the rendered row count.
4. [notebook/line_source_test.go](https://github.com/panyam/demokit/pull/42/files#diff-d623df8f1db2c13fe44163f75c9d06dceca4f390ad93b8e7be2404f085523fa2) — acceptance for wrap + ANSI carry + partial-line layout.
5. [notebook/output_buffer_test.go](https://github.com/panyam/demokit/pull/42/files#diff-afdfbd3186621ea386d7f381e23ddb7e0337b2d34200906cfa7898b0fd1ae9f9), [notebook/cells/output_wrap_test.go](https://github.com/panyam/demokit/pull/42/files#diff-b34067bb43b08a5cad1af04d2b553e213022e9ff9604224067c2831796fe578f) — partial-line surfacing at the buffer and cell levels.

## Decision log

- **Layout behind an interface, storage left alone.** `LineSource` abstracts the width→visual-rows mapping (the part a future indexed/Fenwick impl optimizes); `OutputBuffer` stays the storage + `io.Writer` sink, so the streaming write path and existing tests are untouched.
- **Pure `RowCount(width)`/`Rows(width,...)`, not stateful `SetWidth`.** Stateful width would enable incremental index updates on append, but adds temporal coupling, a single-width assumption, and moves concurrency into the source. Deferred: the right stateful/invalidation contract is best designed alongside the indexed impl. (Captured in issue 43.)
- **Hand-rolled SGR carry.** `ansi.Hardwrap` is width-correct and never splits an escape, but does not reopen the active style on the next row — a long colored run would lose color after the first break. Added a small SGR-prefix tracker to reopen it.
- **Wrap to `inner-2`.** lipgloss `Width(inner)` + `Padding(0,1)` reserves the padding inside the box, so the real content area is two columns narrower; wrapping wider lets lipgloss re-wrap and desync the row count vs `HeightHint`.

## Risk / blast radius

- Affects: every `OutputCell` (notebookbridge dungeon/graph/basic, mathrepl `series`/`lines`, cmdshell). All use the same cell + buffer path.
- Tests covering this: notebook + cells suites (existing scroll/follow/copy/height tests pass unchanged — they use short, non-wrapping lines; visual rows == logical lines there).
- Be paranoid about: `HeightHint` == rendered-row-count invariant under wrapping (viewport row math depends on it); follow-mode tailing the last *visual* row; ANSI carry on multi-attribute SGR runs (the tracker carries a running prefix, not a full attribute model).

## Out of scope (deliberately deferred)

- Indexed (Fenwick-backed) `LineSource` for large scrollback, and the stateful-width interface question → issue 43.
- Lockstep release: tag notebook + bump demokit's `require` after merge.


