### PR TITLE
fix(demokit): serialise global os.Stdout / os.Stderr access (issue 23)

### DIFF
--- a/demokit.go
+++ b/demokit.go
@@ -741,7 +741,13 @@ walk:
 				streaming = true
 			}
 			stepNum := totalVisits
+			// Snapshot the real terminal stdout before captureOutput
+			// redirects it. RLock-gated so we read a stable value even
+			// if a concurrent demo's captureOutput is mid-mutation —
+			// see term.go's stdoutMu.
+			stdoutMu.RLock()
 			originalStdout := os.Stdout
+			stdoutMu.RUnlock()
 			// Always emit OutputChunk events (so the queue is the
 			// canonical log for any consumer); pass through to
 			// the streaming renderer when present.

--- a/term.go
+++ b/term.go
@@ -8,15 +8,35 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/charmbracelet/x/term"
 	"github.com/muesli/cancelreader"
 )
 
+// stdoutMu serialises access to the global os.Stdout / os.Stderr
+// variables, which captureOutput mutates to redirect a step's
+// prints into a pipe. Without it, a concurrent demo's TermWidth
+// (or the originalStdout snapshot in Execute) reads the variable
+// while captureOutput writes it — a Go data race the -race
+// detector flags under `go test -race ./web/`.
+//
+// Writers (captureOutput) hold Lock for the WHOLE redirect window
+// including the user fn — only one captureOutput at a time across
+// the process. Readers (TermWidth and similar snapshots) hold
+// RLock for the bare moment they evaluate os.Stdout / os.Stderr.
+// Per issue 23 (Option 3): concurrent demos' runFns serialise; the
+// principled long-term fix (no global mutation) is left to a
+// future Option-1 refactor.
+var stdoutMu sync.RWMutex
+
 // TermWidth returns the current terminal width, or 80 as fallback.
 // Tries stdout, then stderr (which stays connected even when stdout is piped).
 func TermWidth() int {
-	for _, f := range []*os.File{os.Stdout, os.Stderr} {
+	stdoutMu.RLock()
+	stdout, stderr := os.Stdout, os.Stderr
+	stdoutMu.RUnlock()
+	for _, f := range []*os.File{stdout, stderr} {
 		if w, _, err := term.GetSize(f.Fd()); err == nil && w > 0 {
 			return w
 		}
@@ -83,6 +103,15 @@ func cancelReason(err error) string {
 // output (returned string) still contains everything regardless of
 // onChunk — the chunk callback tees, it doesn't replace the buffer.
 func captureOutput(fn func(StepContext) *StepResult, ctx StepContext, onChunk func([]byte)) (output string, result *StepResult) {
+	// Hold the package mutex for the WHOLE redirect window — mutation,
+	// user fn execution, AND restore. The redirect is in effect during
+	// fn; another captureOutput re-redirecting would corrupt this
+	// demo's capture, and the variable swap itself races with any
+	// concurrent reader (TermWidth, the Execute-side originalStdout
+	// snapshot). See stdoutMu's doc comment.
+	stdoutMu.Lock()
+	defer stdoutMu.Unlock()
+
 	oldOut, oldErr := os.Stdout, os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/term_test.go
+++ b/term_test.go
@@ -199,3 +199,34 @@ func TestExecuteStreamingTraceCapturesFullOutput(t *testing.T) {
 		t.Errorf("trace[0].Output = %q, want %q", rec.Entries[0].Output, "archive me")
 	}
 }
+
+// Regression for issue 23: captureOutput's mutation of global
+// os.Stdout / os.Stderr raced with concurrent readers (TermWidth,
+// the originalStdout snapshot in Execute) — race-flagged by
+// `go test -race ./web/`. Drive both sides in parallel under
+// -race; the test passes when both are gated by stdoutMu, and
+// fails (race detector) when they aren't.
+func TestCaptureOutputDoesNotRaceWithTermWidth(t *testing.T) {
+	const goroutines = 6
+	const iters = 25
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				_, _ = captureOutput(func(ctx StepContext) *StepResult {
+					fmt.Print("x")
+					return nil
+				}, StepContext{}, nil)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters*4; j++ {
+				_ = TermWidth()
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What changes

`captureOutput` mutates global `os.Stdout` / `os.Stderr` to redirect a step's prints into a pipe. With two concurrent demos in the same process (the web mode's live-server tests), one demo's `captureOutput` races another's `TermWidth` read — the `-race` detector flagged it under `go test -race -count=N ./web/` (any N ≥ 2). Issue 23 proposed Option 3 (serialise via a package mutex); this is that fix.

## Reviewer's guide

1. [term.go](https://github.com/panyam/demokit/pull/49/files#diff-ea3c9cc1a609dfbe5d9991750ed65d6be59d4ebb7a47b438f77593cb9e8d7637) — start here: new package-level `stdoutMu sync.RWMutex`. `captureOutput` holds `Lock` for the **whole** redirect window (mutation + user `fn` + restore); `TermWidth` holds `RLock` around the bare read of `os.Stdout` / `Stderr`.
2. [demokit.go](https://github.com/panyam/demokit/pull/49/files#diff-8d288d869eee51fb928e552417c1f39e03f623e07aaccfe068472e4c8feea6b3) — also gates the `originalStdout := os.Stdout` snapshot taken right before `captureOutput` on demokit's main goroutine (races with *another* demo's `captureOutput`).
3. [term_test.go](https://github.com/panyam/demokit/pull/49/files#diff-74ad7cf6aa7a9555a3603f5a88a57c718e410612a8358f60d32c047ec0b9eab4) — `TestCaptureOutputDoesNotRaceWithTermWidth` drives concurrent `captureOutput` + `TermWidth`; race-detected red without the locks, clean green with them.

## Decision log

- **Option 3 (mutex) per issue 23's recommendation.** Cost: concurrent demos' `runFn` execution serialises one-at-a-time across the process. Accepted for demokit's low-concurrency live-served use case; Option 1 (no global mutation; thread `io.Writer` through `Run`) is the principled long-term answer but a much bigger refactor — explicitly out of scope per the issue.
- **`RWMutex` over `Mutex`** so readers (`TermWidth`, the `originalStdout` snapshot) parallelise; only `captureOutput` excludes them.
- **Lock spans the user `fn`** (not just the mutation). Required because the redirect is *in effect* during `fn`; another concurrent `captureOutput` would re-redirect and corrupt this demo's capture.
- **Other `os.Stdout` / `Stderr` readers left alone** — `tui/tui.go`, `web/web.go:146`, `logger.go`, `demokit.go` error messages are outside the demonstrated race trace and gating them would force a cross-package mutex export. Pre-existing background hazards; follow-up if surfaced.

## Risk / blast radius

- Behavior change: `captureOutput` now serialises across concurrent demos in the same process. Live-served multi-demo setups see their `runFn` execution serialised (not parallel). Matches the issue's accepted trade-off; no in-repo consumer relies on concurrent `runFn` execution.
- `make race` (the whole workspace, every module, `go test -race`) and `make testall` both green. The exact reproducer from the issue (`go test -race -count=2 ./web/`) now passes.

## Before / after

```
# Before (issue 23)
$ go test -race -count=2 ./web/
WARNING: DATA RACE
  ... captureOutput (term.go:138) vs TermWidth (term.go:19) ...
FAIL

# After
$ go test -race -count=2 ./web/
ok  	github.com/panyam/demokit/web	1.960s
```

## Out of scope

- Option 1 (no global mutation). Track as a follow-up if Option 3's serialisation becomes a bottleneck.
- Gating `tui/tui.go`, `web/web.go:146`, `logger.go` reads. File follow-ups if surfaced.

