### PR TITLE
chore: bump notebook to v0.0.24 across modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/muesli/cancelreader v0.2.2
-	github.com/panyam/demokit/notebook v0.0.23
+	github.com/panyam/demokit/notebook v0.0.24
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/servicekit v0.1.1
 	github.com/panyam/templar v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/panyam/demokit/notebook v0.0.2 h1:v2/f/KmUl9oZUvabrl+Y3lTSIEAjs176jCJ
 github.com/panyam/demokit/notebook v0.0.2/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsUDoCNXlcBU=
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
+github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezegaU=
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=

--- a/notebook/examples/cmdshell/go.mod
+++ b/notebook/examples/cmdshell/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
-	github.com/panyam/demokit/notebook v0.0.23
+	github.com/panyam/demokit/notebook v0.0.24
 )
 
 require (

--- a/notebook/examples/cmdshell/go.sum
+++ b/notebook/examples/cmdshell/go.sum
@@ -50,6 +50,8 @@ github.com/panyam/demokit/notebook v0.0.2 h1:v2/f/KmUl9oZUvabrl+Y3lTSIEAjs176jCJ
 github.com/panyam/demokit/notebook v0.0.2/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsUDoCNXlcBU=
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
+github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/notebook/examples/mathrepl/go.mod
+++ b/notebook/examples/mathrepl/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/expr-lang/expr v1.17.8
-	github.com/panyam/demokit/notebook v0.0.23
+	github.com/panyam/demokit/notebook v0.0.24
 )
 
 require (

--- a/notebook/examples/mathrepl/go.sum
+++ b/notebook/examples/mathrepl/go.sum
@@ -52,6 +52,8 @@ github.com/panyam/demokit/notebook v0.0.2 h1:v2/f/KmUl9oZUvabrl+Y3lTSIEAjs176jCJ
 github.com/panyam/demokit/notebook v0.0.2/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsUDoCNXlcBU=
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
+github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
Pick up the OutputCell streaming/wrap change (notebook/v0.0.24 — partial-line streaming + ANSI-aware wrap via LineSource, PR 42).

Bumps the `github.com/panyam/demokit/notebook` require + go.sum to v0.0.24 in:
- the demokit module (go.mod)
- notebook/examples/cmdshell
- notebook/examples/mathrepl

The notebook/v0.0.24 tag is already pushed, so these resolve. Local dev already used the workspace copy; this is for external builds / fresh clones.

After merge: tag the demokit root module v0.0.24 at the merged HEAD (so demokit v0.0.24 consistently requires notebook v0.0.24).