### PR TITLE
feat(tui+notebook): WithBorderStyle + WithBorderChars on verbatim/output

### DIFF
--- a/demokit.go
+++ b/demokit.go
@@ -171,6 +171,149 @@ func (d *Demo) RegisterServeHandler(h ServeHandler) *Demo {
 	return d
 }
 
+// Border configuration has two independent axes. Renderers honor
+// both at their verbatim and output draw sites only — header,
+// step, section, and done boxes always use the renderer's default
+// border, since those contain no copy-relevant content.
+//
+//	tui.New().
+//	    WithBorderStyle(demokit.BorderHorizontalOnly).
+//	    WithBorderChars(demokit.BorderCharsDouble)
+//
+//	notebookbridge.New().
+//	    WithBorderStyle(demokit.BorderHorizontalOnly).
+//	    WithBorderChars(demokit.BorderCharsDouble)
+
+// BorderStyle controls which sides of a verbatim/output box draw a
+// border line. Walkthroughs that want mouse-select copy of step
+// output use BorderHorizontalOnly so triple-click selection
+// doesn't pick up vertical box characters.
+type BorderStyle int
+
+const (
+	// BorderDefault leaves the renderer's per-site default in
+	// place. The TUI draws all four sides; the notebook OutputCell
+	// defaults to horizontal-only and the VerbatimCell to all four
+	// sides. Zero value so existing callers don't migrate.
+	BorderDefault BorderStyle = iota
+	// BorderFull draws all four sides.
+	BorderFull
+	// BorderHorizontalOnly draws only the top and bottom edges.
+	// Mouse-select copy on inner content rows then picks up the
+	// content alone — no side chars.
+	BorderHorizontalOnly
+	// BorderNone draws no border. Cell content sits flush with
+	// scrollback; suits walkthroughs that prefer minimal chrome.
+	BorderNone
+)
+
+// BorderChars controls which characters the border lines use.
+// Each field holds the glyph for one position on the box; fields
+// are strings (not runes) so callers can use multi-byte combiners
+// or intentional blanks. The empty BorderChars{} value means
+// "use the renderer's built-in default" — the renderer falls
+// back to lipgloss.RoundedBorder() on the TUI side and to the
+// cell's default Border style on the notebook side.
+//
+// Use one of the named presets (BorderCharsRounded,
+// BorderCharsDouble, BorderCharsThick, BorderCharsASCII) for the
+// common visual styles, or supply a struct literal with custom
+// glyphs (`*`, `#`, `=`, etc.) for one-off looks:
+//
+//	tui.New().WithBorderChars(demokit.BorderChars{
+//	    Top: "#", Bottom: "#", Left: "*", Right: "*",
+//	    TopLeft: "+", TopRight: "+", BottomLeft: "+", BottomRight: "+",
+//	})
+//
+// Field shape mirrors lipgloss.Border so renderers can translate
+// to lipgloss without per-field bridging.
+type BorderChars struct {
+	Top, Bottom, Left, Right                   string
+	TopLeft, TopRight, BottomLeft, BottomRight string
+}
+
+// IsZero reports whether bc is the zero value (no fields set).
+// Renderers use this to choose between "configured" and "use my
+// built-in default."
+func (bc BorderChars) IsZero() bool {
+	return bc == BorderChars{}
+}
+
+// BorderCharsRounded matches lipgloss.RoundedBorder().
+var BorderCharsRounded = BorderChars{
+	Top: "─", Bottom: "─", Left: "│", Right: "│",
+	TopLeft: "╭", TopRight: "╮", BottomLeft: "╰", BottomRight: "╯",
+}
+
+// BorderCharsNormal matches lipgloss.NormalBorder() — single
+// straight lines with square corners.
+var BorderCharsNormal = BorderChars{
+	Top: "─", Bottom: "─", Left: "│", Right: "│",
+	TopLeft: "┌", TopRight: "┐", BottomLeft: "└", BottomRight: "┘",
+}
+
+// BorderCharsDouble matches lipgloss.DoubleBorder().
+var BorderCharsDouble = BorderChars{
+	Top: "═", Bottom: "═", Left: "║", Right: "║",
+	TopLeft: "╔", TopRight: "╗", BottomLeft: "╚", BottomRight: "╝",
+}
+
+// BorderCharsThick matches lipgloss.ThickBorder() — heavy strokes.
+var BorderCharsThick = BorderChars{
+	Top: "━", Bottom: "━", Left: "┃", Right: "┃",
+	TopLeft: "┏", TopRight: "┓", BottomLeft: "┗", BottomRight: "┛",
+}
+
+// BorderCharsASCII matches lipgloss.ASCIIBorder() — uses only
+// printable ASCII (-, |, +), readable in terminals without
+// Unicode box-drawing support.
+var BorderCharsASCII = BorderChars{
+	Top: "-", Bottom: "-", Left: "|", Right: "|",
+	TopLeft: "+", TopRight: "+", BottomLeft: "+", BottomRight: "+",
+}
+
+// Horizontal-only ("H") presets: same character set as their
+// full siblings but with Left/Right empty. Renderers honoring
+// the IsZero-per-side rule (empty → suppress that side) will
+// draw only the top + bottom lines plus the four corner glyphs,
+// leaving inner content rows free of side chars. Suits
+// copy-paste-friendly walkthroughs that still want the visual
+// framing the corners provide.
+//
+// One call is enough — no companion WithBorderStyle needed —
+// because the empty side fields imply BorderHorizontalOnly's
+// side toggles. Apply an explicit WithBorderStyle to override.
+
+// BorderCharsRoundedH is BorderCharsRounded with empty Left/Right.
+var BorderCharsRoundedH = BorderChars{
+	Top: "─", Bottom: "─",
+	TopLeft: "╭", TopRight: "╮", BottomLeft: "╰", BottomRight: "╯",
+}
+
+// BorderCharsNormalH is BorderCharsNormal with empty Left/Right.
+var BorderCharsNormalH = BorderChars{
+	Top: "─", Bottom: "─",
+	TopLeft: "┌", TopRight: "┐", BottomLeft: "└", BottomRight: "┘",
+}
+
+// BorderCharsDoubleH is BorderCharsDouble with empty Left/Right.
+var BorderCharsDoubleH = BorderChars{
+	Top: "═", Bottom: "═",
+	TopLeft: "╔", TopRight: "╗", BottomLeft: "╚", BottomRight: "╝",
+}
+
+// BorderCharsThickH is BorderCharsThick with empty Left/Right.
+var BorderCharsThickH = BorderChars{
+	Top: "━", Bottom: "━",
+	TopLeft: "┏", TopRight: "┓", BottomLeft: "┗", BottomRight: "┛",
+}
+
+// BorderCharsASCIIH is BorderCharsASCII with empty Left/Right.
+var BorderCharsASCIIH = BorderChars{
+	Top: "-", Bottom: "-",
+	TopLeft: "+", TopRight: "+", BottomLeft: "+", BottomRight: "+",
+}
+
 // BoxedVerbatim opts this demo into the TUI's boxed + interactive
 // rendering of verbatim blocks. When set, single-variant verbatim
 // renders inside a styled box (today's behavior is outside the box
