### PR TITLE
chore: bump notebook to v0.0.28 across modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/muesli/cancelreader v0.2.2
-	github.com/panyam/demokit/notebook v0.0.27
+	github.com/panyam/demokit/notebook v0.0.28
 	github.com/panyam/gocurrent v0.1.1
 	github.com/panyam/servicekit v0.1.1
 	github.com/panyam/templar v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/panyam/demokit/notebook v0.0.27 h1:PA5uOeRHAxCOltCT4r2oS2EmnSsxlo19zaqszmPOHNo=
-github.com/panyam/demokit/notebook v0.0.27/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
+github.com/panyam/demokit/notebook v0.0.28 h1:gzR6X9c/XlkTqKHkbtTK8K0QobIAYARt+zvFfOrZr1c=
+github.com/panyam/demokit/notebook v0.0.28/go.mod h1:412YG4kCp9K/VqrfAg6cJqaBhcRQOi0Jc81Nc75nf0k=
 github.com/panyam/gocurrent v0.1.1 h1:UFFCkAxYNdGL4RuUCYBneWCS0jIlquIpvgvDcezegaU=
 github.com/panyam/gocurrent v0.1.1/go.mod h1:jIIhcNfNnnIe2JXH8aY2+ba+/5G1fzwCWoZXdcMNw6o=
 github.com/panyam/goutils v0.1.13 h1:V819IdZTEJ3rpu33ZqohC6O9ou7KOu6cxfigoYT12OQ=


### PR DESCRIPTION
## What changes

Picks up `notebook/v0.0.28` (tagged at the PR 63 merge commit) which adds `Notebook.AlignCell`.

After merge, tag `v0.0.29` on demokit.

## Verification

- `go build ./...` clean.
- `go test ./...` clean across all root-module packages.