### PR TITLE
feat(notebook): add RevealTop and RevealMiddle to Append/Insert

### DIFF
--- a/notebook/crud.go
+++ b/notebook/crud.go
@@ -22,8 +22,18 @@ const (
 	// streams/grows — the `tail -f` behavior. Use for output a caller
 	// streams into, prompts, and anything the user should track.
 	RevealBottom
-	// Future: RevealTop, RevealMiddle (see issues). Adding values here
-	// is backward-compatible — the enum, not the signature, grows.
+	// RevealTop scrolls the new cell so it sits at the top of the
+	// body viewport. One-shot, not sticky: unlike RevealBottom this
+	// does NOT establish a follow anchor (cursor is untouched), so
+	// the user can scroll freely afterward and a subsequent
+	// streaming append won't pull the viewport away. Suits
+	// navigation-style "show me this cell" jumps.
+	RevealTop
+	// RevealMiddle scrolls the new cell so it sits vertically
+	// centered in the body viewport. Same one-shot semantics as
+	// RevealTop. Cells taller than the body clamp to top
+	// alignment (Middle has no meaningful answer there).
+	RevealMiddle
 )
 
 // Append adds c to the end of the cell list and reveals it per the
@@ -44,10 +54,24 @@ func (nb *Notebook) Insert(index int, c Cell, reveal Reveal) (CellID, error) {
 	if err != nil {
 		return id, err
 	}
-	if reveal == RevealBottom {
+	switch reveal {
+	case RevealBottom:
 		// Make the new cell the cursor; the model's per-frame
 		// ensureCursorVisible then keeps it in view as it grows.
 		nb.store.setCursorByIdx(nb.indexOrEndLocked(id))
+	case RevealTop, RevealMiddle:
+		// Move the cursor to the new cell (so the user navigates
+		// from where they're looking) AND queue a one-shot
+		// alignment that overrides ensureCursorVisible's default
+		// placement — Top puts the cell at the viewport's top
+		// row, Middle centers it. Because the cursor lands on the
+		// aligned cell, subsequent RevealNone appends below
+		// don't pull the viewport: ensureCursorVisible is a
+		// no-op while the cursor cell stays in view, so the
+		// alignment is one-shot in the user-visible sense.
+		newIdx := nb.indexOrEndLocked(id)
+		nb.store.setCursorByIdx(newIdx)
+		nb.store.setPendingAlign(newIdx, reveal)
 	}
 	return id, nil
 }

--- a/notebook/model.go
+++ b/notebook/model.go
@@ -64,12 +64,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.ensureCursorVisible()
+		m.applyPendingAlignment()
 		return m, nil
 	case repaintTickMsg:
 		m.ensureCursorVisible()
+		m.applyPendingAlignment()
 		return m, repaintTick()
 	case snapshotMsg:
 		m.ensureCursorVisible()
+		m.applyPendingAlignment()
 		msg.reply <- m.View()
 		return m, nil
 	case setModeMsg:
@@ -542,5 +545,51 @@ func (m *model) ensureCursorVisible() {
 		if m.viewportOffset > start {
 			m.viewportOffset = start
 		}
+	}
+}
+
+// applyPendingAlignment consumes any queued RevealTop / RevealMiddle
+// from the store and adjusts viewportOffset so the requested cell
+// sits at the top or center of the body. Runs after
+// ensureCursorVisible in the per-frame Update cases — explicit
+// alignment overrides the cursor-tracking nudge for the one frame
+// it fires on.
+//
+// Skips silently when width/height haven't been set yet (e.g.
+// Insert ran before the first WindowSizeMsg); the request stays
+// queued only if we don't consume — but here we DO consume, so
+// a queued align before init is dropped. In practice the model
+// gets WindowSizeMsg as its first message after Run starts, so
+// this only matters in pathological setups.
+func (m *model) applyPendingAlignment() {
+	idx, r, ok := m.nb.store.consumePendingAlign()
+	if !ok {
+		return
+	}
+	if m.width == 0 || m.height == 0 {
+		return
+	}
+	snap := m.nb.store.snapshot()
+	if idx < 0 || idx >= len(snap.cells) {
+		return
+	}
+	body := m.bodyHeight(snap)
+	start, end := m.cellRowSpan(snap, idx)
+	cellH := end - start
+	switch r {
+	case RevealTop:
+		m.viewportOffset = start
+	case RevealMiddle:
+		// Center the cell's span in the body. Cells taller than
+		// the body have no meaningful middle — clamp to top.
+		if cellH >= body {
+			m.viewportOffset = start
+			return
+		}
+		off := start - (body-cellH)/2
+		if off < 0 {
+			off = 0
+		}
+		m.viewportOffset = off
 	}
 }

--- a/notebook/reveal_test.go
+++ b/notebook/reveal_test.go
@@ -53,3 +53,119 @@ func TestAppendRevealBottomScrollsIntoView(t *testing.T) {
 		t.Fatalf("RevealBottom cell should scroll into view:\n%s", nb.Snapshot())
 	}
 }
