### PR TITLE
refactor(demokit): retire legacy Renderer interface; event drain is the contract

### DIFF
--- a/cancel_test.go
+++ b/cancel_test.go
@@ -135,7 +135,7 @@ func TestRunHonorsCancelDuringStreaming(t *testing.T) {
 	defer func() { os.Args = orig }()
 	os.Args = []string{"test", "--non-interactive"}
 
-	r := &streamingResultRenderer{}
+	r := newStreamingResultRenderer()
 	demo := New("flush").WithRenderer(r)
 	demo.Step("watch").Timeout(20 * time.Millisecond).Run(func(ctx StepContext) *StepResult {
 		fmt.Print("starting...\n")

--- a/demokit.go
+++ b/demokit.go
@@ -34,27 +34,28 @@ import (
 	"github.com/panyam/demokit/events"
 )
 
-// EventAwareRenderer is an optional interface a Renderer can
-// implement to receive the demo's event queue. Renderers that
-// consume from the queue retain the reference and drain it
-// themselves; Execute then skips the blocking Renderer.WaitForStep
-// / Renderer.Prompt calls for them, since the queue-side
-// resolution covers the sync rendezvous.
+// Renderer is the contract demokit calls into. A renderer receives
+// the demo's event queue at the start of each Execute via
+// AttachEventQueue, drains it on its own goroutine, and translates
+// events into whatever surface it presents (terminal text, TUI
+// boxes, WebSocket frames, notebook cells). The queue is the only
+// data flow from demokit to the renderer — there are no per-event
+// callbacks.
 //
-// Legacy renderers (Plain, TUI) don't implement this; Execute
-// continues to call WaitForStep / Prompt directly and mirrors the
-// resolution into the queue afterward for consistency.
-type EventAwareRenderer interface {
-	Renderer
+// Discrete events (Header, StepStart, StepEnd, Section, Done) are
+// fire-and-forget. Sync events (WaitForAdvance, PromptOpen) carry
+// an offset the renderer's drain Resolves once user input arrives;
+// Execute blocks on AwaitResolution for that offset.
+type Renderer interface {
 	AttachEventQueue(q *events.EventQueue)
 }
 
-// FinishableRenderer is implemented by event-aware renderers that
-// need a post-Done barrier — typically waiting for a drain goroutine
-// to exit before Execute returns. Demokit calls Finish after emitting
-// the Done event and after the legacy RenderDone path, so writes from
-// the renderer's drain are sequenced before the test/process moves on
-// (race-detector safety). Optional; renderers without it just skip.
+// FinishableRenderer is implemented by renderers that need a
+// post-Done barrier — typically waiting for a drain goroutine to
+// exit before Execute returns. Demokit calls Finish after emitting
+// the Done event so writes from the renderer's drain are sequenced
+// before the test/process moves on (race-detector safety).
+// Optional; renderers without it just skip.
 type FinishableRenderer interface {
 	Finish()
 }
@@ -107,10 +108,9 @@ type Demo struct {
 	docHandlers  map[string]DocHandler
 	serveHandler ServeHandler
 
-	// events is the per-Execute event queue. Renderers that
-	// implement EventAwareRenderer consume from it; legacy
-	// renderers don't reference it, but events are still emitted
-	// so future consumers (web, --record) can hook in.
+	// events is the per-Execute event queue. The renderer drains
+	// it via AttachEventQueue; the recorder (and any other
+	// consumer) can read from it independently.
 	events *events.EventQueue
 }
 
@@ -612,16 +612,12 @@ func (d *Demo) RunLoop() {
 		ShowCountdown:   d.showCountdown,
 	}
 
-	// Event queue: fresh per Execute. Renderers implementing
-	// EventAwareRenderer attach here and drain it themselves;
-	// legacy renderers see only the Renderer interface calls but
-	// the queue is still populated so future consumers (web,
-	// --record) can hook in.
+	// Event queue: fresh per Execute. Renderers drain it themselves
+	// via AttachEventQueue; demokit's only side-channel is the
+	// recorder. The queue is the canonical log for any consumer
+	// (renderer, --record, future observers).
 	d.events = events.NewQueue()
-	eventAware, isEventAware := r.(EventAwareRenderer)
-	if isEventAware {
-		eventAware.AttachEventQueue(d.events)
-	}
+	r.AttachEventQueue(d.events)
 
 	d.events.Append(events.Header{
 		Title:         d.title,
@@ -629,16 +625,6 @@ func (d *Demo) RunLoop() {
 		StepCount:     d.stepCount,
 		BoxedVerbatim: d.IsBoxedVerbatim(),
 	})
-	// Skip the legacy method when the renderer drains the queue itself —
-	// avoids dual-rendering. Same shape repeats for the other discrete
-	// events below; sync events (WaitForAdvance, PromptOpen) are already
-	// only dispatched along the legacy WaitForStep/Prompt path when
-	// !isEventAware (see the WaitForAdvance + collectInputsWithEvents
-	// branches), and StreamOutput stays inline so chunks tee live in
-	// both paths.
-	if !isEventAware {
-		r.RenderHeader(d.title, d.description, d.stepCount)
-	}
 
 	visits := make(map[string]int)
 	totalVisits := 0
@@ -665,13 +651,9 @@ walk:
 					})
 				}
 				abortErr := Errf("%s", msg)
-				// Emit a StepEnd event so the event-aware drain surfaces
-				// the abort the same way the legacy path does via the
-				// RenderResult call below.
+				// Emit a StepEnd event so the drain surfaces the abort
+				// (no legacy RenderResult path remains).
 				d.events.Append(stepEndEvent(totalVisits, abortErr))
-				if !isEventAware {
-					r.RenderResult(totalVisits, "", abortErr)
-				}
 				break walk
 			}
 
@@ -682,9 +664,6 @@ walk:
 				declared = d.stepCount
 			}
 			d.events.Append(stepStartEvent(totalVisits, declared, v))
-			if !isEventAware {
-				r.RenderStep(totalVisits, declared, v)
-			}
 
 			// Replay mode pulls inputs and the next-step path from the
 			// recorded trace. A mismatched step ID falls through to the
@@ -705,22 +684,10 @@ walk:
 					wait.Deadline = time.Now().Add(waitOpts.AutoAcceptAfter)
 				}
 				offset := d.events.Append(wait)
-				if isEventAware {
-					// Queue-side rendezvous: event-aware renderer's
-					// user input calls q.Resolve. Blocks here until
-					// that happens (or program shutdown).
-					_ = d.events.AwaitResolution(offset)
-				} else {
-					// Legacy renderer: it does the blocking via
-					// stdin / raw-mode keypress. Mirror the
-					// resolution into the queue afterward so the
-					// event log is complete for any other consumer
-					// observing the queue (e.g. --record).
-					r.WaitForStep(waitOpts)
-					_ = d.events.Resolve(offset, &events.AdvanceResolution{
-						Source: "legacy-renderer", Timestamp: time.Now(),
-					})
-				}
+				// Queue-side rendezvous: the renderer's user-input
+				// path calls q.Resolve. Block here until that
+				// happens (or program shutdown).
+				_ = d.events.AwaitResolution(offset)
 			}
 
 			var inputs map[string]any
@@ -730,7 +697,7 @@ walk:
 					inputs = map[string]any{}
 				}
 			} else {
-				inputs = d.collectInputsWithEvents(r, v, interactive, isEventAware, totalVisits)
+				inputs = d.collectInputsWithEvents(v, interactive, totalVisits)
 			}
 			// Build a per-step context for cancellation. Steps without
 			// Timeout or Cancellable get a never-cancelled background
@@ -760,35 +727,13 @@ walk:
 
 			var output string
 			var result *StepResult
-			// Tee output chunks into the renderer in real time when it
-			// supports streaming. The trace and recorder still receive
-			// the full captured string regardless. Snapshot os.Stdout
-			// before captureOutput redirects it so the chunk callback
-			// can write to the user's actual terminal — writing to
-			// os.Stdout from the drain goroutine would loop the bytes
-			// back into the capture pipe.
-			var onChunk func([]byte)
-			streaming := false
-			sr, srOk := r.(StreamingRenderer)
-			if srOk {
-				streaming = true
-			}
 			stepNum := totalVisits
-			// Snapshot the real terminal stdout before captureOutput
-			// redirects it. RLock-gated so we read a stable value even
-			// if a concurrent demo's captureOutput is mid-mutation —
-			// see term.go's stdoutMu.
-			stdoutMu.RLock()
-			originalStdout := os.Stdout
-			stdoutMu.RUnlock()
-			// Always emit OutputChunk events (so the queue is the
-			// canonical log for any consumer); pass through to
-			// the streaming renderer when present.
-			onChunk = func(chunk []byte) {
+			// Every chunk a step writes is emitted as an OutputChunk
+			// event so the queue is the canonical log. Renderers that
+			// want live streaming consume OutputChunk in their drain —
+			// no separate StreamingRenderer plumbing needed.
+			onChunk := func(chunk []byte) {
 				d.events.Append(events.OutputChunk{Visit: stepNum, Chunk: chunk})
-				if srOk {
-					sr.StreamOutput(stepNum, chunk, originalStdout)
-				}
 			}
 			// StepReadyToRun marks the boundary between "user has
 			// signalled advance" and "runFn is about to execute."
@@ -827,23 +772,11 @@ walk:
 				result.Next = replayEntry.Next
 			}
 
-			// Emit the StepEnd event before RenderResult — the
-			// queue is the canonical log; the renderer call is
-			// for legacy paths.
+			// StepEnd carries the result vocabulary for the drain.
+			// Output already flowed via OutputChunk events; the
+			// trace entry below still carries the full captured
+			// string for the recorder.
 			d.events.Append(stepEndEvent(totalVisits, result))
