### PR TITLE
feat(notebook): add Notebook.AlignCell(id, alignment) primitive

### DIFF
--- a/notebook/crud.go
+++ b/notebook/crud.go
@@ -121,6 +121,43 @@ func (nb *Notebook) IndexOf(id CellID) (int, bool) { return nb.store.indexOf(id)
 // Len returns the current cell count.
 func (nb *Notebook) Len() int { return nb.store.count() }
 
+// AlignCell moves the cursor to the cell with the given ID and
+// adjusts the viewport so the cell sits at the requested
+// position. Returns false (no-op) if no such cell.
+//
+// Honors the same alignment semantics as Append/Insert:
+//
+//   - RevealNone: no-op (returns true if the cell exists).
+//   - RevealTop / RevealMiddle: cursor moves to the cell and a
+//     one-shot viewport alignment fires next frame, placing the
+//     cell at the top of the body or vertically centered. The
+//     cursor pin keeps subsequent RevealNone appends from
+//     pulling the viewport — the "jump-and-focus" semantic
+//     PR 60 introduced.
+//   - RevealBottom: cursor moves to the cell and the model's
+//     per-frame ensureCursorVisible pulls it to the bottom edge.
+//     Subsequent appends keep dragging the viewport down
+//     (`tail -f`).
+//
+// Safe to call from any goroutine. Cell lookup, cursor mutation,
+// and pending-align queue are all guarded by the store mutex.
+// No tea.Msg is sent, so it's safe inside KeyMap action handlers
+// (unlike SetMode / FocusCell).
+func (nb *Notebook) AlignCell(id CellID, alignment Reveal) bool {
+	idx, ok := nb.store.indexOf(id)
+	if !ok {
+		return false
+	}
+	switch alignment {
+	case RevealBottom:
+		nb.store.setCursorByIdx(idx)
+	case RevealTop, RevealMiddle:
+		nb.store.setCursorByIdx(idx)
+		nb.store.setPendingAlign(idx, alignment)
+	}
+	return true
+}
+
 // SetCursor moves the cursor to the cell with the given ID and
 // returns true. Returns false (no-op) if no such cell.
 func (nb *Notebook) SetCursor(id CellID) bool {

--- a/notebook/reveal_test.go
+++ b/notebook/reveal_test.go
@@ -169,3 +169,143 @@ func TestRevealTopIsOneShotNotTailFollow(t *testing.T) {
 			firstBody, snap)
 	}
 }
+
+// TestAlignCellTopMovesExistingCellToTop verifies the
+// post-insertion alignment primitive: an existing cell, far from
+// the cursor, can be brought to the top of the viewport by
+// AlignCell(id, RevealTop). The cursor moves to the aligned cell
+// — same shape as the Insert-time RevealTop path.
+func TestAlignCellTopMovesExistingCellToTop(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	if ok := nb.AlignCell("f25", RevealTop); !ok {
+		t.Fatalf("AlignCell should return true for existing cell")
+	}
+
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "f25/") {
+		t.Fatalf("AlignCell(Top) should bring f25 into view:\n%s", snap)
+	}
+	lines := strings.Split(snap, "\n")
+	var firstBody string
+	for _, ln := range lines {
+		if strings.Contains(ln, "/") && !strings.Contains(ln, "·") {
+			firstBody = ln
+			break
+		}
+	}
+	if !strings.Contains(firstBody, "f25/") {
+		t.Errorf("AlignCell(Top): first body row should hold f25, got %q\nfull snapshot:\n%s",
+			firstBody, snap)
+	}
+}
+
+// TestAlignCellMiddleCenters verifies AlignCell(id, RevealMiddle)
+// places the target cell near the vertical midpoint of the body.
+func TestAlignCellMiddleCenters(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 12))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	if ok := nb.AlignCell("f20", RevealMiddle); !ok {
+		t.Fatalf("AlignCell should return true for existing cell")
+	}
+
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "f20/") {
+		t.Fatalf("AlignCell(Middle) should bring f20 into view:\n%s", snap)
+	}
+	lines := strings.Split(snap, "\n")
+	bodyRows := []int{}
+	targetRow := -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "/") && !strings.Contains(ln, "·") {
+			bodyRows = append(bodyRows, i)
+			if strings.Contains(ln, "f20/") {
+				targetRow = i
+			}
+		}
+	}
+	if len(bodyRows) == 0 {
+		t.Fatalf("no body rows in snapshot:\n%s", snap)
+	}
+	bodyTop, bodyBottom := bodyRows[0], bodyRows[len(bodyRows)-1]
+	mid := (bodyTop + bodyBottom) / 2
+	if targetRow < mid-2 || targetRow > mid+2 {
+		t.Errorf("AlignCell(Middle): target row %d should be near mid %d (bodyTop=%d, bodyBottom=%d)\n%s",
+			targetRow, mid, bodyTop, bodyBottom, snap)
+	}
+}
+
+// TestAlignCellBottomPositionsAtBottom verifies AlignCell with
+// RevealBottom places the target cell at the bottom of the body
+// viewport (matching Insert's RevealBottom semantics).
+func TestAlignCellBottomPositionsAtBottom(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 30; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	if ok := nb.AlignCell("f10", RevealBottom); !ok {
+		t.Fatalf("AlignCell should return true for existing cell")
+	}
+
+	snap := nb.Snapshot()
+	if !strings.Contains(snap, "f10/") {
+		t.Fatalf("AlignCell(Bottom) should bring f10 into view:\n%s", snap)
+	}
+	lines := strings.Split(snap, "\n")
+	var lastBody string
+	for _, ln := range lines {
+		if isBodyRow(ln) {
+			lastBody = ln
+		}
+	}
+	if !strings.Contains(lastBody, "f10/") {
+		t.Errorf("AlignCell(Bottom): last body row should hold f10, got %q\nfull snapshot:\n%s",
+			lastBody, snap)
+	}
+}
+
+// isBodyRow reports whether a snapshot line is a rendered cell
+// row (not header, not status). Tests use it to scan snapshots
+// without picking up the "NAV cell N/M" status footer that also
+// contains a `/`.
+func isBodyRow(ln string) bool {
+	return strings.Contains(ln, "/") &&
+		!strings.Contains(ln, "·") &&
+		!strings.Contains(ln, "NAV") &&
+		!strings.Contains(ln, "INSERT") &&
+		!strings.Contains(ln, "cell ")
+}
+
+// TestAlignCellMissingIDReturnsFalse verifies AlignCell on a
+// non-existent ID is a no-op and reports false. The cursor and
+// viewport must not move.
+func TestAlignCellMissingIDReturnsFalse(t *testing.T) {
+	nb := New(WithHeadless(), WithSize(40, 10))
+	go nb.Run()
+	defer nb.Stop()
+
+	for i := 0; i < 5; i++ {
+		nb.Append(newTestCell(fmt.Sprintf("f%d", i), 1), RevealNone)
+	}
+	cursorBefore := nb.store.cursor
+	if ok := nb.AlignCell("does-not-exist", RevealTop); ok {
+		t.Errorf("AlignCell with unknown ID should return false")
+	}
+	if nb.store.cursor != cursorBefore {
+		t.Errorf("AlignCell with unknown ID should not move cursor (was %d, now %d)",
+			cursorBefore, nb.store.cursor)
+	}
+}