+
+// TestAppendRevealTopPositionsAtTop verifies a RevealTop append
+// scrolls so the new cell sits at the top of the body viewport.
+// Fill enough cells to push the body well past one screen, then
+// append "target" with RevealTop; assert it lands on the first body
+// row.
+func TestAppendRevealTopPositionsAtTop(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	nb.Append(newTestCell("target", 1), RevealTop)
+
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "target/") {
+		t.Fatalf("RevealTop cell should be visible:\n%s", snap)
+	}
+	// Body-content rows start after the header. Find the first row
+	// that contains a cell-rendered "fN/" or "target/" — that's the
+	// top of the body. RevealTop must put "target/" there, not any
+	// earlier cell.
+	lines := strings.Split(snap, "\n")
+	var firstBody string
+	for _, ln := range lines {
+		if strings.Contains(ln, "/") && !strings.Contains(ln, "·") {
+			firstBody = ln
+			break
+		}
+	}
+	if !strings.Contains(firstBody, "target/") {
+		t.Errorf("RevealTop: first body row should hold target, got %q (full snapshot:\n%s)",
+			firstBody, snap)
+	}
+}
+
+// TestAppendRevealMiddleCenters verifies a RevealMiddle append
+// scrolls so the new cell sits approximately at the vertical
+// center of the body. The exact center row depends on body
+// height; we check the cell's row index is in the central band.
+func TestAppendRevealMiddleCenters(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 12))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	nb.Append(newTestCell("target", 1), RevealMiddle)
+
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "target/") {
+		t.Fatalf("RevealMiddle cell should be visible:\n%s", snap)
+	}
+	lines := strings.Split(snap, "\n")
+	bodyRows := []int{}
+	targetRow := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "/") && !strings.Contains(ln, "·") {
+			bodyRows = append(bodyRows, i)
+			if strings.Contains(ln, "target/") {
+				targetRow = i
+			}
+		}
+	}
+	if len(bodyRows) == 0 {
+		t.Fatalf("no body rows in snapshot:\n%s", snap)
+	}
+	bodyTop, bodyBottom := bodyRows[0], bodyRows[len(bodyRows)-1]
+	mid := (bodyTop + bodyBottom) / 2
+	// Allow a 2-row band around exact mid for body-height parity
+	// and the cell occupying multiple rows.
+	if targetRow < mid-2 || targetRow > mid+2 {
+		t.Errorf("RevealMiddle: target row %d should be near mid %d (bodyTop=%d, bodyBottom=%d)\n%s",
+			targetRow, mid, bodyTop, bodyBottom, snap)
+	}
+}
+
+// TestRevealTopIsOneShotNotTailFollow verifies the user-facing
+// difference between RevealTop and RevealBottom: subsequent
+// RevealNone appends do NOT pull the viewport. RevealBottom would
+// (cursor sits at the streaming cell, ensureCursorVisible drags
+// the viewport down each frame). RevealTop pins the cursor on the
+// aligned cell, so ensureCursorVisible is a no-op while that cell
+// stays in view — the viewport stays put.
+//
+// The load-bearing assertion: the anchor cell remains at the top
+// body row after a later RevealNone append. If the viewport had
+// followed, anchor would scroll off the top.
+func TestRevealTopIsOneShotNotTailFollow(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	nb.Append(newTestCell("anchor", 1), RevealTop)
+	nb.Append(newTestCell("later", 1), RevealNone)
+
+	snap := nb.Snapshot()
+	lines := strings.Split(snap, "\n")
+	var firstBody string
+	for _, ln := range lines {
+		if strings.Contains(ln, "/") && !strings.Contains(ln, "·") {
+			firstBody = ln
+			break
+		}
+	}
+	if !strings.Contains(firstBody, "anchor/") {
+		t.Errorf("RevealTop should pin anchor at the top body row; a later RevealNone append moved viewport. firstBody=%q\nfull snapshot:\n%s",
+			firstBody, snap)
+	}
+}

--- a/notebook/store.go
+++ b/notebook/store.go
@@ -26,6 +26,15 @@ type store struct {
 	headerDesc string
 	done       bool
 	docks      map[positionKey]Cell
+	// pendingAlign carries a one-shot viewport-alignment request
+	// from CRUD callers to the BT goroutine's per-frame layout.
+	// Insert sets it for RevealTop/RevealMiddle (which don't move
+	// the cursor); the model consumes it next frame and computes
+	// the right viewportOffset. Last-write-wins — repeated Inserts
+	// before a frame consumes the prior request just drop it.
+	pendingAlign    Reveal
+	pendingAlignIdx int
+	pendingAlignSet bool
 }
 
 func newStore() *store { return &store{docks: map[positionKey]Cell{}} }
