### PR TITLE
chore: bump notebook to v0.0.25 across modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/muesli/cancelreader v0.2.2
-	github.com/panyam/demokit/notebook v0.0.24
+	github.com/panyam/demokit/notebook v0.0.25
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/servicekit v0.1.1
 	github.com/panyam/templar v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsU
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
 github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.25 h1:p10uKajal7yi7GFjVu+wfopH42d83qWc28On2Cqmqzs=
+github.com/panyam/demokit/notebook v0.0.25/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezegaU=
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=

--- a/notebook/examples/cmdshell/go.mod
+++ b/notebook/examples/cmdshell/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
-	github.com/panyam/demokit/notebook v0.0.24
+	github.com/panyam/demokit/notebook v0.0.25
 )
 
 require (

--- a/notebook/examples/cmdshell/go.sum
+++ b/notebook/examples/cmdshell/go.sum
@@ -52,6 +52,8 @@ github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsU
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
 github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.25 h1:p10uKajal7yi7GFjVu+wfopH42d83qWc28On2Cqmqzs=
+github.com/panyam/demokit/notebook v0.0.25/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/notebook/examples/mathrepl/go.mod
+++ b/notebook/examples/mathrepl/go.mod
@@ -6,7 +6,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/expr-lang/expr v1.17.8
-	github.com/panyam/demokit/notebook v0.0.24
+	github.com/panyam/demokit/notebook v0.0.25
 )
 
 require (

--- a/notebook/examples/mathrepl/go.sum
+++ b/notebook/examples/mathrepl/go.sum
@@ -54,6 +54,8 @@ github.com/panyam/demokit/notebook v0.0.23 h1:8ZyCZeAM1lN19F1y9NC38o5k7Do14wzgsU
 github.com/panyam/demokit/notebook v0.0.23/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/demokit/notebook v0.0.24 h1:h0KuZ7RVCMoyoVijwvKxR8aSbxvTY5IcqDRTLMBwZAE=
 github.com/panyam/demokit/notebook v0.0.24/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.25 h1:p10uKajal7yi7GFjVu+wfopH42d83qWc28On2Cqmqzs=
+github.com/panyam/demokit/notebook v0.0.25/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
Pick up notebook/v0.0.25 — mandatory `Reveal` arg on `Append`/`Insert` + rendezvous resolve-before-register (PR 45).

Bumps `github.com/panyam/demokit/notebook` require + go.sum to v0.0.25 in the demokit module, cmdshell, and mathrepl. The notebook/v0.0.25 tag is pushed, so these resolve. Local dev already used the workspace copy.

Note: this is a breaking notebook change (Append/Insert signature) — the demokit/bridge + examples in this repo are already updated to match.

After merge: tag the demokit root module v0.0.25 at the merged HEAD.