### PR DESCRIPTION
## What changes

Adds `Notebook.AlignCell(id CellID, alignment Reveal) bool` — a programmatic primitive that re-aligns an existing cell in the viewport using the same `Reveal` vocabulary `Append` / `Insert` already speak.

Closes issue 62. The per-frame `applyPendingAlignment` infrastructure landed in PR 60 already supports any cell index, not just freshly-inserted ones — this PR just exposes it as a method.

The natural consumer is keyboard navigation (Home / PgUp / End / Ctrl+L / G-style jumps in `model.handleKey`), but `AlignCell` is general — any caller wanting to draw attention to a specific cell can use it.

## Reviewer's guide

Read in this order:

1. [notebook/crud.go](https://github.com/panyam/demokit/pull/63/files#diff-fa4acb71b249b1a5fcf16926a5e89bbbedd0640230da5c84a38d076cefd10219) — start here. The new `AlignCell` method: switch on `Reveal`, dispatch to `setCursorByIdx` + (for Top/Middle) `setPendingAlign`. Mirrors `Insert`'s switch exactly.
2. [notebook/reveal_test.go](https://github.com/panyam/demokit/pull/63/files#diff-bacc37c395f3e4da00cc84bc93820a925cdf53dc14de53465418ac9b20577adb) — four new tests:
   - `TestAlignCellTopMovesExistingCellToTop` (Top lands at body row 0)
   - `TestAlignCellMiddleCenters` (vertical-band check around midpoint)
   - `TestAlignCellBottomPositionsAtBottom` (last body row holds the target)
   - `TestAlignCellMissingIDReturnsFalse` (no-op on unknown ID, cursor unchanged)
   Plus a small `isBodyRow(ln)` helper that filters out the "NAV cell N/M" status footer from snapshot scans (the previous tests' ad-hoc filter caught the status line for the Bottom case).

## Decision log

- **`RevealNone` is a no-op that returns true** when the cell exists — matches `Insert`'s contract where `RevealNone` is also a valid call that simply doesn't alter the viewport. Symmetry over economy.
- **`RevealBottom` sets cursor only, no pendingAlign** — matches `Insert`. The model's `ensureCursorVisible` then naturally pulls the viewport so the cursor sits at the bottom edge. Adding pendingAlign for Bottom would be redundant.
- **Safe from KeyMap action handlers** unlike `SetMode` / `FocusCell` which `Send` a `tea.Msg` synchronously. `AlignCell` does pure store mutations (cell lookup + cursor + pending-align queue) under the existing store mutex, so a KeyMap handler can call it directly without deadlocking on its own goroutine.
- **No new store fields or message types.** The pendingAlign machinery from PR 60 is the load-bearing infrastructure; this PR's production-side delta is a single dispatch method.

## Risk / blast radius

- **Affects:** notebook module only. No demokit-side change.
- **Cross-module:** notebook needs a tag (`notebook/v0.0.28`) after merge, then a chore PR to bump demokit's `go.mod`, then tag `v0.0.29` on demokit.
- **Tests covering this:** four new tests in `reveal_test.go`. Existing Append/Insert reveal tests untouched. `make race` clean across all 8 modules.

## Out of scope

- **Wiring keybindings** (Home / PgUp / End / Ctrl+L / G) into `model.handleKey` — separate concern. The keymap layer should be reviewed independently. Once `AlignCell` is in, that's a small follow-up PR.

## Related

- PR 60 / issue 46 — RevealTop / RevealMiddle on Append/Insert and the pendingAlign infrastructure this PR builds on.
