### PR TITLE
feat(notebook)!: mandatory Reveal on Append/Insert + rendezvous resolve-before-register

### DIFF
--- a/advance_contract_test.go
+++ b/advance_contract_test.go
@@ -1,0 +1,28 @@
+package demokit
+
+import (
+	"testing"
+
+	"github.com/panyam/demokit/events"
+)
+
+// Source side of the advance handshake contract: an event-aware
+// renderer calls queue.Resolve when the user advances, while the
+// demokit loop sits in AwaitResolution. If Resolve lands FIRST, the
+// resolution must not be lost. demokit's queue honors this; the
+// notebook rendezvous mirrors it (see notebook.TestRendezvous...).
+//
+// Characterization test — guards the behavior the WaitForAdvance
+// flow depends on against a future queue change.
+func TestQueueResolveBeforeAwaitNotLost(t *testing.T) {
+	q := events.NewQueue()
+	off := q.Append(events.WaitForAdvance{})
+	if err := q.Resolve(off, &events.AdvanceResolution{Source: "user"}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	got := q.AwaitResolution(off) // resolution already present — must return, not block
+	res, ok := got.(*events.AdvanceResolution)
+	if !ok || res.Source != "user" {
+		t.Fatalf("AwaitResolution after Resolve = %#v, want *events.AdvanceResolution{Source:user}", got)
+	}
+}

--- a/notebook/concurrent_test.go
+++ b/notebook/concurrent_test.go
@@ -74,7 +74,7 @@ func TestStreamFillsCellIncrementally(t *testing.T) {
 	t.Cleanup(nb.Stop)
 
 	c := newStreamCell("out")
-	nb.Append(c)
+	nb.Append(c, RevealNone)
 	w := nb.Stream("out")
 	for i := 0; i < 5; i++ {
 		fmt.Fprintf(w, "line %d\n", i)
@@ -95,7 +95,7 @@ func TestStreamAfterRemoveDiscards(t *testing.T) {
 	t.Cleanup(nb.Stop)
 
 	c := newStreamCell("out")
-	nb.Append(c)
+	nb.Append(c, RevealNone)
 	w := nb.Stream("out")
 	nb.Remove("out")
 	// After removal, the next Stream("out") returns Discard.
@@ -127,7 +127,7 @@ func TestPromptResolvesWithSubmittedAnswer(t *testing.T) {
 	go nb.Run()
 	t.Cleanup(nb.Stop)
 
-	nb.Append(newStreamCell("p")) // any cell; AwaitInputBy doesn't care
+	nb.Append(newStreamCell("p"), RevealNone) // any cell; AwaitInputBy doesn't care
 	done := make(chan InputResponse, 1)
 	go func() { done <- nb.AwaitInputBy("p") }()
 	waitForInputWaiter(t, nb, "p")
@@ -154,7 +154,7 @@ func TestAwaitInputCancelledOnRemove(t *testing.T) {
 	go nb.Run()
 	t.Cleanup(nb.Stop)
 
-	nb.Append(newStreamCell("p"))
+	nb.Append(newStreamCell("p"), RevealNone)
 	done := make(chan InputResponse, 1)
 	go func() { done <- nb.AwaitInputBy("p") }()
 	waitForInputWaiter(t, nb, "p")
@@ -176,7 +176,7 @@ func TestStopUnblocksAwaitInput(t *testing.T) {
 	nb := New(WithHeadless(), WithSize(40, 10))
 	go nb.Run()
 
-	nb.Append(newStreamCell("p"))
+	nb.Append(newStreamCell("p"), RevealNone)
 	done := make(chan InputResponse, 1)
 	go func() { done <- nb.AwaitInputBy("p") }()
 	waitForInputWaiter(t, nb, "p")
@@ -202,7 +202,7 @@ func TestConcurrentStreams(t *testing.T) {
 	const cells = 4
 	const linesPerCell = 200
 	for i := 0; i < cells; i++ {
-		nb.Append(newStreamCell(fmt.Sprintf("c%d", i)))
+		nb.Append(newStreamCell(fmt.Sprintf("c%d", i)), RevealNone)
 	}
 	var wg sync.WaitGroup
 	for i := 0; i < cells; i++ {
@@ -230,7 +230,7 @@ func TestAppendDuringStream(t *testing.T) {
 	t.Cleanup(nb.Stop)
 
 	c := newStreamCell("stream")
-	nb.Append(c)
+	nb.Append(c, RevealNone)
 	w := nb.Stream("stream")
 
 	streamDone := make(chan struct{})
@@ -243,7 +243,7 @@ func TestAppendDuringStream(t *testing.T) {
 
 	// Append many cells while the stream runs.
 	for i := 0; i < 100; i++ {
-		if _, err := nb.Append(newStreamCell(fmt.Sprintf("a%d", i))); err != nil {
+		if _, err := nb.Append(newStreamCell(fmt.Sprintf("a%d", i)), RevealNone); err != nil {
 			t.Fatalf("Append a%d error: %v", i, err)
 		}
 	}
@@ -263,7 +263,7 @@ func TestStreamLineCountUnderLoad(t *testing.T) {
 	t.Cleanup(nb.Stop)
 
 	c := newStreamCell("hi")
-	nb.Append(c)
+	nb.Append(c, RevealNone)
 	w := nb.Stream("hi")
 
 	const N = 5000

--- a/notebook/crud.go
+++ b/notebook/crud.go
@@ -4,20 +4,62 @@ package notebook
 // are safe from any goroutine. The model's repaint tick picks
 // changes up within one frame.
 
-// Append adds c to the end of the cell list. On a duplicate ID
-// returns an error; the cell is not added. Auto-wires the
-// configured clipboard into cells that implement SetClipboard.
-func (nb *Notebook) Append(c Cell) (CellID, error) {
-	nb.injectClipboard(c)
-	return nb.store.insert(-1, c)
+// Reveal tells Append / Insert whether to scroll the new cell into
+// view. It is a mandatory parameter (not an option with a silent
+// default) so every caller makes a deliberate choice — the common
+// "I appended a streaming cell but it never shows up" bug comes from
+// forgetting to follow it, and a required arg surfaces that at the
+// call site instead of at runtime on a short terminal.
+type Reveal int
+
+const (
+	// RevealNone leaves the viewport where it is. The new cell may be
+	// off-screen until the user scrolls to it. Pass this explicitly
+	// when the cell isn't what the user should be looking at.
+	RevealNone Reveal = iota
+	// RevealBottom scrolls the new cell into view and makes it the
+	// viewport's follow anchor (the cursor), so it stays visible as it
+	// streams/grows — the `tail -f` behavior. Use for output a caller
+	// streams into, prompts, and anything the user should track.
+	RevealBottom
+	// Future: RevealTop, RevealMiddle (see issues). Adding values here
+	// is backward-compatible — the enum, not the signature, grows.
+)
+
+// Append adds c to the end of the cell list and reveals it per the
+// given Reveal. On a duplicate ID returns an error; the cell is not
+// added. Auto-wires the configured clipboard into cells that
+// implement SetClipboard.
+func (nb *Notebook) Append(c Cell, reveal Reveal) (CellID, error) {
+	return nb.Insert(-1, c, reveal)
 }
 
 // Insert places c at the given index — index < 0 or past the end
-// appends. On a duplicate ID returns an error; the cell is not
-// inserted. Auto-wires the configured clipboard.
-func (nb *Notebook) Insert(index int, c Cell) (CellID, error) {
+// appends — and reveals it per the given Reveal. On a duplicate ID
+// returns an error; the cell is not inserted. Auto-wires the
+// configured clipboard.
+func (nb *Notebook) Insert(index int, c Cell, reveal Reveal) (CellID, error) {
 	nb.injectClipboard(c)
-	return nb.store.insert(index, c)
+	id, err := nb.store.insert(index, c)
+	if err != nil {
+		return id, err
+	}
+	if reveal == RevealBottom {
+		// Make the new cell the cursor; the model's per-frame
+		// ensureCursorVisible then keeps it in view as it grows.
+		nb.store.setCursorByIdx(nb.indexOrEndLocked(id))
+	}
+	return id, nil
+}
+
+// indexOrEndLocked returns the current index of id, or the last
+// index if not found (shouldn't happen right after a successful
+// insert). Used to anchor RevealBottom on the just-inserted cell.
+func (nb *Notebook) indexOrEndLocked(id CellID) int {
+	if idx, ok := nb.store.indexOf(id); ok {
+		return idx
+	}
+	return nb.store.count() - 1
 }
 
 // Update replaces the cell with the given ID by fn(old). Returns

--- a/notebook/dock_test.go
+++ b/notebook/dock_test.go
@@ -64,7 +64,7 @@ func TestDock_ReplaceBottomWithCustomThenRestoreDefault(t *testing.T) {
 
 func TestDock_AfterAndBeforeStoreDistinctly(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("x", 1))
+	nb.Append(newTestCell("x", 1), RevealNone)
 	a := newTestCell("a", 1)
 	b := newTestCell("b", 1)
 	nb.SetDockedCell(After("x"), a)
@@ -79,7 +79,7 @@ func TestDock_AfterAndBeforeStoreDistinctly(t *testing.T) {
 
 func TestDock_AfterAutoUnregistersOnAnchorRemoval(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("x", 1))
+	nb.Append(newTestCell("x", 1), RevealNone)
 	nb.SetDockedCell(After("x"), newTestCell("a", 1))
 	nb.SetDockedCell(Before("x"), newTestCell("b", 1))
 	if !nb.Remove("x") {
@@ -95,8 +95,8 @@ func TestDock_AfterAutoUnregistersOnAnchorRemoval(t *testing.T) {
 
 func TestDock_RemoveOnlyAffectsMatchingAnchor(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("x", 1))
-	nb.Append(newTestCell("y", 1))
+	nb.Append(newTestCell("x", 1), RevealNone)
+	nb.Append(newTestCell("y", 1), RevealNone)
 	keepA := newTestCell("ka", 1)
 	keepB := newTestCell("kb", 1)
 	nb.SetDockedCell(After("y"), keepA)
@@ -256,9 +256,9 @@ func TestDock_CtrlWNoopWhenBottomCleared(t *testing.T) {
 
 func TestStatusCell_RendersLegacyFormat(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	nb.Append(newTestCell("b", 1))
-	nb.Append(newTestCell("c", 1))
+	nb.Append(newTestCell("a", 1), RevealNone)
+	nb.Append(newTestCell("b", 1), RevealNone)
+	nb.Append(newTestCell("c", 1), RevealNone)
 	cell, _ := nb.DockedCell(Bottom)
 	rows := cell.RenderRows(40, 0, 1, false, NavigationMode)
 	if len(rows) != 1 {

--- a/notebook/examples/cmdshell/main.go
+++ b/notebook/examples/cmdshell/main.go
@@ -105,7 +105,7 @@ func (s *shellState) runFromCommandBar(nb *notebook.Notebook, src string) {
 
 func runREPL(nb *notebook.Notebook, repl *shellState) {
 	nb.SetHeader("cmdshell", "type a shell command · : opens command bar · q quits · clear wipes history")
-	nb.Append(cells.NewNote("intro", "Try", introBody()))
+	nb.Append(cells.NewNote("intro", "Try", introBody()), notebook.RevealBottom)
 
 	for {
 		repl.mu.Lock()
@@ -156,7 +156,7 @@ func runCommand(nb *notebook.Notebook, n int, src string) notebook.CellID {
 	// clipboard" case: OSC52 reports success but is suppressed.
 	// 't' after 'c' writes the buffer to /tmp.
 	oc.SetFallbackClipboard(notebook.FileClipboard(""))
-	if _, err := nb.Append(oc); err != nil {
+	if _, err := nb.Append(oc, notebook.RevealBottom); err != nil {
 		return id
 	}
 	w := nb.Stream(id)

--- a/notebook/examples/mathrepl/main.go
+++ b/notebook/examples/mathrepl/main.go
@@ -56,7 +56,7 @@ func main() {
 
 func runREPL(nb *notebook.Notebook, env *Env, seriesCtl *seriesController) {
 	nb.SetHeader("Math Notebook", "expressions · plot · series · q quits")
-	nb.Append(cells.NewNote("intro", "How to use", introBody()))
+	nb.Append(cells.NewNote("intro", "How to use", introBody()), notebook.RevealBottom)
 
 	n := 0
 	for {
@@ -83,7 +83,7 @@ func runREPL(nb *notebook.Notebook, env *Env, seriesCtl *seriesController) {
 				appendResultCell(nb, n, src, "", err)
 				continue
 			}
-			nb.Append(cell)
+			nb.Append(cell, notebook.RevealBottom)
 		case strings.HasPrefix(src, "series "):
 			// `series <e> from <a> to <b>` — streams f(x) values
 			// into an OutputCell one row at a time. The eval loop
@@ -115,7 +115,7 @@ func appendResultCell(nb *notebook.Notebook, n int, src, value string, err error
 	if err != nil {
 		msg = err.Error()
 	}
-	nb.Append(NewResult(fmt.Sprintf("res-%d", n), src, value, msg))
+	nb.Append(NewResult(fmt.Sprintf("res-%d", n), src, value, msg), notebook.RevealBottom)
 }
 
 // appendStressCell creates an OutputCell with N generated lines.
@@ -126,7 +126,7 @@ func appendResultCell(nb *notebook.Notebook, n int, src, value string, err error
 func appendStressCell(nb *notebook.Notebook, n, count int) {
 	oc := cells.NewOutput(fmt.Sprintf("lines-%d", n), 12)
 	oc.SetFallbackClipboard(notebook.FileClipboard(""))
-	id, err := nb.Append(oc)
+	id, err := nb.Append(oc, notebook.RevealBottom)
 	if err != nil {
 		return
 	}

--- a/notebook/examples/mathrepl/series.go
+++ b/notebook/examples/mathrepl/series.go
@@ -182,7 +182,7 @@ func runSeries(nb *notebook.Notebook, ctl *seriesController, n int, src string, 
 	// as it grows — no in-cell scroll, the notebook viewport
 	// handles overflow between cells.
 	oc := cells.NewOutput(string(id), count+2)
-	if _, err := nb.Append(oc); err != nil {
+	if _, err := nb.Append(oc, notebook.RevealBottom); err != nil {
 		return err
 	}
 	w := nb.Stream(id)

--- a/notebook/notebook_test.go
+++ b/notebook/notebook_test.go
@@ -63,7 +63,7 @@ func (c *testCell) Update(msg tea.Msg, mode Mode) (Cell, tea.Cmd, bool) {
 
 func TestAppendReturnsIDAndIncrementsLen(t *testing.T) {
 	nb := New()
-	id, err := nb.Append(newTestCell("a", 1))
+	id, err := nb.Append(newTestCell("a", 1), RevealNone)
 	if err != nil {
 		t.Fatalf("Append error: %v", err)
 	}
@@ -77,9 +77,9 @@ func TestAppendReturnsIDAndIncrementsLen(t *testing.T) {
 
 func TestInsertAtIndexPositionsCellAndCursor(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	nb.Append(newTestCell("c", 1))
-	if _, err := nb.Insert(1, newTestCell("b", 1)); err != nil {
+	nb.Append(newTestCell("a", 1), RevealNone)
+	nb.Append(newTestCell("c", 1), RevealNone)
+	if _, err := nb.Insert(1, newTestCell("b", 1), RevealNone); err != nil {
 		t.Fatalf("Insert error: %v", err)
 	}
 	for i, want := range []string{"a", "b", "c"} {
@@ -91,8 +91,8 @@ func TestInsertAtIndexPositionsCellAndCursor(t *testing.T) {
 
 func TestInsertAtNegativeIndexAppends(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	if _, err := nb.Insert(-1, newTestCell("b", 1)); err != nil {
+	nb.Append(newTestCell("a", 1), RevealNone)
+	if _, err := nb.Insert(-1, newTestCell("b", 1), RevealNone); err != nil {
 		t.Fatalf("Insert(-1) error: %v", err)
 	}
 	if got := nb.store.snapshot().cells[1].ID(); got != "b" {
@@ -102,8 +102,8 @@ func TestInsertAtNegativeIndexAppends(t *testing.T) {
 
 func TestInsertRejectsDuplicateID(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("dup", 1))
-	if _, err := nb.Insert(0, newTestCell("dup", 1)); err == nil {
+	nb.Append(newTestCell("dup", 1), RevealNone)
+	if _, err := nb.Insert(0, newTestCell("dup", 1), RevealNone); err == nil {
 		t.Error("Insert with duplicate ID should error")
 	}
 	if got := nb.Len(); got != 1 {
@@ -113,8 +113,8 @@ func TestInsertRejectsDuplicateID(t *testing.T) {
 
 func TestRemoveReturnsTrueAndShortensList(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	nb.Append(newTestCell("b", 1))
+	nb.Append(newTestCell("a", 1), RevealNone)
+	nb.Append(newTestCell("b", 1), RevealNone)
 	if !nb.Remove("a") {
 		t.Error("Remove(a) returned false")
 	}
@@ -128,9 +128,9 @@ func TestRemoveReturnsTrueAndShortensList(t *testing.T) {
 
 func TestRemoveAdjustsCursorWhenFocused(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	nb.Append(newTestCell("b", 1))
-	nb.Append(newTestCell("c", 1))
+	nb.Append(newTestCell("a", 1), RevealNone)
+	nb.Append(newTestCell("b", 1), RevealNone)
+	nb.Append(newTestCell("c", 1), RevealNone)
 	nb.store.moveCursor(+2) // cursor on c
 	nb.Remove("c")
 	if got := nb.store.cursorPos(); got != 1 {
@@ -145,7 +145,7 @@ func TestRemoveAdjustsCursorWhenFocused(t *testing.T) {
 
 func TestUpdateReplacesCell(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
+	nb.Append(newTestCell("a", 1), RevealNone)
 	replaced := newTestCell("a", 5) // same id, new height
 	ok := nb.Update("a", func(_ Cell) Cell { return replaced })
 	if !ok {
@@ -159,8 +159,8 @@ func TestUpdateReplacesCell(t *testing.T) {
 
 func TestGetAndIndexOf(t *testing.T) {
 	nb := New()
-	nb.Append(newTestCell("a", 1))
-	nb.Append(newTestCell("b", 1))
+	nb.Append(newTestCell("a", 1), RevealNone)
+	nb.Append(newTestCell("b", 1), RevealNone)
 	if c, ok := nb.Get("b"); !ok || c.ID() != "b" {
 		t.Errorf("Get(b) = (%v, %v), want b/true", c, ok)
 	}
@@ -185,7 +185,7 @@ func TestAppendAutoInjectsClipboard(t *testing.T) {
 	myClip := Clipboard(func(s string) (string, bool) { return "test", true })
 	nb := New(WithClipboard(myClip))
 	cc := &clipCell{testCell: newTestCell("c", 1)}
-	nb.Append(cc)
+	nb.Append(cc, RevealNone)
 	if cc.got == nil {
 		t.Error("SetClipboard was not called on Append")
 	}
@@ -219,8 +219,8 @@ func TestSnapshotRendersAppendedCells(t *testing.T) {
 	go nb.Run()
 	t.Cleanup(nb.Stop)
 
-	nb.Append(newTestCell("alpha", 1))
-	nb.Append(newTestCell("beta", 1))
+	nb.Append(newTestCell("alpha", 1), RevealNone)
+	nb.Append(newTestCell("beta", 1), RevealNone)
 	snap := nb.Snapshot()
 	for _, want := range []string{"alpha", "beta"} {
 		if !strings.Contains(snap, want) {

--- a/notebook/rendezvous.go
+++ b/notebook/rendezvous.go
@@ -25,44 +25,72 @@ type InputResponse struct {
 // All channels are buffered cap 1 so resolveInput never blocks
 // even if the awaiter has already returned via a different select
 // arm (e.g. <-stopped).
+//
+// resolveInput may legitimately fire BEFORE registerInput: a caller
+// typically focuses the cell (enabling its Enter -> PromptSubmittedMsg
+// -> resolveInput) and only then calls AwaitInputBy (registerInput).
+// A fast keystroke lands in that gap. So an unmatched resolution is
+// buffered in `early` and handed to the next registerInput for that
+// id, rather than dropped — the same resolve-before-await guarantee
+// gocurrent's Queue.AwaitResolution makes on the producer side.
 type rendezvous struct {
 	mu     sync.Mutex
 	inputs map[CellID]chan InputResponse
+	early  map[CellID]InputResponse // resolutions that arrived before a waiter registered
 }
 
 func newRendezvous() *rendezvous {
-	return &rendezvous{inputs: map[CellID]chan InputResponse{}}
+	return &rendezvous{
+		inputs: map[CellID]chan InputResponse{},
+		early:  map[CellID]InputResponse{},
+	}
 }
 
-// registerInput enrols a waiter keyed by the prompt cell's ID.
+// registerInput enrols a waiter keyed by the prompt cell's ID. If a
+// resolution for id already arrived (resolve-before-register), the
+// returned channel is pre-loaded with it so the waiter never blocks.
 func (r *rendezvous) registerInput(id CellID) chan InputResponse {
 	ch := make(chan InputResponse, 1)
 	r.mu.Lock()
-	r.inputs[id] = ch
+	if resp, ok := r.early[id]; ok {
+		delete(r.early, id)
+		ch <- resp // cap-1 buffer; non-blocking
+	} else {
+		r.inputs[id] = ch
+	}
 	r.mu.Unlock()
 	return ch
 }
 
-// removeInput drops the waiter for id without resolving it.
+// removeInput drops the waiter for id without resolving it, and
+// discards any buffered early resolution so it can't leak or be
+// delivered to an unrelated later waiter.
 func (r *rendezvous) removeInput(id CellID) {
 	r.mu.Lock()
 	delete(r.inputs, id)
+	delete(r.early, id)
 	r.mu.Unlock()
 }
 
-// resolveInput hands the waiter for id (if any) its response.
+// resolveInput hands the waiter for id its response, or buffers it
+// for the next registerInput if no waiter is enrolled yet. Returns
+// true if a live waiter received it directly. First resolution for
+// an id wins; later ones for the same un-awaited id are ignored.
 func (r *rendezvous) resolveInput(id CellID, answers map[string]any, source string) bool {
+	resp := InputResponse{Answers: answers, Source: source, At: time.Now()}
 	r.mu.Lock()
 	ch, ok := r.inputs[id]
 	if ok {
 		delete(r.inputs, id)
+	} else if _, buffered := r.early[id]; !buffered {
+		r.early[id] = resp
 	}
 	r.mu.Unlock()
 	if !ok {
 		return false
 	}
 	select {
-	case ch <- InputResponse{Answers: answers, Source: source, At: time.Now()}:
+	case ch <- resp:
 	default:
 	}
 	return true
@@ -74,6 +102,7 @@ func (r *rendezvous) cancelAll() {
 	r.mu.Lock()
 	inputs := r.inputs
 	r.inputs = map[CellID]chan InputResponse{}
+	r.early = map[CellID]InputResponse{}
 	r.mu.Unlock()
 
 	for _, ch := range inputs {
@@ -122,7 +151,7 @@ func (nb *Notebook) AwaitInput(inputs []Input) InputResponse {
 	}
 	id := nb.nextPromptID()
 	cell := nb.promptFactory(id, inputs)
-	if _, err := nb.Append(cell); err != nil {
+	if _, err := nb.Append(cell, RevealBottom); err != nil {
 		// Duplicate ID — shouldn't happen because nextPromptID is
 		// monotonic per Notebook, but surface it via cancelled
 		// rather than blocking forever.

--- a/notebook/rendezvous_test.go
+++ b/notebook/rendezvous_test.go
@@ -1,0 +1,57 @@
+package notebook
+
+import (
+	"testing"
+	"time"
+)
+
+// Consumer side of the advance/prompt contract: a caller focuses the
+// cell (enabling Enter -> resolveInput) and only then calls
+// AwaitInputBy (registerInput). If the resolution lands FIRST it must
+// not be lost — registerInput delivers the buffered resolution.
+func TestRendezvousResolveBeforeRegisterNotLost(t *testing.T) {
+	r := newRendezvous()
+	r.resolveInput("advance-1", nil, "user-submitted") // Enter arrives first
+	ch := r.registerInput("advance-1")                 // AwaitInputBy registers after
+	select {
+	case resp := <-ch:
+		if resp.Source != "user-submitted" {
+			t.Fatalf("source = %q, want user-submitted", resp.Source)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("resolution arriving before registerInput was dropped (lost wakeup)")
+	}
+}
+
+// Normal order still works and isn't disturbed by the early-buffer path.
+func TestRendezvousRegisterThenResolve(t *testing.T) {
+	r := newRendezvous()
+	ch := r.registerInput("p1")
+	if !r.resolveInput("p1", map[string]any{"x": 1}, "user-submitted") {
+		t.Fatal("resolveInput should report a live waiter")
+	}
+	select {
+	case resp := <-ch:
+		if resp.Answers["x"] != 1 {
+			t.Fatalf("answers = %v", resp.Answers)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("registered waiter never received its resolution")
+	}
+}
+
+// A buffered early resolution is discarded by removeInput, so it can't
+// leak or be delivered to a later, unrelated waiter for the same id.
+func TestRendezvousRemoveClearsEarly(t *testing.T) {
+	r := newRendezvous()
+	r.resolveInput("gone", nil, "user-submitted") // buffered, no waiter
+	r.removeInput("gone")                         // cell removed before any await
+
+	ch := r.registerInput("gone")
+	select {
+	case resp := <-ch:
+		t.Fatalf("expected no buffered resolution after removeInput, got %+v", resp)
+	case <-time.After(100 * time.Millisecond):
+		// correct: nothing delivered
+	}
+}

--- a/notebook/reveal_test.go
+++ b/notebook/reveal_test.go
@@ -1,0 +1,55 @@
+package notebook
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// RevealNone must not move the cursor (the viewport's follow anchor);
+// RevealBottom must move it to the newly appended cell so the viewport
+// follows it. This is the mechanism behind "streamed output stays in
+// view" — see TestAppendRevealBottomScrollsIntoView for the rendered
+// effect.
+func TestAppendRevealControlsCursor(t *testing.T) {
+	nb := New()
+	for i := 0; i < 5; i++ {
+		if _, err := nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if nb.store.cursor != 0 {
+		t.Fatalf("RevealNone moved the cursor to %d, want 0 (viewport must stay put)", nb.store.cursor)
+	}
+
+	id, err := nb.Append(newTestCell("followed", 1), RevealBottom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx, _ := nb.IndexOf(id)
+	if nb.store.cursor != idx {
+		t.Fatalf("RevealBottom: cursor = %d, want %d (the new cell, so the viewport follows it)", nb.store.cursor, idx)
+	}
+}
+
+// The rendered effect: with cells filled past the screen, a RevealNone
+// append stays below the fold, while a RevealBottom append scrolls into
+// view — the fix for "I appended/streamed a cell but it never shows up".
+func TestAppendRevealBottomScrollsIntoView(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	nb.Append(newTestCell("hidden", 1), RevealNone)
+	if strings.Contains(nb.Snapshot(), "hidden/") {
+		t.Fatal("RevealNone cell should be below the fold, not rendered")
+	}
+
+	nb.Append(newTestCell("shown", 1), RevealBottom)
+	if !strings.Contains(nb.Snapshot(), "shown/") {
+		t.Fatalf("RevealBottom cell should scroll into view:\n%s", nb.Snapshot())
+	}
+}

--- a/notebookbridge/bridge.go
+++ b/notebookbridge/bridge.go
@@ -187,11 +187,11 @@ func (b *Bridge) handleEvent(off int, ev events.Event) {
 		if b.theme != nil {
 			note.Style = b.theme.Note
 		}
-		b.nb.Append(note)
+		b.nb.Append(note, notebook.RevealBottom)
 
 	case events.StepStart:
 		for _, c := range b.buildCellsFromStepStart(e) {
-			b.nb.Append(c)
+			b.nb.Append(c, notebook.RevealBottom)
 		}
 
 	case events.StepReadyToRun:
@@ -204,7 +204,7 @@ func (b *Bridge) handleEvent(off int, ev events.Event) {
 		if b.theme != nil {
 			oc.Style = b.theme.Output
 		}
-		b.nb.Append(oc)
+		b.nb.Append(oc, notebook.RevealBottom)
 		b.visitMu.Lock()
 		b.outCellByVisit[e.Visit] = oid
 		b.visitMu.Unlock()
@@ -234,7 +234,7 @@ func (b *Bridge) handleEvent(off int, ev events.Event) {
 			ac.Style = b.theme.Advance
 		}
 		ac.Deadline = e.Deadline // zero = no auto-advance
-		b.nb.Append(ac)
+		b.nb.Append(ac, notebook.RevealBottom)
 		b.nb.FocusCell(id)
 		resp := b.nb.AwaitInputBy(id)
 		_ = b.queue.Resolve(off, &events.AdvanceResolution{


### PR DESCRIPTION
## What changes

Two robustness fixes for streaming/interactive notebook consumers, plus the breaking API change that prevents the class of bug behind the main one.

**The symptom:** a consumer streams output into a freshly-appended cell, but once accumulated cells exceed the terminal height the new output renders *below the fold* and never scrolls into view. The bridge hit this (the dungeon's "doesn't incrementally update"); mathrepl dodged it only by accident (its input prompt is the bottom cell).

**Root cause:** the viewport follows the cursor (`ensureCursorVisible` runs every repaint tick), but `Append` never moved the cursor, so streamed-into cells fell off-screen.

**Fix + breaking change:** `Append`/`Insert` now take a **mandatory** `Reveal` arg — `RevealNone` (leave viewport) or `RevealBottom` (scroll into view + become the follow anchor, so it stays visible as it grows). Required, not a silent default, so "my cell never shows up" is a call-site decision, not a runtime surprise. The bridge and examples append with `RevealBottom`.

Also: the rendezvous now buffers a resolve-before-register (an `Enter` landing between `FocusCell` and `AwaitInputBy` is delivered, not dropped) — mirroring `gocurrent`'s `Queue.AwaitResolution` on the producer side.

## Reviewer's guide

1. [notebook/crud.go](https://github.com/panyam/demokit/pull/45/files#diff-fa4acb71b249b1a5fcf16926a5e89bbbedd0640230da5c84a38d076cefd10219) — start here: the `Reveal` enum + `Append`/`Insert` signature change; `RevealBottom` anchors the cursor to the new cell.
2. [notebook/reveal_test.go](https://github.com/panyam/demokit/pull/45/files#diff-bacc37c395f3e4da00cc84bc93820a925cdf53dc14de53465418ac9b20577adb) — acceptance: `RevealBottom` moves the cursor and scrolls the cell into view past the fold; `RevealNone` doesn't.
3. [notebook/rendezvous.go](https://github.com/panyam/demokit/pull/45/files#diff-d669687516b18fbcc53cf3579ad0a92e03d385c06a20175945b8ad250a76fb02) — the resolve-before-register buffer (`early` map) + `AwaitInput` now reveals its prompt.
4. [notebook/rendezvous_test.go](https://github.com/panyam/demokit/pull/45/files#diff-cf21230cf4e289d879776094f9373277ad5bcdb808b65472561ff0a2cf48cd0f) + [advance_contract_test.go](https://github.com/panyam/demokit/pull/45/files#diff-e1c746a33819586ede52be98e114e523169e6e8f302b6805cfaabdd814c2ec48) — the two-sided contract: consumer (notebook) and source (demokit queue).
5. [notebookbridge/bridge.go](https://github.com/panyam/demokit/pull/45/files#diff-07836f0687e256dd4502ff3340485c2fb7c2d7c74136e11f09e31416f9607c81) — appends now pass `RevealBottom` (the symptom fix in the real consumer).
6. Skim: `notebook/examples/*`, `notebook/*_test.go` — mechanical caller updates (`RevealBottom` in prod, `RevealNone` in tests).

## Decision log

- **Mandatory `Reveal` arg over an optional/default.** A required parameter turns the silent "cell never appears" footgun into a compile-time choice. Breaking, but the lib is pre-1.0 and the safety is worth it.
- **`RevealBottom` sets the cursor** rather than a one-shot scroll: the per-tick `ensureCursorVisible` then keeps a *growing* (streaming) cell in view, not just visible at append time.
- **Rendezvous buffers early resolutions** (fix A) rather than reordering the bridge's focus/await: order-independent, fixes advance + prompt paths, mirrors the queue's proven semantics. Instrumentation showed this race doesn't currently fire in the bridge flow, so it's defense-in-depth — kept because it closes a real hole and pairs with the contract tests.
- **Bottom-only reveal for now.** `RevealTop`/`RevealMiddle` deferred to a follow-up issue; the enum is extensible so adding them isn't a breaking change (issue 46).

## Risk / blast radius

- Breaking signature change to `Notebook.Append`/`Insert` — every caller updated across demokit, notebookbridge, mathrepl, cmdshell, and notebook tests.
- Be paranoid about: existing notebook tests that assert cursor/scroll positions (kept on `RevealNone` to preserve behavior); the bridge now moving the cursor to output/advance cells each step (intended — keeps the transcript pinned to the latest).

## Before / after

PTY repro (3 streaming steps, 35-row terminal, fast advance): step 3's output was dropped below the fold before; after, `S1/S2/S3` all render.

## Out of scope

- `RevealTop` / `RevealMiddle` -> issue 46.
- Indexed/Fenwick `LineSource` for large scrollback -> issue 43.