@@ -180,6 +189,32 @@ func (s *store) cursorPos() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.cursor
+}
+
+// setPendingAlign queues a one-shot viewport alignment for the
+// next frame. CRUD callers use it for RevealTop / RevealMiddle —
+// reveals that scroll once and don't establish a follow anchor.
+// Last write wins.
+func (s *store) setPendingAlign(idx int, r Reveal) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingAlignIdx = idx
+	s.pendingAlign = r
+	s.pendingAlignSet = true
+}
+
+// consumePendingAlign returns and clears any queued alignment.
+// The model calls this each frame; if ok is false there's nothing
+// to apply. Idempotent — calling on an empty queue returns false.
+func (s *store) consumePendingAlign() (idx int, r Reveal, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.pendingAlignSet {
+		return 0, 0, false
+	}
+	idx, r = s.pendingAlignIdx, s.pendingAlign
+	s.pendingAlignSet = false
+	return idx, r, true
 }
 
 func (s *store) setHeader(title, desc string) {


### PR DESCRIPTION
## What changes

Adds two new values to the `notebook.Reveal` enum (closes issue 46):

- **`RevealTop`** — appends/inserts the cell, moves the cursor to it, and one-shot-scrolls so the cell sits at the top of the body viewport.
- **`RevealMiddle`** — same but centers the cell. Cells taller than the body clamp to top alignment.

Unlike `RevealBottom` (which keeps the cursor on the inserted cell at the END so subsequent streams pull the viewport down, `tail -f` style), Top/Middle pin the cursor on the aligned cell — `ensureCursorVisible` is a no-op while it stays in view, so a later `RevealNone` append below does NOT scroll the viewport. That's the "jump-and-focus" semantics the issue called for: useful as a primitive for future Home / PgUp / Ctrl+L style keybindings, but also directly usable from any `Append`/`Insert` site.

## Reviewer's guide

Read in this order:

1. [notebook/crud.go](https://github.com/panyam/demokit/pull/60/files#diff-fa4acb71b249b1a5fcf16926a5e89bbbedd0640230da5c84a38d076cefd10219) — start here. Two new enum values + the `switch` in `Insert` that routes Top/Middle to set cursor + queue pending alignment.
2. [notebook/store.go](https://github.com/panyam/demokit/pull/60/files#diff-a75b2600994888b6a8b85c7f4915fe108b488875acbc131cebbb53f3381b74b8) — the new `pendingAlign` slot + `setPendingAlign` / `consumePendingAlign`. Mutex-guarded, last-write-wins single slot.
3. [notebook/model.go](https://github.com/panyam/demokit/pull/60/files#diff-0d92338ba7adb1172045fae5f90be027b051e1302375bb8712fb50d02426fcb8) — `applyPendingAlignment` consumes the queued request and computes `viewportOffset` from `cellRowSpan` + `bodyHeight`. Wired into the three per-frame Update cases (`WindowSizeMsg`, `repaintTickMsg`, `snapshotMsg`) right after `ensureCursorVisible` so the alignment overrides the cursor-tracking default.
4. [notebook/reveal_test.go](https://github.com/panyam/demokit/pull/60/files#diff-bacc37c395f3e4da00cc84bc93820a925cdf53dc14de53465418ac9b20577adb) — three new tests mirroring the existing `RevealBottom` snapshot pattern.

## Decision log

- **Top/Middle move the cursor.** The issue raised this as an open question (initial lean: viewport-only). Viewport-only sounded clean but creates a navigation hazard: the cursor stays on whatever the user was previously focused on (likely off-screen after the scroll), so `j`/`k` continues from a stale position. Moving the cursor to the aligned cell makes the primitive useful for the natural jump-and-focus use case without sacrificing the one-shot scroll property.
- **Single-slot pendingAlign, last-write-wins.** No queue. Repeated `Insert(RevealTop)` calls before a frame consumes the prior request just drop the prior — matches the user intent of "show me the LATEST cell I asked for."
- **`consumePendingAlign` always clears.** If `width`/`height` aren't set yet when consumed (Insert ran before the first `WindowSizeMsg`), the request is dropped silently. In practice the model gets WindowSizeMsg as its first message after Run starts; this only matters in pathological setups.

## Risk / blast radius

- **Affects:** `notebook` module only. No demokit-side change; `notebookbridge` continues to use `RevealBottom` (its current behavior).
- **Cross-module:** notebook needs a tag (`notebook/v0.0.27`) after merge, then a chore PR to bump demokit's `go.mod`, then tag demokit (`v0.0.28`, since v0.0.27 went out for the TUI tabs fix).
- **Tests covering this:** the new tests in `reveal_test.go`; existing `RevealBottom` snapshot tests still pass unchanged. `make race` clean.
- **Be paranoid about:** the `applyPendingAlignment` ordering — it runs AFTER `ensureCursorVisible` so the alignment overrides the cursor-tracking default. If a future Update case adds `ensureCursorVisible` without also calling `applyPendingAlignment`, queued alignments would be silently dropped on that path.

## Out of scope

- **`nb.AlignCell(id, alignment)`** — a programmatic API to re-align an existing cell. The current API only adds alignment via Append/Insert, matching the issue scope. If the keyboard-navigation use case the issue mentions actually wants to re-align without inserting (PgUp/Home/Ctrl+L), file a follow-up.
- **`notebookbridge` plumbing** — the bridge still uses `RevealBottom` for everything. If a step section / verbatim block should be RevealTop instead, that's a bridge-side decision; out of this PR's scope.

## Related

- Closes issue 46.