@@ -179,7 +322,9 @@ func (d *Demo) RegisterServeHandler(h ServeHandler) *Demo {
 //
 // Multi-variant verbatim blocks (declared via VerbatimVariants) always
 // render boxed regardless of this flag — per-variant labels require a
-// frame to be readable.
+// frame to be readable. Walkthroughs that want the tab switcher AND
+// copy-friendly rows pair this with BorderHorizontalOnly on the
+// renderer.
 //
 // Has no effect on plain / markdown / HTML / JSON renderers — boxing
 // is a TUI rendering concern only.

--- a/notebook/cells/box.go
+++ b/notebook/cells/box.go
@@ -22,6 +22,21 @@ func focusedBorder(focused bool) lipgloss.Border {
 	return lipgloss.RoundedBorder()
 }
 
+// borderFor returns the lipgloss.Border a cell should draw with,
+// honoring an explicit style override before falling back to the
+// focus-based default. The override (when non-zero) wins
+// regardless of focus state — focus is then signaled via
+// BorderForeground (Color), not by swapping the char set.
+//
+// Cells call this from their RenderRows. Custom cells using the
+// same Style shape can adopt it for consistent override behavior.
+func borderFor(style lipgloss.Border, focused bool) lipgloss.Border {
+	if style != (lipgloss.Border{}) {
+		return style
+	}
+	return focusedBorder(focused)
+}
+
 // BorderEdges configures which sides of a cell's box draw a
 // border line. Default zero value is all-off, which is rarely
 // desired; cells expose typed style defaults instead. The

--- a/notebook/cells/output.go
+++ b/notebook/cells/output.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"strings"
+	"sync/atomic"
 
 	"charm.land/lipgloss/v2"
 	tea "github.com/charmbracelet/bubbletea"
@@ -29,6 +30,11 @@ type OutputStyle struct {
 	// bottom only) so users can drag-select the output body
 	// without picking up vertical bar characters.
 	Edges BorderEdges
+	// Border overrides the lipgloss border shape (which glyphs
+	// the four sides + corners use). Zero value falls back to the
+	// focus-based default (RoundedBorder unfocused, ThickBorder
+	// focused). When set, focus is signaled via BorderColor only.
+	Border lipgloss.Border
 }
 
 // DarkOutputStyle returns the dark-terminal defaults.
@@ -90,8 +96,11 @@ type OutputCell struct {
 	fallbackClip notebook.Clipboard
 	scrollOffset int
 	follow       bool
-	done         bool
-	copyMsg      string
+	// done is set by MarkDone() from the streaming goroutine and
+	// read by RenderRows() from the bubbletea View goroutine. Use
+	// atomic so the two-write/read pair stays race-free.
+	done    atomic.Bool
+	copyMsg string
 	lastCopy     string // payload retained after 'c' so 't' can replay it
 	lastWidth    int    // body width from the last render; scopes key/wheel scroll math to visual rows
 }
@@ -138,7 +147,9 @@ func (c *OutputCell) SetFallbackClipboard(clip notebook.Clipboard) {
 }
 
 // MarkDone flips the box state accent from "·live" to "·end".
-func (c *OutputCell) MarkDone() { c.done = true }
+// Safe to call from any goroutine; the View goroutine reads the
+// flag atomically.
+func (c *OutputCell) MarkDone() { c.done.Store(true) }
 
 // MaxBody returns the current row cap for the cell's rendered
 // body. Useful for resize key bindings ("+"/"-" actions in the
@@ -219,7 +230,7 @@ func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 	dim := lipgloss.NewStyle().Foreground(c.Style.DimColor)
 	state := "live"
 	stateStyle := lipgloss.NewStyle().Foreground(c.Style.LiveColor)
-	if c.done {
+	if c.done.Load() {
 		state = "end"
 		stateStyle = lipgloss.NewStyle().Foreground(c.Style.DoneColor)
 	}
@@ -233,7 +244,7 @@ func (c *OutputCell) RenderRows(width, startRow, endRow int, focused bool, _ not
 	content := title + "\n" + bodyText + "\n" + status
 
 	boxStyle := lipgloss.NewStyle().
-		Border(focusedBorder(focused)).
+		Border(borderFor(c.Style.Border, focused)).
 		BorderForeground(border).
 		BorderTop(c.Style.Edges.Top).
 		BorderRight(c.Style.Edges.Right).

--- a/notebook/cells/verbatim.go
+++ b/notebook/cells/verbatim.go
@@ -32,6 +32,12 @@ type VerbatimStyle struct {
 	ActiveTabColor   color.Color
 	InactiveTabColor color.Color
 	Edges            BorderEdges
+	// Border overrides the lipgloss border shape (which glyphs
+	// the four sides + corners use). Zero value falls back to the
+	// focus-based default (RoundedBorder unfocused, ThickBorder
+	// focused). When set, focus is signaled via BorderColor only
+	// — chars stay consistent for the configured look.
+	Border lipgloss.Border
 }
 
 // DarkVerbatimStyle returns the dark-terminal defaults.
@@ -291,7 +297,7 @@ func (c *VerbatimCell) materialize(width int, focused bool) {
 
 	content := strings.Join(parts, "\n\n")
 	boxStyle := lipgloss.NewStyle().
-		Border(focusedBorder(focused)).
+		Border(borderFor(c.Style.Border, focused)).
 		BorderForeground(border).
 		BorderTop(c.Style.Edges.Top).
 		BorderRight(c.Style.Edges.Right).

--- a/notebookbridge/bridge.go
+++ b/notebookbridge/bridge.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"charm.land/lipgloss/v2"
 	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/events"
 	"github.com/panyam/demokit/notebook"
@@ -40,8 +41,10 @@ type Bridge struct {
 	outCellByVisit map[int]notebook.CellID
 
 	// configurable knobs
-	theme      *cells.Theme
-	maxOutBody int
+	theme       *cells.Theme
+	maxOutBody  int
+	borderStyle demokit.BorderStyle // per-side toggles for VerbatimCell + OutputCell
+	borderChars demokit.BorderChars // glyphs for the border; zero value = each cell's default
 }
 
 // defaultMaxOutputBody is the OutputCell row cap the bridge
@@ -84,6 +87,102 @@ func (b *Bridge) WithMaxOutputBody(n int) *Bridge {
 		b.maxOutBody = n
 	}
 	return b
+}
+
+// WithBorderStyle configures which sides of VerbatimCell and
+// OutputCell boxes draw border lines. Header / Note / Advance
+// cells keep their per-cell defaults — they have no copy-relevant
+// content. BorderHorizontalOnly is the mouse-select-friendly
+// choice for walkthroughs whose readers copy from verbatim and
+// output rows.
+func (b *Bridge) WithBorderStyle(s demokit.BorderStyle) *Bridge {
+	b.borderStyle = s
+	return b
+}
+
+// WithBorderChars configures which characters the VerbatimCell
+// and OutputCell borders use. Pass a preset
+// (demokit.BorderCharsDouble, .Thick, .ASCII, .Normal, or the
+// horizontal-only .RoundedH / .DoubleH variants) or a struct
+// literal for custom glyphs. The zero BorderChars{} value
+// preserves each cell's built-in default (rounded for verbatim,
+// horizontal-edges-only rounded for output).
+//
+// Composes with WithBorderStyle: chars say what glyphs to use,
+// style says which sides those glyphs draw on. When style is
+// BorderDefault, empty char fields imply that side is off.
+func (b *Bridge) WithBorderChars(bc demokit.BorderChars) *Bridge {
+	b.borderChars = bc
+	return b
+}
+
+// edgesForVerbatim resolves the BorderEdges for VerbatimCell
+// given the bridge's BorderStyle + BorderChars configuration.
+// Explicit BorderStyle wins; otherwise empty char fields imply
+// the corresponding side is off; otherwise falls back to the
+// cell's all-sides default.
+func (b *Bridge) edgesForVerbatim() cells.BorderEdges {
+	switch b.borderStyle {
+	case demokit.BorderFull:
+		return cells.AllEdges()
+	case demokit.BorderHorizontalOnly:
+		return cells.HorizontalEdges()
+	case demokit.BorderNone:
+		return cells.BorderEdges{}
+	}
+	if b.borderChars.IsZero() {
+		return cells.AllEdges()
+	}
+	return cells.BorderEdges{
+		Top:    b.borderChars.Top != "",
+		Right:  b.borderChars.Right != "",
+		Bottom: b.borderChars.Bottom != "",
+		Left:   b.borderChars.Left != "",
+	}
+}
+
+// edgesForOutput resolves the BorderEdges for OutputCell. Same
+// rules as edgesForVerbatim except the default (when nothing's
+// configured) is HorizontalEdges, matching OutputCell's package
+// default — output bodies are already copy-friendly out of the
+// box.
+func (b *Bridge) edgesForOutput() cells.BorderEdges {
+	switch b.borderStyle {
+	case demokit.BorderFull:
+		return cells.AllEdges()
+	case demokit.BorderHorizontalOnly:
+		return cells.HorizontalEdges()
+	case demokit.BorderNone:
+		return cells.BorderEdges{}
+	}
+	if b.borderChars.IsZero() {
+		return cells.HorizontalEdges()
+	}
+	return cells.BorderEdges{
+		Top:    b.borderChars.Top != "",
+		Right:  b.borderChars.Right != "",
+		Bottom: b.borderChars.Bottom != "",
+		Left:   b.borderChars.Left != "",
+	}
+}
+
+// lipglossBorder translates b.borderChars into a lipgloss.Border.
+// Returns the zero lipgloss.Border{} when chars are unset so cells
+// fall back to their focus-based default in cells.borderFor.
+func (b *Bridge) lipglossBorder() lipgloss.Border {
+	if b.borderChars.IsZero() {
+		return lipgloss.Border{}
+	}
+	return lipgloss.Border{
+		Top:         b.borderChars.Top,
+		Bottom:      b.borderChars.Bottom,
+		Left:        b.borderChars.Left,
+		Right:       b.borderChars.Right,
+		TopLeft:     b.borderChars.TopLeft,
+		TopRight:    b.borderChars.TopRight,
+		BottomLeft:  b.borderChars.BottomLeft,
+		BottomRight: b.borderChars.BottomRight,
+	}
 }
 
 // AttachEventQueue stores the queue and spawns the notebook program
@@ -194,6 +293,8 @@ func (b *Bridge) handleEvent(off int, ev events.Event) {
 		if b.theme != nil {
 			oc.Style = b.theme.Output
 		}
+		oc.Style.Edges = b.edgesForOutput()
+		oc.Style.Border = b.lipglossBorder()
 		b.nb.Append(oc, notebook.RevealBottom)
 		b.visitMu.Lock()
 		b.outCellByVisit[e.Visit] = oid
@@ -278,6 +379,8 @@ func (b *Bridge) buildCellsFromStepStart(e events.StepStart) []notebook.Cell {
 		if b.theme != nil {
 			vc.Style = b.theme.Verbatim
 		}
+		vc.Style.Edges = b.edgesForVerbatim()
+		vc.Style.Border = b.lipglossBorder()
 		out = append(out, vc)
 	}
 	return out

--- a/notebookbridge/bridge_test.go
+++ b/notebookbridge/bridge_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/panyam/demokit"
 	"github.com/panyam/demokit/events"
 	"github.com/panyam/demokit/notebook"
+	"github.com/panyam/demokit/notebook/cells"
 )
 
 func TestSlugifyNormalizesCommonShapes(t *testing.T) {
@@ -76,6 +78,124 @@ func TestBuildCellsFromStepStartProducesHeaderAndVerbatims(t *testing.T) {
 	}
 	if out[1].ID() != "refresh#0.verbatim0" {
 		t.Errorf("verbatim id = %q, want refresh#0.verbatim0", out[1].ID())
+	}
+}
+
+// TestBorderStyleHorizontalOnlyPlumbedToVerbatim verifies the
+// bridge's WithBorderStyle reaches the constructed VerbatimCell's
+// Edges field. Acceptance for the sides axis of issue 55 on the
+// notebook side.
+func TestBorderStyleHorizontalOnlyPlumbedToVerbatim(t *testing.T) {
+	b := New().WithBorderStyle(demokit.BorderHorizontalOnly)
+	e := events.StepStart{
+		StepID: "s",
+		Title:  "S",
+		Verbatims: []events.Verbatim{
+			{Label: "Body", Variants: []events.Variant{
+				{Label: "curl", Content: "curl ..."},
+			}},
+		},
+	}
+	out := b.buildCellsFromStepStart(e)
+	if len(out) != 2 {
+		t.Fatalf("cells = %d, want 2", len(out))
+	}
+	vc, ok := out[1].(*cells.VerbatimCell)
+	if !ok {
+		t.Fatalf("expected *cells.VerbatimCell, got %T", out[1])
+	}
+	want := cells.HorizontalEdges()
+	if vc.Style.Edges != want {
+		t.Errorf("VerbatimCell.Style.Edges = %+v, want %+v", vc.Style.Edges, want)
+	}
+}
+
+// TestBorderStyleNoneZeroesEdges verifies BorderNone drops all
+// edges from the VerbatimCell.
+func TestBorderStyleNoneZeroesEdges(t *testing.T) {
+	b := New().WithBorderStyle(demokit.BorderNone)
+	e := events.StepStart{
+		StepID: "s",
+		Verbatims: []events.Verbatim{
+			{Label: "Body", Variants: []events.Variant{{Content: "x"}}},
+		},
+	}
+	out := b.buildCellsFromStepStart(e)
+	vc := out[1].(*cells.VerbatimCell)
+	want := cells.BorderEdges{}
+	if vc.Style.Edges != want {
+		t.Errorf("BorderNone should zero all edges, got %+v", vc.Style.Edges)
+	}
+}
+
+// TestBorderCharsCustomPlumbedToVerbatim verifies a custom
+// BorderChars value reaches the VerbatimCell's Border field as a
+// matching lipgloss.Border. Acceptance for the chars axis of
+// issue 55 on the notebook side.
+func TestBorderCharsCustomPlumbedToVerbatim(t *testing.T) {
+	custom := demokit.BorderChars{
+		Top: "#", Bottom: "#", Left: "*", Right: "*",
+		TopLeft: "+", TopRight: "+", BottomLeft: "+", BottomRight: "+",
+	}
+	b := New().WithBorderChars(custom)
+	e := events.StepStart{
+		StepID: "s",
+		Verbatims: []events.Verbatim{
+			{Label: "Body", Variants: []events.Variant{{Content: "x"}}},
+		},
+	}
+	out := b.buildCellsFromStepStart(e)
+	vc := out[1].(*cells.VerbatimCell)
+	if vc.Style.Border.Top != "#" || vc.Style.Border.Left != "*" || vc.Style.Border.TopLeft != "+" {
+		t.Errorf("VerbatimCell.Style.Border = %+v, want chars from custom %+v",
+			vc.Style.Border, custom)
+	}
+}
+
+// TestBorderCharsHInfersHorizontalEdges verifies that the H-suffix
+// presets (Left/Right empty) one-call-set the sides to horizontal-
+// only without a companion WithBorderStyle.
+func TestBorderCharsHInfersHorizontalEdges(t *testing.T) {
+	b := New().WithBorderChars(demokit.BorderCharsRoundedH)
+	e := events.StepStart{
+		StepID: "s",
+		Verbatims: []events.Verbatim{
+			{Label: "Body", Variants: []events.Variant{{Content: "x"}}},
+		},
+	}
+	out := b.buildCellsFromStepStart(e)
+	vc := out[1].(*cells.VerbatimCell)
+	if vc.Style.Edges.Left || vc.Style.Edges.Right {
+		t.Errorf("Left/Right edges should be off (inferred from empty chars), got %+v",
+			vc.Style.Edges)
+	}
+	if !vc.Style.Edges.Top || !vc.Style.Edges.Bottom {
+		t.Errorf("Top/Bottom edges should be on, got %+v", vc.Style.Edges)
+	}
+}
+
+// TestBorderStyleDefaultPreservesCellDefaults verifies that with
+// no WithBorderStyle / WithBorderChars call, VerbatimCell uses its
+// all-sides default and OutputCell uses its horizontal-edges
+// default — backwards compatibility for callers who don't opt in.
+func TestBorderStyleDefaultPreservesCellDefaults(t *testing.T) {
+	b := New()
+	e := events.StepStart{
+		StepID: "s",
+		Verbatims: []events.Verbatim{
+			{Label: "Body", Variants: []events.Variant{{Content: "x"}}},
+		},
+	}
+	out := b.buildCellsFromStepStart(e)
+	vc := out[1].(*cells.VerbatimCell)
+	if vc.Style.Edges != cells.AllEdges() {
+		t.Errorf("default VerbatimCell edges should be AllEdges, got %+v", vc.Style.Edges)
+	}
+
+	// OutputCell's default-from-bridge differs: we want horizontal-
+	// edges-only (matching the cell's built-in default).
+	if got, want := b.edgesForOutput(), cells.HorizontalEdges(); got != want {
+		t.Errorf("default OutputCell edges should be HorizontalEdges, got %+v", got)
 	}
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -66,11 +66,13 @@ func DefaultPalette() Palette {
 
 // Renderer renders demo output using Lipgloss styled boxes.
 type Renderer struct {
-	Palette  Palette
-	MaxWidth int           // hard cap on box width; 0 means 120
-	Fraction float64       // fraction of terminal width to use; 0 means 0.80
-	Delay    time.Duration // per-line scroll delay; 0 means 18ms, negative disables
-	prompter FormPrompter
+	Palette     Palette
+	MaxWidth    int                 // hard cap on box width; 0 means 120
+	Fraction    float64             // fraction of terminal width to use; 0 means 0.80
+	Delay       time.Duration       // per-line scroll delay; 0 means 18ms, negative disables
+	borderStyle demokit.BorderStyle // per-side toggles for verbatim + result boxes; see WithBorderStyle
+	borderChars demokit.BorderChars // glyphs for the border; zero value = lipgloss.RoundedBorder(); see WithBorderChars
+	prompter    FormPrompter
 
 	// activeVariant maps a block's index within the current step to
 	// the currently-active variant index within that block. Initial
@@ -138,6 +140,87 @@ func New() *Renderer {
 func (r *Renderer) WithPrompter(p FormPrompter) *Renderer {
 	r.prompter = p
 	return r
+}
+
+// WithBorderStyle configures which sides of the verbatim and result
+// boxes draw border lines. Header, step, section, and done boxes
+// always use their default rounded/double borders — they have no
+// copy-relevant content, so per-side toggling there is noise.
+//
+// BorderDefault preserves today's all-sides rounded look.
+// BorderHorizontalOnly is the copy-paste-friendly choice for
+// walkthroughs whose readers mouse-select snippets out of multi-
+// variant verbatim blocks.
+func (r *Renderer) WithBorderStyle(s demokit.BorderStyle) *Renderer {
+	r.borderStyle = s
+	return r
+}
+
+// WithBorderChars configures which characters the verbatim and
+// result borders use. The zero BorderChars{} value (the default)
+// means "use lipgloss.RoundedBorder()" — today's look. Apply a
+// preset (demokit.BorderCharsDouble, .Thick, .ASCII, .Normal) or
+// supply a struct literal with custom glyphs.
+//
+// Composes with WithBorderStyle: chars say what glyphs to use,
+// style says which sides those glyphs draw on.
+func (r *Renderer) WithBorderChars(bc demokit.BorderChars) *Renderer {
+	r.borderChars = bc
+	return r
+}
+
+// verbatimBorder returns the lipgloss.Border the verbatim/result
+// boxes should draw with. Honors r.borderChars when non-zero;
+// otherwise falls back to lipgloss.RoundedBorder() so today's
+// look is preserved for callers who don't opt in.
+func (r *Renderer) verbatimBorder() lipgloss.Border {
+	if r.borderChars.IsZero() {
+		return lipgloss.RoundedBorder()
+	}
+	return lipgloss.Border{
+		Top:         r.borderChars.Top,
+		Bottom:      r.borderChars.Bottom,
+		Left:        r.borderChars.Left,
+		Right:       r.borderChars.Right,
+		TopLeft:     r.borderChars.TopLeft,
+		TopRight:    r.borderChars.TopRight,
+		BottomLeft:  r.borderChars.BottomLeft,
+		BottomRight: r.borderChars.BottomRight,
+	}
+}
+
+// applyBorderStyle takes a base lipgloss.Style and returns it with
+// per-side toggles applied. Resolution order:
+//
+//  1. An explicit r.borderStyle (Full / HorizontalOnly / None)
+//     wins outright — the chars don't get a say.
+//  2. r.borderStyle == BorderDefault AND r.borderChars is non-zero:
+//     infer sides from the chars. Empty char fields → that side off.
+//     Lets one-call use of `WithBorderChars(BorderCharsRoundedH)`
+//     produce a horizontal-only box without a companion
+//     WithBorderStyle.
+//  3. Neither set: pass through unchanged. The base style's
+//     Border(...) (set by the caller) decides.
+//
+// Called at the verbatim and result draw sites only — header,
+// step, section, done boxes skip this and keep their defaults.
+func (r *Renderer) applyBorderStyle(s lipgloss.Style) lipgloss.Style {
+	switch r.borderStyle {
+	case demokit.BorderFull:
+		return s.BorderTop(true).BorderRight(true).BorderBottom(true).BorderLeft(true)
+	case demokit.BorderHorizontalOnly:
+		return s.BorderTop(true).BorderRight(false).BorderBottom(true).BorderLeft(false)
+	case demokit.BorderNone:
+		return s.BorderTop(false).BorderRight(false).BorderBottom(false).BorderLeft(false)
+	}
+	if r.borderChars.IsZero() {
+		return s
+	}
+	return s.
+		BorderTop(r.borderChars.Top != "").
+		BorderRight(r.borderChars.Right != "").
+		BorderBottom(r.borderChars.Bottom != "").
+		BorderLeft(r.borderChars.Left != "")
 }
 
 // activePrompter returns the configured FormPrompter, lazily creating
@@ -406,11 +489,11 @@ func (r *Renderer) renderBoxedBlock(blockIdx int, v demokit.VerbatimView, multi 
 		fmt.Fprintln(r.stdoutFor(), r.renderTabStrip(v.Variants, r.activeIndex(blockIdx)))
 	}
 	active := v.Variants[r.activeIndex(blockIdx)]
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
+	box := r.applyBorderStyle(lipgloss.NewStyle().
+		Border(r.verbatimBorder()).
 		BorderForeground(p.Note).
 		Padding(0, 1).
-		Width(r.width())
+		Width(r.width()))
 	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
 }
 
@@ -589,11 +672,11 @@ func (r *Renderer) printResultBlock(_ int, output string, result *demokit.StepRe
 		content += "\n" + strings.Join(bodyParts, "\n")
 	}
 
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
+	box := r.applyBorderStyle(lipgloss.NewStyle().
+		Border(r.verbatimBorder()).
 		BorderForeground(borderColor).
 		Padding(0, 1).
-		Width(r.width())
+		Width(r.width()))
 
 	r.smoothPrint(box.Render(content))
 	fmt.Fprintln(r.stdoutFor())
@@ -761,11 +844,11 @@ func (r *Renderer) echoActiveVariant(copyables []copyableBlock) {
 	fmt.Fprintln(r.stdoutFor())
 	fmt.Fprintln(r.stdoutFor(), r.renderTabStrip(target.view.Variants, r.activeIndex(target.index)))
 	active := target.view.Variants[r.activeIndex(target.index)]
-	box := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
+	box := r.applyBorderStyle(lipgloss.NewStyle().
+		Border(r.verbatimBorder()).
 		BorderForeground(r.Palette.Note).
 		Padding(0, 1).
-		Width(r.width())
+		Width(r.width()))
 	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
 }
 

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -145,6 +145,236 @@ func TestRenderStepVerbatimNoBorderInjection(t *testing.T) {
 	}
 }
 
+// TestVerbatimBorderHorizontalOnlyNoSideChars verifies a multi-
+// variant verbatim block under BorderHorizontalOnly produces top +
+// bottom border lines but no `│` chars on inner content rows. This
+// is the load-bearing assertion for the copy-paste use case from
+// mcpkit walkthroughs (issue 55): mouse-select on a content row
+// must not pick up vertical box characters.
+func TestVerbatimBorderHorizontalOnlyNoSideChars(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderHorizontalOnly)
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET https://example.com").Default(),
+		demokit.MakeVariant("python", "python", "requests.get('https://example.com')"),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	// Inner content rows must not contain `│`.
+	for i, row := range strings.Split(out, "\n") {
+		if strings.Contains(row, "curl -X GET") || strings.Contains(row, "requests.get") {
+			if strings.ContainsRune(row, '│') {
+				t.Errorf("row %d contains a side-border char on a content row:\n%q", i, row)
+			}
+		}
+	}
+
+	// And the horizontal border must appear at the top + bottom — the
+	// frame is still visually present, just without side chars.
+	if !strings.ContainsRune(out, '─') {
+		t.Errorf("expected horizontal border char `─` in output, got:\n%s", out)
+	}
+}
+
+// TestVerbatimBorderNoneNoBoxChars verifies BorderNone strips the
+// box entirely from verbatim blocks. The verbatim region starts at
+// the "Fetch" label; from there, no border chars should appear.
+// The step header box (out of scope) retains its rounded chars.
+func TestVerbatimBorderNoneNoBoxChars(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderNone)
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET https://example.com").Default(),
+		demokit.MakeVariant("python", "python", "requests.get('https://example.com')"),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	if !strings.Contains(out, "curl -X GET") {
+		t.Fatalf("expected variant content in output, got:\n%s", out)
+	}
+
+	// Snip off everything before the "Fetch" label so the step
+	// header box (out of scope) doesn't muddy the assertion.
+	verbatimStart := strings.Index(out, "Fetch")
+	if verbatimStart < 0 {
+		t.Fatalf("verbatim label `Fetch` missing from output:\n%s", out)
+	}
+	verbatimRegion := out[verbatimStart:]
+
+	for _, b := range []rune{'│', '─', '╭', '╮', '╰', '╯'} {
+		if strings.ContainsRune(verbatimRegion, b) {
+			t.Errorf("BorderNone should suppress all border chars in the verbatim region, found %q in:\n%s",
+				string(b), verbatimRegion)
+		}
+	}
+}
+
+// TestVerbatimBorderCharsCustom verifies a custom BorderChars value
+// reaches the rendered output of the verbatim block: a struct
+// literal with `#` on top/bottom, `*` on sides, and `+` corners
+// produces those chars on the verbatim frame. Acceptance for the
+// "custom chars via struct literal" path of the issue 55 design.
+// The step header box (out of scope per WithBorderStyle/Chars) is
+// unaffected.
+func TestVerbatimBorderCharsCustom(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderFull).
+		WithBorderChars(demokit.BorderChars{
+			Top: "#", Bottom: "#", Left: "*", Right: "*",
+			TopLeft: "+", TopRight: "+", BottomLeft: "+", BottomRight: "+",
+		})
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET https://example.com").Default(),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	// Find the verbatim content row, then assert its surrounding
+	// frame uses the custom chars.
+	rows := strings.Split(out, "\n")
+	contentRowIdx := -1
+	for i, row := range rows {
+		if strings.Contains(row, "curl -X GET") {
+			contentRowIdx = i
+			break
+		}
+	}
+	if contentRowIdx < 0 {
+		t.Fatalf("verbatim content row not found in output:\n%s", out)
+	}
+	contentRow := rows[contentRowIdx]
+	if !strings.Contains(contentRow, "*") {
+		t.Errorf("content row should have `*` side chars (Left/Right custom), got:\n%q", contentRow)
+	}
+	// Inner content rows must NOT contain rounded side-chars `│`.
+	if strings.ContainsRune(contentRow, '│') {
+		t.Errorf("content row should not have default `│`, custom Left=`*` should win:\n%q", contentRow)
+	}
+	// Top/bottom rows of the verbatim frame use `#` and `+`.
+	if contentRowIdx == 0 || contentRowIdx >= len(rows)-1 {
+		t.Fatalf("content row at edge of output, can't inspect frame; output:\n%s", out)
+	}
+	topRow := rows[contentRowIdx-1]
+	bottomRow := rows[contentRowIdx+1]
+	for _, want := range []string{"#", "+"} {
+		if !strings.Contains(topRow, want) {
+			t.Errorf("top frame row should contain %q, got:\n%q", want, topRow)
+		}
+		if !strings.Contains(bottomRow, want) {
+			t.Errorf("bottom frame row should contain %q, got:\n%q", want, bottomRow)
+		}
+	}
+}
+
+// TestVerbatimBorderCharsRoundedHInfersHorizontalSides verifies the
+// one-call ergonomic shortcut: passing BorderCharsRoundedH (Left/
+// Right empty) without an explicit WithBorderStyle still produces
+// a horizontal-only box. The empty side fields are the signal.
+func TestVerbatimBorderCharsRoundedHInfersHorizontalSides(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderChars(demokit.BorderCharsRoundedH)
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET https://example.com").Default(),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	// Content rows must not have side chars.
+	for i, row := range strings.Split(out, "\n") {
+		if strings.Contains(row, "curl -X GET") {
+			if strings.ContainsRune(row, '│') {
+				t.Errorf("row %d unexpectedly contains side char `│`:\n%q", i, row)
+			}
+		}
+	}
+	// Top/bottom horizontal chars must appear.
+	if !strings.ContainsRune(out, '─') {
+		t.Errorf("expected horizontal char `─` from BorderCharsRoundedH, got:\n%s", out)
+	}
+}
+
+// TestResultBoxBorderHorizontalOnly verifies the result/output box
+// (printResultBlock) also honors BorderHorizontalOnly. Result box
+// contains captured stdout, so mouse-select on output rows must
+// not pick up `│`.
+func TestResultBoxBorderHorizontalOnly(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderHorizontalOnly)
+
+	out := captureStdout(t, func() {
+		r.printResultBlock(1, "some captured output line", nil)
+	})
+
+	for i, row := range strings.Split(out, "\n") {
+		if strings.Contains(row, "some captured output") {
+			if strings.ContainsRune(row, '│') {
+				t.Errorf("result output row %d has side-border char:\n%q", i, row)
+			}
+		}
+	}
+}
+
+// TestVerbatimBorderDefaultUnchanged is the regression guard for
+// callers who never opt in: the existing rounded all-sides border
+// must still be drawn when WithBorderStyle / WithBorderChars are
+// not called.
+func TestVerbatimBorderDefaultUnchanged(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", "curl -X GET https://example.com").Default(),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	// Rounded corners must appear (today's default).
+	for _, want := range []rune{'╭', '╮', '╰', '╯', '│', '─'} {
+		if !strings.ContainsRune(out, want) {
+			t.Errorf("default border should contain rounded char %q, missing in:\n%s",
+				string(want), out)
+		}
+	}
+}
+
 // TestRenderStepVerbatimMultilinePreserved verifies multi-line content
 // is emitted line-by-line with each input line on its own output row.
 func TestRenderStepVerbatimMultilinePreserved(t *testing.T) {


### PR DESCRIPTION
## What changes

Adds two top-level builder methods to `tui.Renderer` and `notebookbridge.Bridge` for configuring verbatim and output box borders:

- `WithBorderStyle(demokit.BorderStyle)` — which sides draw (Default / Full / HorizontalOnly / None)
- `WithBorderChars(demokit.BorderChars)` — which glyphs the borders use (presets + struct literal for custom chars)

Composable: chars say *what* to draw, style says *where*. The two axes are independent — you can mix HorizontalOnly + Double, or Full + ASCII, or HorizontalOnly + custom `#` chars. When BorderStyle is left at Default and BorderChars has empty fields, the empty side fields imply that side is off — so the H-suffix presets (e.g. `BorderCharsRoundedH`) get you a copy-friendly box in one call.

Motivation (per issue 55): walkthroughs whose readers mouse-select from multi-variant verbatim blocks were stuck with all-sides rounded borders that triple-click selection picks up. Now:

```go
tui.New().WithBorderChars(demokit.BorderCharsRoundedH)
notebookbridge.New().WithBorderChars(demokit.BorderCharsRoundedH)
```

gets a horizontal-only rounded frame on both renderers consistently.

Scope is verbatim + output boxes only on both renderers. Header / Step / Section / Done boxes keep their built-in defaults — they hold no copy-relevant content.

## Reviewer's guide

Read in this order:

1. [demokit.go](https://github.com/panyam/demokit/pull/56/files#diff-8d288d869eee51fb928e552417c1f39e03f623e07aaccfe068472e4c8feea6b3) — start here. The two new public types (`BorderStyle` enum, `BorderChars` struct) and ten named preset constants. Doc comments capture the contract for both axes and how they compose.
2. [tui/tui.go](https://github.com/panyam/demokit/pull/56/files#diff-d17b0c5a0bb7c530a6d6b632267185fd62ba569f222c504c039e0b1fc6a259cd) — `Renderer.WithBorderStyle` / `WithBorderChars` builders, `verbatimBorder()` helper that translates `BorderChars` → `lipgloss.Border` (zero value falls back to RoundedBorder), and `applyBorderStyle()` resolution logic (explicit style wins, else infer from non-empty chars, else pass-through). Wired at 3 box-draw sites: `renderBoxedBlock`, `printResultBlock`, `echoActiveVariant`.
3. [tui/tui_test.go](https://github.com/panyam/demokit/pull/56/files#diff-45872ce74f04e9679cdda4486d441cdcd215bac084b6d01d7dff5e738995510e) — 6 new tests: HorizontalOnly, None, custom chars (region-scoped assertion), H-preset side inference, result box, and default-unchanged regression.
4. [notebook/cells/box.go](https://github.com/panyam/demokit/pull/56/files#diff-ebd73871f52fdc52d75ba47821beaa68d9cede8bcf0857d5173596eb63121627) — new `borderFor(style, focused)` helper. When `style` (a `lipgloss.Border`) is the zero value, falls back to the existing `focusedBorder` behavior (rounded ↔ thick on focus). When non-zero, returns it as-is; focus is then signaled via `BorderColor` only.
5. [notebook/cells/verbatim.go](https://github.com/panyam/demokit/pull/56/files#diff-8abeece06e659ca0219ed69ad86c72c8c893132d972c31d1ec6256c3e1685323) + `output.go` — new `Border lipgloss.Border` field on `VerbatimStyle` and `OutputStyle`. Both cells switch their `Border(...)` call from `focusedBorder(focused)` to `borderFor(c.Style.Border, focused)`.
6. [notebookbridge/bridge.go](https://github.com/panyam/demokit/pull/56/files#diff-07836f0687e256dd4502ff3340485c2fb7c2d7c74136e11f09e31416f9607c81) — `Bridge.WithBorderStyle` / `WithBorderChars` builders, `edgesForVerbatim` / `edgesForOutput` (sides) and `lipglossBorder` (chars) helpers. Wired at `cells.NewVerbatim` and `cells.NewOutput` construction sites.
7. [notebookbridge/bridge_test.go](https://github.com/panyam/demokit/pull/56/files#diff-58e393f9c0abc5eea882532258ca64606365f0fe9261fc8ce8e05c33572bd5d3) — 5 new tests mirroring the TUI assertions.

Opportunistic race fix (see Risk section below):
8. `notebook/cells/output.go:101` — `done bool` → `done atomic.Bool`. Race between streaming-goroutine `MarkDone()` and View-goroutine `RenderRows()`.

Skim or skip: nothing generated.

## Decision log

- **Two methods, two structs** instead of a single combined config — sides and chars are independent axes (mcpkit's use case is `HorizontalOnly` + any chars). Combining would force a combinatorial enum.
- **`BorderChars` struct mirrors `lipgloss.Border` field shape** so renderers can translate without per-field bridging. Strings (not runes) for fields because lipgloss uses strings — some box chars are multi-byte combiners; intentional `" "` blanks are distinct from no char.
- **Empty char fields imply that side is off** (in `applyBorderStyle` and `edgesForVerbatim/Output`) so the H-suffix presets work as one-call shortcuts. An explicit `BorderStyle` value still wins — predictable override path.
- **Cell `Border` field, not `Border` + `FocusBorder`** — when chars are overridden, focus is signaled via color (the existing `BorderColor` / `FocusBorderColor`), not by swapping char sets. Author who chose double-line stays double-line on focus; the focus signal is the color flip. Default (zero `Border` field) still flips Rounded↔Thick on focus.
- **Web mode not in scope** — web renders via CSS in the browser player, not lipgloss. Same conceptual axes apply but the mechanism is totally different (`border-style` CSS rules + classes on `.verbatim-block`). Filed as separate follow-up for the web side.

## Risk / blast radius

- **Affects:** `tui.Renderer`, `notebookbridge.Bridge`, `notebook/cells.VerbatimStyle`, `notebook/cells.OutputStyle`. All changes are additive — new builder methods, new struct fields with zero-value-preserves-existing-behavior semantics. No existing caller migrates.
- **Cross-module:** notebook/cells gets two new public fields. After merge, the notebook module needs a tag (e.g., v0.0.26), then demokit bumps its notebook dep before its own tag.
- **Tests covering this:** 6 new TUI tests + 5 new bridge tests. Existing tests (including `TestRenderStepVerbatimNoBorderInjection`, the load-bearing copy-paste invariant test) untouched.
- **Race detector:** clean across every module under `make race`. Includes the opportunistic fix for the pre-existing `OutputCell.done` race that was flaking `mathrepl.TestRunSeries_RateAndCancellation` (confirmed pre-existing by reproducing on clean main).
- **Be paranoid about:** the inference logic in `applyBorderStyle` / `edgesForVerbatim` / `edgesForOutput` — when style is BorderDefault and chars are partially set (only some fields filled), the empty-field-suppresses-side rule kicks in. The tests cover the H-suffix case explicitly; pressure-test if you spot a weird preset combination.

## Out of scope (deliberately deferred)

- Web mode equivalent — needs CSS-level styling on the browser player; different mechanism, different design considerations.
- Per-block override of border config — current API is renderer-wide. The mcpkit use case wants demo-wide configuration, so this should be plenty.
- Other cells (HeaderCell, NoteCell, AdvanceCell) — they have no copy-relevant content, intentionally excluded.

## Related

- Closes issue 55.