-
-			// When the body has already been streamed (legacy
-			// StreamingRenderer) or when an event-aware renderer
-			// is in use, hand RenderResult an empty output so the
-			// legacy path doesn't double-print. The trace entry
-			// below still carries the full captured string.
-			displayOutput := output
-			if streaming || isEventAware {
-				displayOutput = ""
-			}
-			if !isEventAware {
-				r.RenderResult(totalVisits, displayOutput, result)
-			}
 
 			entry := TraceEntry{
 				Kind:   KindStep,
@@ -870,12 +803,8 @@ walk:
 					nextErr := Errf("unknown step id %q in Next from %q", result.Next, v.id)
 					// StepEnd already fired above for the step's own
 					// result; emit a second one carrying the routing
-					// error so event-aware drains surface it via
-					// RenderResult the same way the legacy path does.
+					// error so the drain surfaces it.
 					d.events.Append(stepEndEvent(totalVisits, nextErr))
-					if !isEventAware {
-						r.RenderResult(totalVisits, "", nextErr)
-					}
 					break walk
 				}
 				entry.Next = result.Next
@@ -892,9 +821,6 @@ walk:
 
 		case *SectionDef:
 			d.events.Append(events.Section{Title: v.title, Body: v.body})
-			if !isEventAware {
-				r.RenderSection(v)
-			}
 			if d.recorder != nil {
 				d.recorder.Record(TraceEntry{
 					Kind:  KindSection,
@@ -925,9 +851,6 @@ walk:
 		}
 		abortErr := Errf("%s", msg)
 		d.events.Append(stepEndEvent(totalVisits, abortErr))
-		if !isEventAware {
-			r.RenderResult(totalVisits, "", abortErr)
-		}
 	}
 
 	if d.recorder != nil {
@@ -935,9 +858,6 @@ walk:
 	}
 
 	d.events.Append(events.Done{})
-	if !isEventAware {
-		r.RenderDone()
-	}
 	if f, ok := r.(FinishableRenderer); ok {
 		f.Finish()
 	}
@@ -994,16 +914,14 @@ func (d *Demo) emitDoc(format, from string) {
 }
 
 // collectInputsWithEvents gathers a step's input payload via the
-// event queue. Behaviour:
+// event queue.
 //
 //   - Non-interactive: defaults only; a PromptOpen is appended
 //     and auto-resolved so the event log records the resolution.
-//   - Event-aware renderer: PromptOpen → AwaitResolution returns
-//     the user's answers from the queue. The renderer's own
-//     Prompt method is not called.
-//   - Legacy renderer: PromptOpen appended; r.Prompt called; the
-//     returned answers are mirrored into the queue via Resolve.
-func (d *Demo) collectInputsWithEvents(r Renderer, s *StepDef, interactive, isEventAware bool, visit int) map[string]any {
+//   - Interactive: PromptOpen → AwaitResolution returns the
+//     user's answers from the queue. The renderer's drain is
+//     responsible for resolving the prompt offset.
+func (d *Demo) collectInputsWithEvents(s *StepDef, interactive bool, visit int) map[string]any {
 	if len(s.inputs) == 0 {
 		return map[string]any{}
 	}
@@ -1023,21 +941,11 @@ func (d *Demo) collectInputsWithEvents(r Renderer, s *StepDef, interactive, isEv
 		})
 		return out
 	}
-	if isEventAware {
-		res, _ := d.events.AwaitResolution(offset).(*events.PromptResolution)
-		if res == nil || res.Answers == nil {
-			return map[string]any{}
-		}
-		return res.Answers
+	res, _ := d.events.AwaitResolution(offset).(*events.PromptResolution)
+	if res == nil || res.Answers == nil {
+		return map[string]any{}
 	}
-	answers := r.Prompt(s.id, s.inputs)
-	if answers == nil {
-		answers = map[string]any{}
-	}
-	_ = d.events.Resolve(offset, &events.PromptResolution{
-		Answers: answers, Source: "legacy-renderer", Timestamp: time.Now(),
-	})
-	return answers
+	return res.Answers
 }
 
 // assignStepIDs fills in any unset step IDs with auto-generated ones

--- a/demokit_test.go
+++ b/demokit_test.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/panyam/demokit/events"
 )
 
 func TestStepAccessors(t *testing.T) {
@@ -233,33 +236,96 @@ func TestStepResultDefaultLabels(t *testing.T) {
 	}
 }
 
-// recordingRenderer captures all renderer calls for testing.
+// recordingRenderer is an event-aware test spy. It drains the demo's
+// event queue and records a string for each discrete event so tests
+// can assert on the demo's emission sequence. AttachEventQueue +
+// Finish satisfy the EventAwareRenderer / FinishableRenderer contract;
+// PromptOpen events auto-resolve with declared defaults so tests
+// that exercise input-bearing steps don't deadlock.
+//
+// Subclasses install onChunk / onStepEnd hooks to react to streamed
+// output without re-implementing the drain loop — used by the
+// streaming spies in term_test.go and cancel_test.go.
 type recordingRenderer struct {
-	calls []string
+	mu      sync.Mutex
+	calls   []string
+	queue   *events.EventQueue
+	drainWG sync.WaitGroup
+	done    bool
+
+	onChunk   func(visit int, chunk []byte)
+	onStepEnd func(visit int, status, message, errorText string)
 }
 
-func (r *recordingRenderer) RenderHeader(title, desc string, n int) {
-	r.calls = append(r.calls, "header:"+title)
-}
-func (r *recordingRenderer) RenderStep(num, total int, s *StepDef) {
-	r.calls = append(r.calls, "step:"+s.title)
-}
-func (r *recordingRenderer) RenderResult(num int, out string, res *StepResult) {
-	r.calls = append(r.calls, "result")
-}
-func (r *recordingRenderer) RenderSection(s *SectionDef) {
-	r.calls = append(r.calls, "section:"+s.title)
-}
-func (r *recordingRenderer) RenderDone()               { r.calls = append(r.calls, "done") }
-func (r *recordingRenderer) WaitForStep(opts WaitOpts) {} // no-op
-func (r *recordingRenderer) Prompt(stepID string, inputs []InputDef) map[string]any {
-	out := make(map[string]any, len(inputs))
-	for _, in := range inputs {
-		if in.Default != nil {
-			out[in.Name] = in.Default
+func (r *recordingRenderer) AttachEventQueue(q *events.EventQueue) {
+	r.queue = q
+	r.done = false
+	r.drainWG.Add(1)
+	go func() {
+		defer r.drainWG.Done()
+		sub := q.Subscribe()
+		defer sub.Close()
+		offset := r.drainFrom(0)
+		for !r.done {
+			<-sub.Notify()
+			offset = r.drainFrom(offset)
 		}
+	}()
+}
+
+func (r *recordingRenderer) Finish() { r.drainWG.Wait() }
+
+func (r *recordingRenderer) drainFrom(offset int) int {
+	evs, newOff := r.queue.ReadFrom(offset)
+	for i, ev := range evs {
+		r.handleEvent(offset+i, ev)
 	}
-	return out
+	return newOff
+}
+
+func (r *recordingRenderer) handleEvent(off int, ev events.Event) {
+	switch e := ev.(type) {
+	case events.Header:
+		r.record("header:" + e.Title)
+	case events.StepStart:
+		r.record("step:" + e.Title)
+	case events.StepEnd:
+		r.record("result")
+		if r.onStepEnd != nil {
+			r.onStepEnd(e.Visit, e.Status, e.Message, e.ErrorText)
+		}
+	case events.OutputChunk:
+		if r.onChunk != nil {
+			r.onChunk(e.Visit, e.Chunk)
+		}
+	case events.Section:
+		r.record("section:" + e.Title)
+	case events.Done:
+		r.record("done")
+		r.done = true
+	case events.PromptOpen:
+		// Mirror the legacy spy's default-filling behavior so input
+		// steps don't deadlock waiting on a stdin that tests don't
+		// provide.
+		if _, resolved := r.queue.Resolution(off); resolved {
+			return
+		}
+		out := make(map[string]any, len(e.Inputs))
+		for _, in := range e.Inputs {
+			if d := in.InputDefault(); d != nil {
+				out[in.InputName()] = d
+			}
+		}
+		_ = r.queue.Resolve(off, &events.PromptResolution{
+			Answers: out, Source: "default", Timestamp: time.Now(),
+		})
+	}
+}
+
+func (r *recordingRenderer) record(s string) {
+	r.mu.Lock()
+	r.calls = append(r.calls, s)
+	r.mu.Unlock()
 }
 
 // TestExecuteJumpViaNext verifies that a step's StepResult.Next jumps to

--- a/notebookbridge/bridge.go
+++ b/notebookbridge/bridge.go
@@ -1,12 +1,9 @@
 // Package notebookbridge wires demokit's event queue to the
 // standalone notebook component. It implements demokit.Renderer
-// (mostly as no-ops) + demokit.EventAwareRenderer; when demokit
-// detects the EventAwareRenderer interface it skips the legacy
-// renderer-driven path and just appends events. The bridge drains
-// those events in a background goroutine and translates each one
-// into the equivalent notebook.* call.
-//
-// Replaces the in-tree tui/notebook/ event-aware renderer.
+// (the event-aware contract): AttachEventQueue is the entry point
+// for lazy notebook setup + drain, and Finish blocks until the
+// notebook UI exits so demokit's Execute waits for the user before
+// returning.
 package notebookbridge
 
 import (
@@ -20,6 +17,13 @@ import (
 	"github.com/panyam/demokit/events"
 	"github.com/panyam/demokit/notebook"
 	"github.com/panyam/demokit/notebook/cells"
+)
+
+// Compile-time assertions: Bridge is the demokit Renderer
+// (event-aware) and Finishable (waits for notebook UI exit at Done).
+var (
+	_ demokit.Renderer           = (*Bridge)(nil)
+	_ demokit.FinishableRenderer = (*Bridge)(nil)
 )
 
 // Bridge wires the demokit event queue to a notebook.Notebook.
@@ -82,33 +86,19 @@ func (b *Bridge) WithMaxOutputBody(n int) *Bridge {
 	return b
 }
 
-// --- demokit.EventAwareRenderer ---
-
-// AttachEventQueue stores the queue. demokit calls this once at
-// the start of each run, before any Render* call.
-func (b *Bridge) AttachEventQueue(q *events.EventQueue) { b.queue = q }
-
-// --- demokit.Renderer (no-ops; events drive everything) ---
-
-// RenderHeader is the first lifecycle hook; we use it as the
-// trigger to start the notebook program lazily.
-func (b *Bridge) RenderHeader(string, string, int) { b.ensureBridge() }
-
-func (b *Bridge) RenderStep(int, int, *demokit.StepDef)         { b.ensureBridge() }
-func (b *Bridge) RenderResult(int, string, *demokit.StepResult) {}
-func (b *Bridge) RenderSection(*demokit.SectionDef)             {}
-func (b *Bridge) WaitForStep(demokit.WaitOpts)                  {}
-func (b *Bridge) Prompt(string, []demokit.InputDef) map[string]any {
-	return nil
-}
-func (b *Bridge) StreamOutput(int, []byte, io.Writer) {}
-
-// RenderDone blocks until the notebook program exits (user
-// pressed Ctrl+C / q / etc.). Idempotent.
-func (b *Bridge) RenderDone() {
+// AttachEventQueue stores the queue and spawns the notebook program
+// + the event-drain goroutine. demokit calls this once at the start
+// of each run, before any event is appended.
+func (b *Bridge) AttachEventQueue(q *events.EventQueue) {
+	b.queue = q
 	b.ensureBridge()
-	<-b.nbDone
 }
+
+// Finish blocks until the notebook program exits (user pressed
+// Ctrl+C / q / etc.). Demokit calls this after emitting the Done
+// event so Execute doesn't return until the user has dismissed the
+// notebook UI.
+func (b *Bridge) Finish() { <-b.nbDone }
 
 // ensureBridge spins up the notebook program + the event-drain
 // goroutine the first time it's called.

--- a/renderer.go
+++ b/renderer.go
@@ -16,56 +16,12 @@ import (
 	"github.com/panyam/demokit/events"
 )
 
-// Renderer controls how demo output is displayed. Implement this interface
-// to provide custom visual styles (e.g., TUI with Lipgloss boxes).
-type Renderer interface {
-	// RenderHeader displays the demo title, description, and step count.
-	RenderHeader(title, description string, stepCount int)
-	// RenderStep displays a step's metadata (number, title, arrows, refs, note)
-	// before it is executed.
-	RenderStep(stepNum, totalSteps int, step *StepDef)
-	// RenderResult displays the captured output from a step's run function.
-	// output is the captured stdout. result is nil for success with no message.
-	RenderResult(stepNum int, output string, result *StepResult)
-	// RenderSection displays a non-executable explanatory block.
-	RenderSection(section *SectionDef)
-	// RenderDone displays the demo completion message.
-	RenderDone()
-	// WaitForStep blocks until the user is ready to run the next step.
-	// Called only in interactive mode. If opts.AutoAcceptAfter > 0 the
-	// renderer should advance automatically after that duration.
-	WaitForStep(opts WaitOpts)
-	// Prompt collects the declared inputs from the user and returns a
-	// typed map keyed by InputDef.Name. Only called in interactive mode
-	// when the step has at least one input. Implementations should
-	// re-prompt on Parse error and respect each input's Default.
-	Prompt(stepID string, inputs []InputDef) map[string]any
-}
-
-// StreamingRenderer is implemented by renderers that can show step
-// output incrementally while Run is still executing. demokit detects
-// this via type assertion: when the renderer implements StreamOutput,
-// captureOutput tees each chunk into the renderer in roughly real
-// time. RenderResult is then called with output == "" because the
-// body has already appeared on screen.
-//
-// Renderers that don't implement StreamingRenderer get the buffered
-// path: the full captured output is passed to RenderResult after Run
-// returns.
-type StreamingRenderer interface {
-	Renderer
-	// StreamOutput is called for each byte chunk a step's Run writes
-	// to stdout or stderr while it's still executing. May be invoked
-	// from a goroutine other than the one driving Render*; renderers
-	// must serialize their own state if needed.
-	//
-	// out is the writer to emit chunks to — the user's actual stdout,
-	// captured before captureOutput redirected it. Writing to
-	// os.Stdout directly would loop the chunks back into the capture
-	// pipe. stepNum is the absolute visit count (matching what
-	// RenderStep received); implementations are free to ignore it.
-	StreamOutput(stepNum int, chunk []byte, out io.Writer)
-}
+// Compile-time assertion: PlainRenderer is the demokit Renderer
+// (event-aware, finishable).
+var (
+	_ Renderer           = (*PlainRenderer)(nil)
+	_ FinishableRenderer = (*PlainRenderer)(nil)
+)
 
 // --- PlainRenderer: default text-only renderer (zero dependencies) ---
 
@@ -80,28 +36,15 @@ type PlainRenderer struct {
 	// Fraction of terminal width to use. 0 means 0.90.
 	Fraction float64
 
-	// lastStep is set by RenderStep (legacy path) and consulted by
-	// WaitForStep to build the digit-to-copy prompt. Cleared at the
-	// next RenderStep so a step with no copyables falls through to
-	// the plain Enter pause.
-	lastStep *StepDef
-
-	// --- event-aware path (demokit.EventAwareRenderer) ---
+	// --- event drain state ---
 	//
-	// When Execute attaches its queue via AttachEventQueue, plain
-	// becomes a queue consumer like the bridge: a goroutine drains
-	// the *discrete* events (Header, StepStart, Section, StepEnd,
-	// Done, sync waits/prompts) and dispatches to the same printX
-	// helpers the legacy methods use. OutputChunk events are
-	// deliberately NOT handled here — chunks continue to flow live
-	// to the user's terminal via the StreamingRenderer.StreamOutput
-	// inline tee in Execute, which already has the real
-	// pre-captureOutput stdout writer to print to. Execute skips
-	// its dual legacy-method calls for the discrete events when
-	// this renderer is attached (see demokit.go).
+	// When Execute attaches its queue via AttachEventQueue, a
+	// goroutine drains every event (Header, StepStart, OutputChunk,
+	// StepEnd, Section, Done, sync waits/prompts) and dispatches
+	// to the printX helpers + the stdout snapshot below.
 	queue      *events.EventQueue
 	boxedFlag  bool              // mirror of events.Header.BoxedVerbatim
-	lastStepEv *events.StepStart // event-side mirror of lastStep, for the copy prompt
+	lastStepEv *events.StepStart // most recent StepStart, used to compute the copy prompt
 	done       bool              // set by Done; tells drainEvents to exit so the goroutine doesn't leak across runs/tests
 	drainWG    sync.WaitGroup    // tracks the drain goroutine so Finish can wait for it
 
@@ -116,8 +59,8 @@ type PlainRenderer struct {
 	snapErr *os.File
 }
 
-// width returns the usable output width. Uses the renderer's snapshot
-// *os.File handles when set (drain path) so the term.GetSize call
+// width returns the usable output width. Uses the renderer's
+// pinned snapshot *os.File handles so the term.GetSize call
 // doesn't race with captureOutput's os.Stdout swap.
 func (r *PlainRenderer) width() int {
 	frac := r.Fraction
@@ -139,9 +82,12 @@ func (r *PlainRenderer) width() int {
 }
 
 // termWidth queries the terminal width through the renderer's
-// snapshot file handles (drain path) or live os.Stdout/Stderr (legacy
-// path), 80 fallback. The drain-side path takes no extra lock — its
-// snapshots are pinned at AttachEventQueue time.
+// pinned snapshot file handles, 80 fallback. The snapshots are
+// taken at AttachEventQueue time so no extra lock is needed — they
+// don't race with captureOutput's os.Stdout swap. Before the
+// snapshot is set (e.g. tests that construct a PlainRenderer
+// without attaching to a queue) falls back to live os.Stdout via
+// TermWidth's RLock.
 func (r *PlainRenderer) termWidth() int {
 	if r.snapOut != nil || r.snapErr != nil {
 		for _, f := range []*os.File{r.stdoutFile(), r.stderrFile()} {
@@ -151,7 +97,6 @@ func (r *PlainRenderer) termWidth() int {
 		}
 		return 80
 	}
-	// Legacy path: live os.Stdout/Stderr, gated by TermWidth's RLock.
 	return TermWidth()
 }
 
@@ -197,7 +142,10 @@ func (r *PlainRenderer) printLine(format string, args ...any) {
 	}
 }
 
-func (r *PlainRenderer) RenderHeader(title, description string, stepCount int) {
+// printHeaderBlock formats and emits the demo header. Called by the
+// event drain on Header; tests in the demokit package call it
+// directly to assert the formatting.
+func (r *PlainRenderer) printHeaderBlock(title, description string, stepCount int) {
 	w := r.width()
 	sep := strings.Repeat("=", w)
 	r.printLine("%s\n", sep)
@@ -210,26 +158,9 @@ func (r *PlainRenderer) RenderHeader(title, description string, stepCount int) {
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *PlainRenderer) RenderStep(stepNum, totalSteps int, step *StepDef) {
-	r.lastStep = step
-	demo := step.Demo()
-	r.printStepBlock(stepNum, totalSteps, events.StepStart{
-		Visit:     stepNum,
-		StepID:    step.id,
-		Title:     step.title,
-		Note:      step.note,
-		Declared:  totalSteps,
-		Arrows:    arrowsToEvents(step.Arrows()),
-		Refs:      refsToEvents(step.Refs()),
-		Verbatims: verbatimsToEvents(step.VerbatimBlocks()),
-	}, demo != nil && demo.IsBoxedVerbatim())
-}
-
-// printStepBlock is the shared formatter: the legacy RenderStep
-// extracts fields from *StepDef into the event projection and calls
-// here; the event drain calls here directly with the projection it
-// already has. boxedDefault is the demo-wide flag (Header carries it
-// for the drain; the legacy path pulls it from step.Demo()).
+// printStepBlock is the shared formatter the event drain calls.
+// boxedDefault comes from the Header.BoxedVerbatim flag the drain
+// caches on the renderer.
 func (r *PlainRenderer) printStepBlock(stepNum, totalSteps int, e events.StepStart, boxedDefault bool) {
 	w := r.width()
 	// totalSteps == 0 means "no denominator" — Demo.ShowStepDenominator
@@ -338,7 +269,11 @@ func (r *PlainRenderer) printVerbatimBlocks(blocks []events.Verbatim, boxedDefau
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *PlainRenderer) RenderResult(_ int, output string, result *StepResult) {
+// printResultBlock formats the post-Run result label and any
+// trailing message. Called by the event drain on StepEnd; the
+// output argument is always "" along the event-driven path
+// (chunks arrived via OutputChunk).
+func (r *PlainRenderer) printResultBlock(_ int, output string, result *StepResult) {
 	w := r.width()
 
 	// Determine label
@@ -365,10 +300,6 @@ func (r *PlainRenderer) RenderResult(_ int, output string, result *StepResult) {
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *PlainRenderer) RenderSection(section *SectionDef) {
-	r.printSection(section.title, section.body)
-}
-
 // printSection is the shared formatter the event drain also calls.
 func (r *PlainRenderer) printSection(title, body string) {
 	w := r.width()
@@ -377,57 +308,10 @@ func (r *PlainRenderer) printSection(title, body string) {
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *PlainRenderer) RenderDone() {
+// printDoneBlock prints the completion marker. Called by the event
+// drain on Done.
+func (r *PlainRenderer) printDoneBlock() {
 	r.printLine("=== Done ===\n")
-}
-
-// StreamOutput writes a chunk of step output as it's produced. The
-// out writer is the user's actual stdout (captured by Execute before
-// captureOutput redirected os.Stdout into the capture pipe); writing
-// to os.Stdout directly here would loop straight back into the pipe.
-// PlainRenderer doesn't style or buffer per-chunk — this is a
-// passthrough that lets long-running steps print live.
-func (r *PlainRenderer) StreamOutput(_ int, chunk []byte, out io.Writer) {
-	out.Write(chunk)
-}
-
-func (r *PlainRenderer) WaitForStep(opts WaitOpts) {
-	copyables := r.lastStep.NumberedCopyables()
-	if len(copyables) > 0 {
-		r.waitWithCopyPrompt(opts, copyables)
-		return
-	}
-
-	if opts.AutoAcceptAfter <= 0 {
-		fmt.Fprint(r.stdoutFor(), "\n    Press Enter to run this step...")
-		bufio.NewReader(os.Stdin).ReadString('\n')
-		fmt.Fprintln(r.stdoutFor())
-		return
-	}
-
-	var key byte
-	var gotKey bool
-	if !opts.ShowCountdown {
-		fmt.Fprintf(r.stdoutFor(), "\n    Press Enter to run (auto in %s · any key to hold)...", opts.AutoAcceptAfter.Round(time.Second))
-		key, gotKey = WaitForKeyOrTimeout(opts.AutoAcceptAfter, nil)
-		fmt.Fprintln(r.stdoutFor())
-	} else {
-		fmt.Fprintln(r.stdoutFor())
-		key, gotKey = WaitForKeyOrTimeout(opts.AutoAcceptAfter, func(remaining time.Duration) {
-			bar := countdownBar(remaining, opts.AutoAcceptAfter, 20)
-			fmt.Fprintf(r.stdoutFor(), "\r    %s  %4.1fs  (Enter to accept · any key to hold)", bar, remaining.Seconds())
-		})
-		fmt.Fprintf(r.stdoutFor(), "\r    %s\n", strings.Repeat(" ", 60))
-	}
-
-	if !gotKey || key == KeyEnter || key == '\n' {
-		return // timer fired or Enter — advance
-	}
-	// Any other key cancels the countdown. Drop into a cooked-mode
-	// "press Enter to continue" hold so the user can read the screen
-	// before advancing.
-	fmt.Fprint(r.stdoutFor(), "    (countdown stopped — press Enter to continue) ")
-	bufio.NewReader(os.Stdin).ReadString('\n')
 }
 
 // waitWithCopyPrompt is PlainRenderer's pause when the step exposes
@@ -700,62 +584,6 @@ func WaitForLineOrTimeout(timeout time.Duration, onTick func(remaining time.Dura
 	}
 }
 
-// Prompt collects inputs sequentially via stdin readline. On any Parse
-// error the renderer collects the rest of the fields, prints errors, and
-// re-prompts everything — using each just-typed valid value as the new
-// default so the user only retypes the invalid one (Enter to accept).
-func (r *PlainRenderer) Prompt(stepID string, inputs []InputDef) map[string]any {
-	if len(inputs) == 0 {
-		return map[string]any{}
-	}
-	pending := make([]InputDef, len(inputs))
-	copy(pending, inputs)
-	stdin := bufio.NewReader(os.Stdin)
-
-	for attempt := 0; ; attempt++ {
-		if attempt > 0 {
-			fmt.Fprintln(r.stdoutFor(), "    Re-enter values (Enter to keep [bracketed]):")
-		}
-		result := map[string]any{}
-		errored := false
-		for i, in := range pending {
-			label := in.Prompt
-			if label == "" {
-				label = in.Name
-			}
-			if in.Default != nil {
-				fmt.Fprintf(r.stdoutFor(), "    %s [%v]: ", label, in.Default)
-			} else {
-				fmt.Fprintf(r.stdoutFor(), "    %s: ", label)
-			}
-			line, _ := stdin.ReadString('\n')
-			line = strings.TrimRight(line, "\r\n")
-
-			if line == "" && in.Default != nil {
-				result[in.Name] = in.Default
-				continue
-			}
-
-			parser := in.Parse
-			if parser == nil {
-				parser = func(s string) (any, error) { return s, nil }
-			}
-			val, err := parser(line)
-			if err != nil {
-				fmt.Fprintf(r.stdoutFor(), "    [error] %v\n", err)
-				errored = true
-				continue
-			}
-			result[in.Name] = val
-			// Sticky: a valid value becomes the next attempt's default.
-			pending[i].Default = val
-		}
-		if !errored {
-			return result
-		}
-	}
-}
-
 // countdownBar renders a left-to-right depleting progress bar.
 func countdownBar(remaining, total time.Duration, width int) string {
 	if total <= 0 {
@@ -771,13 +599,12 @@ func countdownBar(remaining, total time.Duration, width int) string {
 	return "[" + strings.Repeat("#", filled) + strings.Repeat(" ", width-filled) + "]"
 }
 
-// --- EventAwareRenderer (demokit.EventAwareRenderer) ---
+// --- demokit.Renderer ---
 
 // AttachEventQueue wires the demokit event queue and spawns the
-// drain goroutine. Execute calls this once per run; once attached,
-// PlainRenderer drains discrete events on its own goroutine and
-// Execute stops dual-calling the legacy Render* methods. Chunks
-// still flow live via StreamOutput (see struct doc).
+// drain goroutine. Execute calls this once per run; the drain
+// dispatches every event into the printX helpers and the stdout
+// snapshot taken below.
 //
 // Resets per-run state so a renderer reused across Execute calls
 // (tests do this) starts each run with a fresh drain rather than
@@ -801,9 +628,10 @@ func (r *PlainRenderer) AttachEventQueue(q *events.EventQueue) {
 	}()
 }
 
-// stdoutFor returns the writer the drain (and legacy path) should
-// write to. Drain uses the snapshot; legacy falls back to live
-// os.Stdout. Same shape for stderr-side queries via stderrFile.
+// stdoutFor returns the writer the drain should write to. Uses
+// the snapshot taken at AttachEventQueue when present, falling
+// back to live os.Stdout for tests that drive printX helpers
+// directly without going through Execute.
 func (r *PlainRenderer) stdoutFor() io.Writer {
 	if r.snapOut != nil {
 		return r.snapOut
@@ -857,9 +685,9 @@ func (r *PlainRenderer) drainFrom(offset int) int {
 	return newOff
 }
 
-// handleEvent dispatches one event. OutputChunk + StepReadyToRun
-// are intentionally no-ops here — chunks tee live via StreamOutput.
-// No outer stdoutMu lock needed: the drain writes through
+// handleEvent dispatches one event. StepReadyToRun is intentionally
+// a no-op here — PlainRenderer has no pre-allocated output widget
+// to place. No outer stdoutMu lock needed: the drain writes through
 // snapshotted *os.File handles (r.snapOut / r.snapErr) taken at
 // AttachEventQueue time, so it never touches the live os.Stdout
 // variable that captureOutput mutates.
@@ -867,20 +695,26 @@ func (r *PlainRenderer) handleEvent(off int, ev events.Event) {
 	switch e := ev.(type) {
 	case events.Header:
 		r.boxedFlag = e.BoxedVerbatim
-		r.RenderHeader(e.Title, e.Description, e.StepCount)
+		r.printHeaderBlock(e.Title, e.Description, e.StepCount)
 	case events.Section:
 		r.printSection(e.Title, e.Body)
 	case events.StepStart:
 		stepCopy := e
 		r.lastStepEv = &stepCopy
 		r.printStepBlock(e.Visit, e.Declared, e, r.boxedFlag)
+	case events.OutputChunk:
+		// Chunks flow through the drain. r.stdoutFor() returns the
+		// snapshot pinned at AttachEventQueue, so we never read the
+		// live os.Stdout var that captureOutput mutates (issue 23 +
+		// the nested RLock deadlock — see AttachEventQueue's doc).
+		r.stdoutFor().Write(e.Chunk)
 	case events.StepEnd:
-		// Output already streamed via StreamOutput's inline tee in
-		// Execute, so RenderResult receives "" (matches today's
-		// displayOutput="" path for streaming/event-aware).
-		r.RenderResult(e.Visit, "", StepResultFromEvent(e))
+		// Output already streamed via the OutputChunk drain above;
+		// printResultBlock gets "" so the result label/message
+		// don't re-emit the body.
+		r.printResultBlock(e.Visit, "", StepResultFromEvent(e))
 	case events.Done:
-		r.RenderDone()
+		r.printDoneBlock()
 		r.done = true
 	case events.WaitForAdvance:
 		// Skip if already resolved (e.g. non-interactive paths where

--- a/term_test.go
+++ b/term_test.go
@@ -2,7 +2,6 @@ package demokit
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"sync"
@@ -85,55 +84,41 @@ func TestCaptureOutputOnChunkCallbackFires(t *testing.T) {
 	}
 }
 
-// streamingTestRenderer extends recordingRenderer with StreamOutput
-// support. Used to verify the streaming dispatch path.
-type streamingTestRenderer struct {
+// streamingResultRenderer is the event-aware test spy: it captures
+// every OutputChunk into the chunks slice so tests can assert what a
+// step streamed during Run. lastOutput stays empty by design — the
+// post-cleanup architecture delivers output exclusively as chunks
+// (StepEnd carries status/message but no output text), so any test
+// asserting on lastOutput is asserting on the no-double-print
+// invariant.
+type streamingResultRenderer struct {
 	recordingRenderer
-	mu     sync.Mutex
-	chunks []string
-}
-
-func (r *streamingTestRenderer) StreamOutput(_ int, chunk []byte, _ io.Writer) {
-	r.mu.Lock()
-	r.chunks = append(r.chunks, string(chunk))
-	r.mu.Unlock()
-}
-
-// resultRecordingRenderer captures the output value RenderResult sees,
-// so tests can assert the streaming path passes "" while the buffered
-// path passes the full text.
-type resultRecordingRenderer struct {
-	recordingRenderer
+	mu         sync.Mutex
+	chunks     []string
 	lastOutput string
 }
 
-func (r *resultRecordingRenderer) RenderResult(num int, out string, res *StepResult) {
-	r.recordingRenderer.RenderResult(num, out, res)
-	r.lastOutput = out
+func newStreamingResultRenderer() *streamingResultRenderer {
+	r := &streamingResultRenderer{}
+	r.onChunk = func(_ int, chunk []byte) {
+		r.mu.Lock()
+		r.chunks = append(r.chunks, string(chunk))
+		r.mu.Unlock()
+	}
+	return r
 }
 
-type streamingResultRenderer struct {
-	resultRecordingRenderer
-	mu     sync.Mutex
-	chunks []string
-}
-
-func (r *streamingResultRenderer) StreamOutput(_ int, chunk []byte, _ io.Writer) {
-	r.mu.Lock()
-	r.chunks = append(r.chunks, string(chunk))
-	r.mu.Unlock()
-}
-
-// TestExecuteStreamingRendererReceivesChunks verifies that when a
-// renderer implements StreamingRenderer, a step's Run output is
-// teed into StreamOutput in roughly real time AND RenderResult is
-// invoked with output == "" so the body isn't double-printed.
-func TestExecuteStreamingRendererReceivesChunks(t *testing.T) {
+// TestExecuteStreamingChunksAreDelivered verifies a step's Run output
+// flows to the renderer as OutputChunk events in roughly real time.
+// The drain accumulates them; the assertion checks the full payload
+// arrived. lastOutput stays empty because StepEnd carries no output
+// (chunks are the only delivery path).
+func TestExecuteStreamingChunksAreDelivered(t *testing.T) {
 	orig := os.Args
 	defer func() { os.Args = orig }()
 	os.Args = []string{"test", "--non-interactive"}
 
-	r := &streamingResultRenderer{}
+	r := newStreamingResultRenderer()
 	demo := New("Stream").WithRenderer(r)
 	demo.Step("emit").ID("emit").Run(func(ctx StepContext) *StepResult {
 		fmt.Print("live output")
@@ -149,28 +134,7 @@ func TestExecuteStreamingRendererReceivesChunks(t *testing.T) {
 		t.Errorf("streamed chunks = %q, want %q", gotChunks, "live output")
 	}
 	if r.lastOutput != "" {
-		t.Errorf("RenderResult should receive empty output when streaming, got %q", r.lastOutput)
-	}
-}
-
-// TestExecuteNonStreamingRendererBuffers verifies the legacy path
-// for renderers that don't implement StreamingRenderer: the captured
-// output flows in full to RenderResult, no streaming.
-func TestExecuteNonStreamingRendererBuffers(t *testing.T) {
-	orig := os.Args
-	defer func() { os.Args = orig }()
-	os.Args = []string{"test", "--non-interactive"}
-
-	r := &resultRecordingRenderer{}
-	demo := New("Buffer").WithRenderer(r)
-	demo.Step("emit").ID("emit").Run(func(ctx StepContext) *StepResult {
-		fmt.Print("buffered output")
-		return nil
-	})
-	demo.Execute()
-
-	if r.lastOutput != "buffered output" {
-		t.Errorf("buffered RenderResult output = %q, want %q", r.lastOutput, "buffered output")
+		t.Errorf("StepEnd should carry no output text (chunks are the only delivery), got %q", r.lastOutput)
 	}
 }
 

--- a/tui/copy_test.go
+++ b/tui/copy_test.go
@@ -68,14 +68,13 @@ func TestCopyableBlocksNilStep(t *testing.T) {
 	}
 }
 
-// rendererWithStep returns a Renderer prepared as if RenderStep had
-// just been called on step — activeVariant map seeded from default
-// markers. Lets the tests skip the actual Render plumbing while still
-// exercising the active-variant logic.
+// rendererWithStep returns a Renderer prepared as if the drain had
+// just dispatched a StepStart for step — activeVariant map seeded
+// from default markers. Lets the tests skip the actual drain plumbing
+// while still exercising the active-variant logic.
 func rendererWithStep(step *demokit.StepDef) *Renderer {
 	r := New()
-	r.lastStep = step
-	r.activeVariant = initialActiveVariants(step)
+	r.activeVariant = initialActiveVariantsFromVerbatims(verbatimsToEventsTUI(step.VerbatimBlocks()))
 	return r
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -72,45 +72,38 @@ type Renderer struct {
 	Delay    time.Duration // per-line scroll delay; 0 means 18ms, negative disables
 	prompter FormPrompter
 
-	// lastStep is set by RenderStep and consulted by WaitForStep so the
-	// line-based copy prompt knows which verbatim blocks the user can
-	// reference. Cleared at RenderResult so a between-step Enter pause
-	// doesn't pick up the previous step's blocks if the next step has
-	// none. v1.1 raw-mode interaction will replace this with a real
-	// focus model.
-	lastStep *demokit.StepDef
-
 	// activeVariant maps a block's index within the current step to
 	// the currently-active variant index within that block. Initial
 	// values seed from each block's Default-marked variant (or 0 if
 	// none is marked). The line-based pause loop mutates this when
 	// the user types a switch command; bare `c` then copies whichever
-	// variant is active. Reset at each RenderStep so a fresh step's
+	// variant is active. Reset at each StepStart so a fresh step's
 	// defaults take over.
 	activeVariant map[int]int
 
-	// --- event-aware path (demokit.EventAwareRenderer) ---
+	// --- event drain state ---
 	//
-	// When Execute attaches its queue via AttachEventQueue, TUI
-	// becomes a queue consumer (same shape as Plain in phase 3a):
-	// a drain goroutine dispatches discrete events into the same
-	// printX helpers the legacy methods use. OutputChunk events
-	// stay on the inline StreamOutput tee for live streaming.
-	// Snapshots of os.Stdout/Stderr are pinned at attach time so
-	// the drain never reads the live globals (race-free against
+	// When Execute attaches its queue via AttachEventQueue, a
+	// drain goroutine dispatches every event (Header, StepStart,
+	// OutputChunk, StepEnd, Section, Done, sync waits/prompts) into
+	// the printX helpers + the stdout snapshot below. Snapshots of
+	// os.Stdout/Stderr are pinned at attach time so the drain
+	// never reads the live globals (race-free against
 	// captureOutput's redirect, per issue 23).
 	queue      *events.EventQueue
 	drainDone  bool
 	drainWG    sync.WaitGroup
 	boxedFlag  bool              // mirror of events.Header.BoxedVerbatim
-	lastStepEv *events.StepStart // event-side mirror of lastStep, for the copy prompt
+	lastStepEv *events.StepStart // most recent StepStart, for the copy prompt
 	snapOut    *os.File
 	snapErr    *os.File
 }
 
-// stdoutFor returns the writer the drain (and legacy path) should
-// write to. Drain uses the snapshot; legacy falls back to live
-// os.Stdout. Same pattern as PlainRenderer's snap helpers.
+// stdoutFor returns the writer the drain should write to. Uses
+// the snapshot taken at AttachEventQueue when present, falling
+// back to live os.Stdout for tests that drive printX helpers
+// directly without going through Execute. Same pattern as
+// PlainRenderer's snap helpers.
 func (r *Renderer) stdoutFor() io.Writer {
 	if r.snapOut != nil {
 		return r.snapOut
@@ -160,10 +153,11 @@ func (r *Renderer) activePrompter() FormPrompter {
 }
 
 // terminalWidth queries the terminal width through the renderer's
-// snapshot file handles (drain path) or the live os.Stdout/Stderr
-// via demokit.TermWidth (legacy path), 80 fallback. The drain-side
-// path takes no extra lock — its snapshots are pinned at
-// AttachEventQueue time.
+// pinned snapshot file handles, 80 fallback. The snapshots are
+// taken at AttachEventQueue time so no extra lock is needed.
+// Before the snapshot is set (tests that construct a Renderer
+// without attaching to a queue) falls back to live os.Stdout via
+// demokit.TermWidth.
 func (r *Renderer) terminalWidth() int {
 	if r.snapOut != nil || r.snapErr != nil {
 		for _, f := range []*os.File{r.stdoutFile(), r.stderrFile()} {
@@ -230,7 +224,9 @@ func (r *Renderer) smoothPrint(rendered string) {
 	}
 }
 
-func (r *Renderer) RenderHeader(title, description string, stepCount int) {
+// printHeaderBlock formats and emits the demo header. Called by
+// the event drain on Header.
+func (r *Renderer) printHeaderBlock(title, description string, stepCount int) {
 	p := r.Palette
 
 	titleStyle := lipgloss.NewStyle().
@@ -268,24 +264,9 @@ func (r *Renderer) RenderHeader(title, description string, stepCount int) {
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *Renderer) RenderStep(stepNum, totalSteps int, step *demokit.StepDef) {
-	r.lastStep = step
-	demo := step.Demo()
-	r.printStepBlock(stepNum, totalSteps, events.StepStart{
-		Visit:     stepNum,
-		StepID:    step.StepID(),
-		Title:     step.Title(),
-		Note:      step.NoteText(),
-		Declared:  totalSteps,
-		Refs:      refsToEvents(step.Refs()),
-		Arrows:    arrowsToEvents(step.Arrows()),
-		Verbatims: verbatimsToEventsTUI(step.VerbatimBlocks()),
-	}, demo != nil && demo.IsBoxedVerbatim())
-}
-
-// printStepBlock is the shared formatter the event drain also calls.
-// Body extracted from RenderStep; reads through the event projection
-// so both legacy and drain paths converge on one implementation.
+// printStepBlock is the shared formatter the event drain calls.
+// boxedDefault comes from the Header.BoxedVerbatim flag the drain
+// caches on the renderer.
 func (r *Renderer) printStepBlock(stepNum, totalSteps int, e events.StepStart, boxedDefault bool) {
 	r.activeVariant = initialActiveVariantsFromVerbatims(e.Verbatims)
 	p := r.Palette
@@ -470,21 +451,11 @@ func (r *Renderer) activeIndex(blockIdx int) int {
 	return r.activeVariant[blockIdx]
 }
 
-// initialActiveVariants computes the starting active-variant index
-// for each block on a step: the Default-marked variant if any,
-// otherwise the first. Returns a fresh map so the previous step's
-// state doesn't leak.
-func initialActiveVariants(step *demokit.StepDef) map[int]int {
-	if step == nil {
-		return nil
-	}
-	return initialActiveVariantsFromVerbatims(verbatimsToEventsTUI(step.VerbatimBlocks()))
-}
-
-// initialActiveVariantsFromVerbatims is the event-projection variant
-// of initialActiveVariants. Same default-marked-variant rule; works
-// off the events.Verbatim shape so the drain doesn't reconstruct
-// *StepDef.
+// initialActiveVariantsFromVerbatims computes the starting
+// active-variant index for each block on a step: the Default-marked
+// variant if any, otherwise the first. Returns a fresh map so the
+// previous step's state doesn't leak. Called by the drain on
+// StepStart and by tests that prep a Renderer with seeded state.
 func initialActiveVariantsFromVerbatims(blocks []events.Verbatim) map[int]int {
 	out := map[int]int{}
 	for i, v := range blocks {
@@ -502,10 +473,9 @@ func initialActiveVariantsFromVerbatims(blocks []events.Verbatim) map[int]int {
 //
 // events.Ref/Arrow/Variant/Verbatim have identical field shapes to
 // demokit.Ref/ArrowView/VariantView/VerbatimView. These tiny copy
-// helpers let the legacy methods build event projections (so they
-// can call the projection-taking printX helpers) and let the drain
-// hand block-rendering helpers the legacy view types they already
-// take. The cleanup PR may extract these to a shared location.
+// helpers let the drain hand block-rendering helpers (which still
+// take the legacy view types) the projected event data, and let
+// tests project a *StepDef into a StepStart event for printStepBlock.
 
 func refsToEvents(in []demokit.Ref) []events.Ref {
 	if len(in) == 0 {
@@ -571,23 +541,10 @@ func (r *Renderer) statusColors(status demokit.ResultStatus) (border, label colo
 	}
 }
 
-// StreamOutput writes a chunk of step output as the step's Run is
-// still executing. demokit's Execute loop dispatches here when the
-// renderer implements StreamingRenderer; the resulting RenderResult
-// call is then handed an empty output so the body isn't double-printed.
-//
-// out is the writer to emit chunks to (the user's actual stdout,
-// captured before the redirect into demokit's capture pipe).
-//
-// Phase-1 implementation writes chunks raw between the step header
-// and the eventual styled status box. A future enhancement would
-// track an in-progress box and redraw it via cursor rewind on each
-// chunk for a live-growing-box effect; that's deferred.
-func (r *Renderer) StreamOutput(_ int, chunk []byte, out io.Writer) {
-	out.Write(chunk)
-}
-
-func (r *Renderer) RenderResult(stepNum int, output string, result *demokit.StepResult) {
+// printResultBlock formats the post-Run result box. Called by the
+// event drain on StepEnd; the output argument is always "" along
+// the event-driven path (chunks arrived via OutputChunk).
+func (r *Renderer) printResultBlock(_ int, output string, result *demokit.StepResult) {
 	output = strings.TrimRight(output, "\n")
 
 	// Nothing to show
@@ -642,11 +599,7 @@ func (r *Renderer) RenderResult(stepNum int, output string, result *demokit.Step
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *Renderer) RenderSection(section *demokit.SectionDef) {
-	r.printSectionBlock(section.Title(), section.Body())
-}
-
-// printSectionBlock is the shared formatter the event drain also calls.
+// printSectionBlock is the shared formatter the event drain calls.
 func (r *Renderer) printSectionBlock(title, body string) {
 	p := r.Palette
 	iw := r.innerWidth()
@@ -678,7 +631,9 @@ func (r *Renderer) printSectionBlock(title, body string) {
 	fmt.Fprintln(r.stdoutFor())
 }
 
-func (r *Renderer) RenderDone() {
+// printDoneBlock prints the completion marker. Called by the
+// event drain on Done.
+func (r *Renderer) printDoneBlock() {
 	p := r.Palette
 	style := lipgloss.NewStyle().
 		Bold(true).
@@ -695,14 +650,8 @@ func (r *Renderer) RenderDone() {
 	r.smoothPrint(box.Render(style.Render("Done")))
 }
 
-func (r *Renderer) WaitForStep(opts demokit.WaitOpts) {
-	r.waitForAdvanceUI(opts, r.copyableBlocks(r.lastStep))
-}
-
-// waitForAdvanceUI is the shared interactive-pause loop the event
-// drain also calls (with copyables computed from r.lastStepEv).
-// Body lifted from WaitForStep so legacy and drain converge on one
-// implementation.
+// waitForAdvanceUI is the interactive-pause loop the event drain
+// calls (with copyables computed from r.lastStepEv).
 func (r *Renderer) waitForAdvanceUI(opts demokit.WaitOpts, copyables []copyableBlock) {
 	p := r.Palette
 	style := lipgloss.NewStyle().
@@ -820,12 +769,6 @@ func (r *Renderer) echoActiveVariant(copyables []copyableBlock) {
 	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
 }
 
-// Prompt delegates to the renderer's FormPrompter (default
-// ReadlinePrompter). Customize via Renderer.WithPrompter.
-func (r *Renderer) Prompt(stepID string, inputs []demokit.InputDef) map[string]any {
-	return r.activePrompter().Prompt(stepID, inputs)
-}
-
 func plainCountdownBar(remaining, total time.Duration, width int) string {
 	if total <= 0 {
 		return strings.Repeat(" ", width)
@@ -840,22 +783,20 @@ func plainCountdownBar(remaining, total time.Duration, width int) string {
 	return "[" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "]"
 }
 
-// --- EventAwareRenderer / FinishableRenderer ---
-
-// Compile-time assertions: TUI is event-aware (drains the queue and
-// dispatches into the same printX helpers the legacy methods use)
-// and finishable (waits for the drain at Done).
+// Compile-time assertions: TUI is the demokit Renderer (drains the
+// queue and dispatches into printX helpers) and finishable (waits
+// for the drain at Done).
 var (
-	_ demokit.EventAwareRenderer = (*Renderer)(nil)
+	_ demokit.Renderer           = (*Renderer)(nil)
 	_ demokit.FinishableRenderer = (*Renderer)(nil)
 )
 
 // AttachEventQueue wires the demokit event queue and spawns the
-// drain goroutine. Once attached, demokit gates the legacy Render*
-// method dispatch and the drain handles everything. Snapshots
-// os.Stdout / Stderr under stdoutMu.RLock (issue 23) so the drain
+// drain goroutine. Execute calls this once per run; the drain
+// dispatches every event into the printX helpers + the stdout
+// snapshot taken below. Snapshots os.Stdout / Stderr so the drain
 // writes to stable file handles, race-free against captureOutput's
-// redirect — same pattern as PlainRenderer in phase 3a.
+// redirect (issue 23).
 func (r *Renderer) AttachEventQueue(q *events.EventQueue) {
 	r.queue = q
 	r.drainDone = false
@@ -899,26 +840,34 @@ func (r *Renderer) drainFrom(offset int) int {
 }
 
 // handleEvent dispatches one event into the shared printX helpers.
-// OutputChunk + StepReadyToRun stay no-ops here — chunks tee live
-// via StreamOutput (the inline path in Execute already has the real
-// pre-captureOutput stdout writer).
+// StepReadyToRun stays a no-op here — TUI has no pre-allocated
+// output widget to place. No outer stdoutMu lock needed: the drain
+// writes through snapshotted *os.File handles taken at
+// AttachEventQueue time, so it never touches the live os.Stdout
+// variable that captureOutput mutates.
 func (r *Renderer) handleEvent(off int, ev events.Event) {
 	switch e := ev.(type) {
 	case events.Header:
 		r.boxedFlag = e.BoxedVerbatim
-		r.RenderHeader(e.Title, e.Description, e.StepCount)
+		r.printHeaderBlock(e.Title, e.Description, e.StepCount)
 	case events.Section:
 		r.printSectionBlock(e.Title, e.Body)
 	case events.StepStart:
 		stepCopy := e
 		r.lastStepEv = &stepCopy
 		r.printStepBlock(e.Visit, e.Declared, e, r.boxedFlag)
+	case events.OutputChunk:
+		// Chunks flow through the drain. r.stdoutFor() returns the
+		// snapshot pinned at AttachEventQueue, race-free against
+		// captureOutput's os.Stdout swap (issue 23).
+		r.stdoutFor().Write(e.Chunk)
 	case events.StepEnd:
-		// Output already streamed via StreamOutput's inline tee, so
-		// the result block gets "" — matches phase 3a's pattern.
-		r.RenderResult(e.Visit, "", demokit.StepResultFromEvent(e))
+		// Output already streamed via the OutputChunk drain above;
+		// printResultBlock gets "" so the result label/message
+		// don't re-emit the body.
+		r.printResultBlock(e.Visit, "", demokit.StepResultFromEvent(e))
 	case events.Done:
-		r.RenderDone()
+		r.printDoneBlock()
 		r.drainDone = true
 	case events.WaitForAdvance:
 		// Already resolved (non-interactive defaults) — skip.

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/events"
 )
 
 // captureStdout runs fn and returns what it wrote to stdout.
@@ -41,6 +42,23 @@ func newTestRenderer() *Renderer {
 	return r
 }
 
+// stepStartFromDef builds the events.StepStart projection for a
+// *demokit.StepDef the same way demokit's event emitter does. Tests
+// use this to drive printStepBlock directly without standing up a
+// full Execute + event queue.
+func stepStartFromDef(visit, declared int, step *demokit.StepDef) events.StepStart {
+	return events.StepStart{
+		Visit:     visit,
+		StepID:    step.StepID(),
+		Title:     step.Title(),
+		Note:      step.NoteText(),
+		Declared:  declared,
+		Refs:      refsToEvents(step.Refs()),
+		Arrows:    arrowsToEvents(step.Arrows()),
+		Verbatims: verbatimsToEventsTUI(step.VerbatimBlocks()),
+	}
+}
+
 func TestRendererImplementsInterface(t *testing.T) {
 	var _ demokit.Renderer = (*Renderer)(nil)
 }
@@ -48,7 +66,7 @@ func TestRendererImplementsInterface(t *testing.T) {
 func TestRenderHeader(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderHeader("My Demo", "A description", 5)
+		r.printHeaderBlock("My Demo", "A description", 5)
 	})
 	if !strings.Contains(out, "My Demo") {
 		t.Error("header should contain title")
@@ -68,7 +86,7 @@ func TestRenderStep(t *testing.T) {
 		Note("This is a note")
 
 	out := captureStdout(t, func() {
-		r.RenderStep(1, 3, step)
+		r.printStepBlock(1, 3, stepStartFromDef(1, 3, step), false)
 	})
 
 	checks := []string{"Step 1/3", "Test Step", "RFC 123", "A", "B", "call", "This is a note"}
@@ -97,7 +115,7 @@ func TestRenderStepVerbatimNoBorderInjection(t *testing.T) {
 	step := demo.Step("Repro").VerbatimLang("the wire", "bash", content)
 
 	out := captureStdout(t, func() {
-		r.RenderStep(1, 1, step)
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), false)
 	})
 
 	// Walk every output row. If a row contains the verbatim content
@@ -139,7 +157,7 @@ func TestRenderStepVerbatimMultilinePreserved(t *testing.T) {
 	step := demo.Step("Repro").Verbatim("", "line1\nline2\nline3")
 
 	out := captureStdout(t, func() {
-		r.RenderStep(1, 1, step)
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), false)
 	})
 
 	for _, want := range []string{"line1", "line2", "line3"} {
@@ -152,7 +170,7 @@ func TestRenderStepVerbatimMultilinePreserved(t *testing.T) {
 func TestRenderResultSuccess(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "some output", nil)
+		r.printResultBlock(1, "some output", nil)
 	})
 	if !strings.Contains(out, "Result") {
 		t.Error("result should contain 'Result' label")
@@ -165,7 +183,7 @@ func TestRenderResultSuccess(t *testing.T) {
 func TestRenderResultEmpty(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "", nil)
+		r.printResultBlock(1, "", nil)
 	})
 	if strings.Contains(out, "Result") {
 		t.Error("empty result should not render a Result box")
@@ -175,7 +193,7 @@ func TestRenderResultEmpty(t *testing.T) {
 func TestRenderResultError(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "partial output", demokit.Errf("something broke"))
+		r.printResultBlock(1, "partial output", demokit.Errf("something broke"))
 	})
 	if !strings.Contains(out, "Error") {
 		t.Error("error result should contain 'Error' label")
@@ -191,7 +209,7 @@ func TestRenderResultError(t *testing.T) {
 func TestRenderResultWarning(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "", demokit.Warn("watch out"))
+		r.printResultBlock(1, "", demokit.Warn("watch out"))
 	})
 	if !strings.Contains(out, "Warning") {
 		t.Error("warning result should contain 'Warning' label")
@@ -204,7 +222,7 @@ func TestRenderResultWarning(t *testing.T) {
 func TestRenderResultInfo(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "", demokit.Info("FYI"))
+		r.printResultBlock(1, "", demokit.Info("FYI"))
 	})
 	if !strings.Contains(out, "Info") {
 		t.Error("info result should contain 'Info' label")
@@ -217,7 +235,7 @@ func TestRenderResultInfo(t *testing.T) {
 func TestRenderResultCustomLabel(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderResult(1, "", &demokit.StepResult{
+		r.printResultBlock(1, "", &demokit.StepResult{
 			Status: demokit.StatusWarning, Label: "Heads Up", Message: "custom label",
 		})
 	})
@@ -258,7 +276,7 @@ func TestRenderSection(t *testing.T) {
 func TestRenderDone(t *testing.T) {
 	r := newTestRenderer()
 	out := captureStdout(t, func() {
-		r.RenderDone()
+		r.printDoneBlock()
 	})
 	if !strings.Contains(out, "Done") {
 		t.Error("done output missing 'Done'")
@@ -272,7 +290,7 @@ func TestCustomWidth(t *testing.T) {
 	r.Delay = -1     // disable smooth scroll for test speed
 
 	out := captureStdout(t, func() {
-		r.RenderHeader("Narrow", "", 1)
+		r.printHeaderBlock("Narrow", "", 1)
 	})
 	if !strings.Contains(out, "Narrow") {
 		t.Error("narrow render missing title")
@@ -284,7 +302,7 @@ func TestCustomPalette(t *testing.T) {
 	// Just verify it doesn't panic with a custom palette.
 	r.Palette = DefaultPalette()
 	out := captureStdout(t, func() {
-		r.RenderHeader("Palette Test", "", 1)
+		r.printHeaderBlock("Palette Test", "", 1)
 	})
 	if !strings.Contains(out, "Palette Test") {
 		t.Error("custom palette render failed")

--- a/web/serve.go
+++ b/web/serve.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -92,14 +91,11 @@ func (s *liveServer) shutdown() {
 
 // --- liveServer ---
 
-// liveServer doubles as the demokit Renderer for --serve mode:
-// implements EventAwareRenderer (drains the demo's event queue,
-// broadcasts WS frames) and FinishableRenderer (waits for the
-// drain on Done). The legacy Render* methods are no-ops because
-// demokit gates them for event-aware renderers; they only exist
-// to satisfy the interface. This is the notebook-style decomposition
+// liveServer is the demokit Renderer for --serve mode: drains the
+// demo's event queue, broadcasts WS frames, and (via Finish) waits
+// for the drain on Done. This is the notebook-style decomposition
 // — the browser player is the view, liveServer is the bridge,
-// nothing wraps an inner local renderer (see PR thread).
+// nothing wraps an inner local renderer.
 type liveServer struct {
 	demo *demokit.Demo
 	hub  *wsHub
@@ -379,32 +375,15 @@ func (h *wsHub) closeAll() {
 	h.conns = make(map[string]*liveConn)
 }
 
-// --- liveServer as demokit.Renderer / EventAwareRenderer / FinishableRenderer ---
+// --- liveServer as demokit.Renderer ---
 
-// Compile-time assertions: liveServer is the renderer demokit calls
-// (every method on the legacy Renderer/StreamingRenderer surface),
-// AND the event-aware drain that does the real work; demokit gates
-// the legacy methods for event-aware renderers (Phase 3a) so the
-// no-ops below only exist to satisfy the interface.
+// Compile-time assertions: liveServer is the demokit Renderer
+// (event-aware drain that broadcasts WS frames) and Finishable
+// (waits for the drain at Done).
 var (
 	_ demokit.Renderer           = (*liveServer)(nil)
-	_ demokit.StreamingRenderer  = (*liveServer)(nil)
-	_ demokit.EventAwareRenderer = (*liveServer)(nil)
 	_ demokit.FinishableRenderer = (*liveServer)(nil)
 )
-
-// --- Renderer interface stubs (never called when event-aware) ---
-
-func (s *liveServer) RenderHeader(string, string, int)                 {}
-func (s *liveServer) RenderStep(int, int, *demokit.StepDef)            {}
-func (s *liveServer) RenderResult(int, string, *demokit.StepResult)    {}
-func (s *liveServer) RenderSection(*demokit.SectionDef)                {}
-func (s *liveServer) RenderDone()                                      {}
-func (s *liveServer) WaitForStep(demokit.WaitOpts)                     {}
-func (s *liveServer) Prompt(string, []demokit.InputDef) map[string]any { return nil }
-func (s *liveServer) StreamOutput(int, []byte, io.Writer)              {}
-
-// --- EventAwareRenderer + FinishableRenderer ---
 
 // AttachEventQueue wires the demo's event queue and spawns the drain.
 // Called once per RunLoop. reset() re-launches runDemo with a fresh
@@ -451,9 +430,7 @@ func (s *liveServer) drainFrom(offset int) int {
 }
 
 // handleEvent translates one demokit event into a WS frame (or
-// blocks for sync events). Mirrors what the pre-3b webRenderer did
-// in its Render*/Prompt/StreamOutput methods, but driven by the
-// queue rather than by Execute's method calls.
+// blocks for sync events).
 func (s *liveServer) handleEvent(off int, ev events.Event) {
 	switch e := ev.(type) {
 	case events.Header:
@@ -497,10 +474,8 @@ func (s *liveServer) handleEvent(off int, ev events.Event) {
 		})
 	case events.StepEnd:
 		// max-visits / max-steps aborts emit StepEnd for a visit
-		// that never had a StepStart (Phase 3a's error-path emits).
-		// Synthesise a step-start so the player has something to
-		// mark as errored — same intent as the pre-3b webRenderer's
-		// !stepOpen branch.
+		// that never had a StepStart. Synthesise a step-start so
+		// the player has something to mark as errored.
 		if _, seen := s.stepIDByVisit[e.Visit]; !seen {
 			abortedID := "__demokit_aborted__"
 			s.broadcast(serverEvent{
@@ -564,7 +539,8 @@ func (s *liveServer) handleEvent(off int, ev events.Event) {
 }
 
 // awaitPromptAnswers blocks on the inputs channel / runCtx / per-step
-// deadline; matches the legacy webRenderer.Prompt select shape.
+// deadline, returning the answers + a source label for the
+// PromptResolution event.
 func (s *liveServer) awaitPromptAnswers(stepID string, inputs []events.Input) (map[string]any, string) {
 	timeout := s.demo.EffectiveInputTimeout(stepID)
 	var deadline <-chan time.Time
@@ -591,9 +567,9 @@ func (s *liveServer) awaitPromptAnswers(stepID string, inputs []events.Input) (m
 	}
 }
 
-// inputDefsFromEvents projects events.Input back into the legacy
-// demokit.InputDef shape the WS frame's `Inputs` field carries (the
-// JS player consumes that JSON shape).
+// inputDefsFromEvents projects events.Input back into the
+// demokit.InputDef shape the WS frame's `Inputs` field carries —
+// the JS player consumes that JSON shape.
 func inputDefsFromEvents(in []events.Input) []demokit.InputDef {
 	out := make([]demokit.InputDef, 0, len(in))
 	for _, ev := range in {


### PR DESCRIPTION
## What changes

Issue 18 phase 3 trilogy (PRs for plain, web, tui) made every renderer event-aware but left the legacy `Renderer` interface and dual-call branches in place for back-compat. With every renderer drained by `AttachEventQueue`, the dual paths are dead weight.

This collapses the contract to a single method:

```go
type Renderer interface {
    AttachEventQueue(q *events.EventQueue)
}
```

Net **-296 LOC** (production -540, tests +244 from drain-spy plumbing). Race detector clean across every module.

## Reviewer's guide

Read in this order:

1. [demokit.go](https://github.com/panyam/demokit/pull/54/files#diff-8d288d869eee51fb928e552417c1f39e03f623e07aaccfe068472e4c8feea6b3) — start here. The `Renderer` interface decl + `Execute`'s loop simplification (no more `isEventAware` gating, no more inline `sr.StreamOutput` tee, no more `originalStdout` snapshot, `collectInputsWithEvents` collapses to event-only).
2. [renderer.go](https://github.com/panyam/demokit/pull/54/files#diff-7258d4cda94c0f2089e19c82059aec4031ab065c7aca2a5a09909fe958b448c9) — `PlainRenderer` shrinks substantially. The legacy `RenderHeader/RenderStep/RenderResult/RenderSection/RenderDone/WaitForStep/Prompt/StreamOutput` methods are gone; the `printXBlock` helpers + drain stay. New `OutputChunk` drain handler writes to the pinned `stdoutFor()` snapshot.
3. [tui/tui.go](https://github.com/panyam/demokit/pull/54/files#diff-d17b0c5a0bb7c530a6d6b632267185fd62ba569f222c504c039e0b1fc6a259cd) — same shape as PlainRenderer (drop legacy methods, keep `printX` helpers, drop `lastStep` field).
4. [web/serve.go](https://github.com/panyam/demokit/pull/54/files#diff-9bab4ff7fbd2869907544614700562f198a9f68f02d57c9160e5b58b21b6e72b) — drop the no-op `Render*` / `StreamOutput` stubs and the `StreamingRenderer` assertion.
5. [notebookbridge/bridge.go](https://github.com/panyam/demokit/pull/54/files#diff-07836f0687e256dd4502ff3340485c2fb7c2d7c74136e11f09e31416f9607c81) — `ensureBridge()` moves from `RenderHeader` to `AttachEventQueue`; the wait on `b.nbDone` moves from `RenderDone` to a new `Finish()`.
6. [demokit_test.go](https://github.com/panyam/demokit/pull/54/files#diff-7170faf7b044599911fad1d56ec17aa3b041cc1ecb47b68304202c67873cbd65) — `recordingRenderer` becomes an event-aware spy (drain populates the `calls` slice; identical assertion shape).
7. [term_test.go](https://github.com/panyam/demokit/pull/54/files#diff-74ad7cf6aa7a9555a3603f5a88a57c718e410612a8358f60d32c047ec0b9eab4) — streaming spies collapse to one `newStreamingResultRenderer()` constructor; `TestExecuteNonStreamingRendererBuffers` removed (the path it tests no longer exists).
8. [tui/tui_test.go](https://github.com/panyam/demokit/pull/54/files#diff-45872ce74f04e9679cdda4486d441cdcd215bac084b6d01d7dff5e738995510e) — direct `r.RenderX` calls swapped for `r.printXBlock`; `stepStartFromDef` helper added to project `*StepDef` into `events.StepStart` for `printStepBlock`.

Skim: [cancel_test.go](https://github.com/panyam/demokit/pull/54/files#diff-4202100e3ad66d18adafcc134383158d4b8ecfe2287f48c01eed78bc4f63c348) / [tui/copy_test.go](https://github.com/panyam/demokit/pull/54/files#diff-3e496de494597bd0c5bd0df599405a9f4fef81fbec251cbc6e1990e037932d04) — mechanical signature swaps to the new spy/helper names.

## Decision log

- **Removed per-renderer legacy methods entirely** instead of keeping them as test-only helpers. The spy refactor makes tests drive the production code path (`AttachEventQueue` → drain → `printX`), which both eliminates dead public methods and keeps tests honest about what they cover.
- **Kept the per-renderer `printX` helpers** rather than driving every test through a real event queue + drain. The helpers are the actual rendering work and the drain calls them; tests calling them directly is one level of indirection saved. Tests that need end-to-end-via-events coverage are already in `events_integration_test.go`.
- **OutputChunk now flows through the drain on every renderer.** Previously chunks teed via an inline `sr.StreamOutput(...)` call in `Execute`, but every event-aware renderer also has to drain `OutputChunk` for the queue to be the canonical log (web does, bridge does). Removing the tee makes the drain the single delivery path and drops a class of double-print bugs from any future renderer.
- **`notebookbridge.AttachEventQueue` now calls `ensureBridge()`** so the notebook lifecycle starts at attach time. Previously `RenderHeader` did this, but with `Render*` gone the bridge needed a different entry point. `AttachEventQueue` runs before any event is appended, so the notebook program is fully ready by the time the first `Header` event lands.

## Risk / blast radius

- **Affects:** every external user with a custom Renderer impl. The interface is now `AttachEventQueue` + (optional) `Finish` instead of the 7-method legacy contract. External consumers must port to the event-aware shape — see PlainRenderer for the canonical pattern. There are no in-tree consumers besides the four renderers + tests, all migrated in this PR.
- **Tests covering this:** `recordingRenderer`-based tests in `demokit_test.go` exercise the full Execute → drain path; `events_integration_test.go` asserts the canonical event sequence; `term_test.go` covers chunk delivery; per-renderer printX tests in `tui/tui_test.go` cover the formatting helpers; `web/serve_test.go` and `notebookbridge/bridge_test.go` cover the drain translators.
- **Be paranoid about:** the `notebookbridge` lifecycle change (ensureBridge moved from `RenderHeader` to `AttachEventQueue`). The bridge's existing tests pass clean under -race, but live notebook UX should be smoke-tested against `notebook/examples/mathrepl`.

## Before / after

```
Production code:
  demokit.go:               1070 → 978   (-92)
  renderer.go:              1078 → 912  (-166)
  tui/tui.go:                990 → 939   (-51)
  web/serve.go:              684 → 660   (-24)
  notebookbridge/bridge.go:  388 → 378   (-10)
  Subtotal:                 4210 → 3867 (-343)

Test code:
  demokit_test.go:          1132 → 1198  (+66)  drain plumbing for spy
  term_test.go:              233 → 196   (-37)  buffered-path test removed
  tui/tui_test.go:           292 → 310   (+18)  stepStartFromDef helper
  tui/copy_test.go:          248 → 247    (-1)
  cancel_test.go:            161 → 160    (-1)
  Subtotal:                 2066 → 2111  (+45)

Net:                       -298 LOC
```

## Out of scope (deliberately deferred)

- Issue 21 — cell-based TUI inline interactive rewrite. Tracked as a separate effort.
- Issue 52 — generic browser-view decoupling for web (web/serve.go is still demokit-coupled in its translators).
- Issue 43 — Fenwick LineSource for notebook perf.
