### PR TITLE
feat(tui): borderless verbatim emits raw content for copy-paste

### DIFF
--- a/demokit.go
+++ b/demokit.go
@@ -185,9 +185,27 @@ func (d *Demo) RegisterServeHandler(h ServeHandler) *Demo {
 //	    WithBorderChars(demokit.BorderCharsDouble)
 
 // BorderStyle controls which sides of a verbatim/output box draw a
-// border line. Walkthroughs that want mouse-select copy of step
-// output use BorderHorizontalOnly so triple-click selection
-// doesn't pick up vertical box characters.
+// border line — AND, on the TUI, what that absence implies for the
+// content inside. Walkthroughs that want mouse-select copy of step
+// output use BorderHorizontalOnly so triple-click selection doesn't
+// pick up vertical box characters, and so long lines (curl payloads,
+// JSON blobs) stay byte-exact for paste.
+//
+// TUI semantics in detail. The presence of a left/right side is the
+// signal for "this content is framed; fit it to the frame":
+//   - With either side drawn (Full, or BorderDefault with side chars),
+//     content is rendered inside a lipgloss box of width r.width()
+//     with 1-char horizontal padding. Lines longer than the inner
+//     width are soft-wrapped by lipgloss.
+//   - With no sides drawn (HorizontalOnly, None, or BorderDefault
+//     with empty side chars), content is emitted RAW — no Width(),
+//     no Padding, flush left. Explicit \n still produces line breaks;
+//     long lines are not re-wrapped. HorizontalOnly still draws top
+//     and bottom rules above and below the raw content; None draws
+//     no rules at all.
+//
+// Callers who want wrapped content under HorizontalOnly/None should
+// pre-wrap the source with explicit \n.
 type BorderStyle int
 
 const (
@@ -196,14 +214,19 @@ const (
 	// defaults to horizontal-only and the VerbatimCell to all four
 	// sides. Zero value so existing callers don't migrate.
 	BorderDefault BorderStyle = iota
-	// BorderFull draws all four sides.
+	// BorderFull draws all four sides. TUI content is fit to the
+	// box width and soft-wrapped if needed.
 	BorderFull
 	// BorderHorizontalOnly draws only the top and bottom edges.
 	// Mouse-select copy on inner content rows then picks up the
-	// content alone — no side chars.
+	// content alone — no side chars. TUI content is emitted raw
+	// (no Width()/Padding) between the rules; pre-wrap with \n if
+	// you want line breaks.
 	BorderHorizontalOnly
 	// BorderNone draws no border. Cell content sits flush with
 	// scrollback; suits walkthroughs that prefer minimal chrome.
+	// TUI content is emitted raw (no Width()/Padding, no rules);
+	// pre-wrap with \n if you want line breaks.
 	BorderNone
 )
 

--- a/examples/verbatims/Makefile
+++ b/examples/verbatims/Makefile
@@ -1,0 +1,31 @@
+.PHONY: demo demo-full demo-horizontal demo-none demo-quiet compare
+
+# Default: TUI with horizontal border — the new copy-paste-friendly mode.
+demo: demo-horizontal
+
+# Side border drawn → content fit to width and soft-wrapped (the old
+# behavior; mouse-select picks up the wrap, copy-paste is broken).
+demo-full:
+	go run . --border full
+
+# Top/bottom rules only → content emitted raw, byte-exact for paste.
+demo-horizontal:
+	go run . --border horizontal
+
+# No rules → raw content flush with scrollback.
+demo-none:
+	go run . --border none
+
+# Non-interactive — skips pause prompts; same horizontal default.
+demo-quiet:
+	go run . --border horizontal --non-interactive
+
+# Run both modes back-to-back so reviewers see the contrast in one
+# scroll. --border full first (the wrap problem), then horizontal
+# (the fix).
+compare:
+	@echo "=== --border full (framed, soft-wrapped) ==="
+	@go run . --border full --non-interactive
+	@echo
+	@echo "=== --border horizontal (raw, byte-exact) ==="
+	@go run . --border horizontal --non-interactive

--- a/examples/verbatims/main.go
+++ b/examples/verbatims/main.go
@@ -1,0 +1,116 @@
+// Verbatims example — a tiny TUI walkthrough that shows the
+// border-implies-wrap contract on verbatim, result, and output
+// blocks.
+//
+// Same demo, three border modes. Flip with --border to see how the
+// TUI renderer handles long content (curl payloads, JSON blobs,
+// captured stdout):
+//
+//	go run ./examples/verbatims/                       # default: horizontal
+//	go run ./examples/verbatims/ --border full         # framed + soft-wrapped
+//	go run ./examples/verbatims/ --border horizontal   # raw between top/bottom rules
+//	go run ./examples/verbatims/ --border none         # raw, no rules, flush left
+//
+// The contrast worth noticing: with --border full, the long curl
+// JSON gets soft-wrapped mid-string and mouse-select picks up the
+// inserted line breaks — copy-paste round-trip is broken. With
+// --border horizontal or --border none, the long line is emitted
+// raw and round-trips cleanly. Pre-wrap with \n if you want
+// explicit line breaks in raw mode.
+//
+// Single-block per-step contrast (one verbatim wrapped, one raw, in
+// the same demo run) is tracked in issue 66.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/tui"
+)
+
+func main() {
+	border := parseBorderFlag(os.Args[1:])
+
+	demo := demokit.New("Verbatim border modes").
+		Description(fmt.Sprintf("Long curl payloads under --border %s — copy-paste check.", borderName(border))).
+		Dir("verbatims").
+		MaxSteps(10).
+		MaxVisits(1).
+		BoxedVerbatim()
+
+	demo.Section("How to read this demo",
+		"Each step has a verbatim block with a long line — curl + JSON, or a piped jq.",
+		"With --border full the line wraps inside the box; mouse-select picks up the wrap.",
+		"With --border horizontal (default) or none, the line stays raw and pastes cleanly.",
+		"Re-run with --border full to compare.",
+	)
+
+	demo.Step("Mint a session").ID("mint").
+		Note("The MCP handshake mints a session id. The curl payload is one long line — exactly the kind that breaks mid-string when soft-wrapped.").
+		Verbatim("Run this",
+			`SID=$(curl -s -X POST http://localhost:8080/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":"i","method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"skills-host","version":"1.0"},"capabilities":{}}}' -D - -o /dev/null | grep -i 'mcp-session-id' | awk '{print $2}' | tr -d '\r\n')`).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			fmt.Println("SID=abc123def456ghi789jkl012mno345pqr678stu901vwx234yz")
+			return nil
+		})
+
+	demo.Step("Probe a stateless server").ID("probe").
+		Note("Two ways to do the same probe. The result box below shows captured stdout — same wrap rules apply there.").
+		VerbatimVariants("server/discover",
+			demokit.MakeVariant("curl", "bash",
+				`curl -s -X POST http://localhost:8080/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":"d","method":"server/discover","params":{}}' | jq '.result'`).Default(),
+			demokit.MakeVariant("httpie", "bash",
+				`http POST http://localhost:8080/mcp Content-Type:application/json Accept:'application/json, text/event-stream' jsonrpc=2.0 id=d method=server/discover params:='{}' | jq '.result'`),
+		).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			fmt.Println(`{"name":"demokit-mcp-host","version":"0.1.0","capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true},"resources":{"subscribe":true,"listChanged":true}},"protocolVersion":"2025-11-25","instructions":"Long stdout lines route through the same border-implies-wrap contract."}`)
+			return demokit.Info("captured stdout flows through the result box — same contract")
+		})
+
+	demo.Step("Recap").ID("recap").
+		Note("Re-run with a different --border to compare. The verbatim blocks above and the result block in step 2 all share the same contract: side border = framed + wrapped, no side border = raw.").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			return nil
+		})
+
+	r := tui.New().WithBorderStyle(border)
+	demo.WithRenderer(r)
+	demo.Execute()
+}
+
+func parseBorderFlag(args []string) demokit.BorderStyle {
+	for i, a := range args {
+		switch {
+		case a == "--border" && i+1 < len(args):
+			return borderFromName(args[i+1])
+		case strings.HasPrefix(a, "--border="):
+			return borderFromName(strings.TrimPrefix(a, "--border="))
+		}
+	}
+	return demokit.BorderHorizontalOnly
+}
+
+func borderFromName(s string) demokit.BorderStyle {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "full":
+		return demokit.BorderFull
+	case "none":
+		return demokit.BorderNone
+	default:
+		return demokit.BorderHorizontalOnly
+	}
+}
+
+func borderName(b demokit.BorderStyle) string {
+	switch b {
+	case demokit.BorderFull:
+		return "full"
+	case demokit.BorderNone:
+		return "none"
+	default:
+		return "horizontal"
+	}
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -223,6 +223,96 @@ func (r *Renderer) applyBorderStyle(s lipgloss.Style) lipgloss.Style {
 		BorderLeft(r.borderChars.Left != "")
 }
 
+// borderSides is the resolved per-side draw decision for a verbatim
+// or result box. Computed once via effectiveSides() so the box vs.
+// raw render branching uses the same logic that applyBorderStyle
+// uses to drive lipgloss.
+type borderSides struct{ top, right, bottom, left bool }
+
+// hasSide reports whether either left or right side is drawn. When
+// false, the box has no visible frame columns and content can be
+// emitted raw (no lipgloss.Width()/Padding()) so long lines stay
+// byte-exact for copy-paste.
+func (s borderSides) hasSide() bool { return s.left || s.right }
+
+// effectiveSides resolves r.borderStyle + r.borderChars into the
+// per-side draw decision, mirroring applyBorderStyle's resolution
+// order. Used by renderBoxOrRaw to decide between the lipgloss box
+// path (any side drawn) and the raw-content-plus-rules path (no
+// sides drawn — copy-paste friendly).
+func (r *Renderer) effectiveSides() borderSides {
+	switch r.borderStyle {
+	case demokit.BorderFull:
+		return borderSides{true, true, true, true}
+	case demokit.BorderHorizontalOnly:
+		return borderSides{top: true, bottom: true}
+	case demokit.BorderNone:
+		return borderSides{}
+	}
+	if r.borderChars.IsZero() {
+		return borderSides{true, true, true, true}
+	}
+	return borderSides{
+		top:    r.borderChars.Top != "",
+		right:  r.borderChars.Right != "",
+		bottom: r.borderChars.Bottom != "",
+		left:   r.borderChars.Left != "",
+	}
+}
+
+// horizontalRule returns a single-line rule string for the raw
+// (no-side) render path, in the requested border color. `side` is
+// "top" or "bottom" and selects the glyph from r.borderChars when
+// set; otherwise falls back to `─` (matching the default rounded
+// border's Top/Bottom char). Width is r.width() so the rule visually
+// aligns with the renderer's other framing.
+func (r *Renderer) horizontalRule(side string, fg color.Color) string {
+	ch := ""
+	if !r.borderChars.IsZero() {
+		switch side {
+		case "top":
+			ch = r.borderChars.Top
+		case "bottom":
+			ch = r.borderChars.Bottom
+		}
+	}
+	if ch == "" {
+		ch = "─"
+	}
+	return lipgloss.NewStyle().Foreground(fg).Render(strings.Repeat(ch, r.width()))
+}
+
+// renderBoxOrRaw is the shared draw path for verbatim and result
+// content. When the active border has any side (left/right) drawn,
+// it renders inside a lipgloss box of width r.width() with the
+// standard Padding(0, 1). When neither side is drawn, content is
+// emitted raw via smoothPrint — no Width(), no Padding — flanked by
+// optional top/bottom horizontal rules. The raw path preserves
+// byte-exact content so long lines (curl payloads, JSON blobs)
+// survive copy-paste; explicit \n in `content` still produces line
+// breaks. fg is the border color (Foreground on the rules,
+// BorderForeground on the lipgloss box).
+func (r *Renderer) renderBoxOrRaw(content string, fg color.Color) {
+	content = strings.TrimRight(content, "\n")
+	sides := r.effectiveSides()
+	if sides.hasSide() {
+		box := r.applyBorderStyle(lipgloss.NewStyle().
+			Border(r.verbatimBorder()).
+			BorderForeground(fg).
+			Padding(0, 1).
+			Width(r.width()))
+		r.smoothPrint(box.Render(content))
+		return
+	}
+	if sides.top {
+		r.smoothPrint(r.horizontalRule("top", fg))
+	}
+	r.smoothPrint(content)
+	if sides.bottom {
+		r.smoothPrint(r.horizontalRule("bottom", fg))
+	}
+}
+
 // activePrompter returns the configured FormPrompter, lazily creating
 // the default ReadlinePrompter on first access.
 func (r *Renderer) activePrompter() FormPrompter {
@@ -489,12 +579,7 @@ func (r *Renderer) renderBoxedBlock(blockIdx int, v demokit.VerbatimView, multi 
 		fmt.Fprintln(r.stdoutFor(), r.renderTabStrip(v.Variants, r.activeIndex(blockIdx)))
 	}
 	active := v.Variants[r.activeIndex(blockIdx)]
-	box := r.applyBorderStyle(lipgloss.NewStyle().
-		Border(r.verbatimBorder()).
-		BorderForeground(p.Note).
-		Padding(0, 1).
-		Width(r.width()))
-	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
+	r.renderBoxOrRaw(active.Content, p.Note)
 }
 
 // renderTabStrip formats the per-variant tabs above a multi-variant
@@ -677,13 +762,7 @@ func (r *Renderer) printResultBlock(_ int, output string, result *demokit.StepRe
 		content += "\n" + strings.Join(bodyParts, "\n")
 	}
 
-	box := r.applyBorderStyle(lipgloss.NewStyle().
-		Border(r.verbatimBorder()).
-		BorderForeground(borderColor).
-		Padding(0, 1).
-		Width(r.width()))
-
-	r.smoothPrint(box.Render(content))
+	r.renderBoxOrRaw(content, borderColor)
 	fmt.Fprintln(r.stdoutFor())
 }
 
@@ -849,12 +928,7 @@ func (r *Renderer) echoActiveVariant(copyables []copyableBlock) {
 	fmt.Fprintln(r.stdoutFor())
 	fmt.Fprintln(r.stdoutFor(), r.renderTabStrip(target.view.Variants, r.activeIndex(target.index)))
 	active := target.view.Variants[r.activeIndex(target.index)]
-	box := r.applyBorderStyle(lipgloss.NewStyle().
-		Border(r.verbatimBorder()).
-		BorderForeground(r.Palette.Note).
-		Padding(0, 1).
-		Width(r.width()))
-	r.smoothPrint(box.Render(strings.TrimRight(active.Content, "\n")))
+	r.renderBoxOrRaw(active.Content, r.Palette.Note)
 }
 
 func plainCountdownBar(remaining, total time.Duration, width int) string {

--- a/tui/tui_test.go
+++ b/tui/tui_test.go
@@ -225,6 +225,75 @@ func TestVerbatimBorderNoneNoBoxChars(t *testing.T) {
 	}
 }
 
+// TestVerbatimBorderHorizontalOnlyDoesNotWrap verifies the raw-content
+// contract introduced for HorizontalOnly: a single content line wider
+// than r.width() survives intact (no lipgloss soft-wrap inserting \n
+// mid-string). Load-bearing for the copy-paste use case where a curl
+// command's JSON payload must round-trip through mouse-select.
+func TestVerbatimBorderHorizontalOnlyDoesNotWrap(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderHorizontalOnly)
+
+	longLine := `curl -X POST http://localhost:8080/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25"}}'`
+	if len(longLine) <= r.width() {
+		t.Fatalf("test fixture sanity: longLine (%d chars) should exceed r.width() (%d) to exercise wrap behavior", len(longLine), r.width())
+	}
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", longLine).Default(),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	if !strings.Contains(out, longLine) {
+		t.Errorf("expected long line preserved intact in HorizontalOnly mode (no soft-wrap), got:\n%s", out)
+	}
+}
+
+// TestVerbatimBorderNoneNoLeftIndent verifies the raw-content path
+// under BorderNone emits content flush left — the lipgloss
+// .Padding(0, 1) that previously added a leading space is gone.
+// Load-bearing for "the absence of a side border means no chrome at
+// all" (issue 55 follow-up).
+func TestVerbatimBorderNoneNoLeftIndent(t *testing.T) {
+	r := newTestRenderer()
+	r.MaxWidth = 80
+	r.Fraction = 1.0
+	r.Delay = -1
+	r.WithBorderStyle(demokit.BorderNone)
+
+	const marker = "curl -X GET https://example.com"
+
+	demo := demokit.New("v").BoxedVerbatim()
+	step := demo.Step("Repro").VerbatimVariants("Fetch",
+		demokit.MakeVariant("curl", "bash", marker).Default(),
+	)
+
+	out := captureStdout(t, func() {
+		r.printStepBlock(1, 1, stepStartFromDef(1, 1, step), true)
+	})
+
+	var contentRow string
+	for _, row := range strings.Split(out, "\n") {
+		if strings.Contains(row, marker) {
+			contentRow = row
+			break
+		}
+	}
+	if contentRow == "" {
+		t.Fatalf("content row %q missing from output:\n%s", marker, out)
+	}
+	if strings.HasPrefix(contentRow, " ") {
+		t.Errorf("BorderNone content row should be flush left, got leading space:\n%q", contentRow)
+	}
+}
+
 // TestVerbatimBorderCharsCustom verifies a custom BorderChars value
 // reaches the rendered output of the verbatim block: a struct
 // literal with `#` on top/bottom, `*` on sides, and `+` corners


### PR DESCRIPTION
## What changes

When the resolved TUI `BorderStyle` has no left/right side (`BorderHorizontalOnly`, `BorderNone`, or `BorderDefault` with empty side chars), verbatim / result / output content is now emitted **raw** — no lipgloss `Width()` / `Padding()`. Long lines (curl payloads, JSON blobs, captured stdout) stay byte-exact so mouse-select and triple-click round-trip cleanly. `BorderFull` (and the unconfigured default) keep the existing framed-and-wrapped behavior.

The contract is now: **presence of a side ⇒ box-and-wrap; absence ⇒ raw content**. Pre-wrap with explicit `\n` if you want line breaks under `HorizontalOnly` / `None`.

`HorizontalOnly` still draws top + bottom horizontal rules around the raw content; `None` draws no rules at all.

## Reviewer's guide

Read in this order:

1. `tui/tui.go` — `effectiveSides()` resolves `r.borderStyle` + `r.borderChars` into per-side draw decisions (mirrors `applyBorderStyle`'s logic). `horizontalRule()` builds a colored `─` rule at `r.width()` (honors `borderChars.Top` / `Bottom` if set). `renderBoxOrRaw()` is the new shared draw path: when any side is drawn it goes through the existing lipgloss-box path; when no side is drawn it emits the content raw via `smoothPrint` flanked by optional top/bottom rules.
2. `tui/tui.go` — the three call sites that switched to `renderBoxOrRaw`: `renderBoxedBlock` (verbatim), `printResultBlock` (result), `echoActiveVariant` (copy-mode echo). All three previously built a lipgloss `Border(...).Padding(0, 1).Width(r.width())` style inline.
3. `demokit.go` — godoc on `BorderStyle` rewritten to document the new contract explicitly. The presence/absence of a side now carries the wrap implication.
4. `tui/tui_test.go` — two new tests: `TestVerbatimBorderHorizontalOnlyDoesNotWrap` (long curl line survives intact under `HorizontalOnly`) and `TestVerbatimBorderNoneNoLeftIndent` (no leading space from the dropped `Padding`). Existing border tests (`NoSideChars`, `NoBoxChars`, `RoundedHInfersHorizontalSides`, `ResultBoxBorderHorizontalOnly`, `DefaultUnchanged`) all still pass — they assert on the visible chars, which the new path produces by different means.
5. `examples/verbatims/main.go` — new demo. Three steps with long content (curl + JSON, multi-variant curl/httpie, long `Run()` stdout). A `--border` flag flips between `full` / `horizontal` / `none` so the contrast is reproducible across runs. See `--border full` vs `--border horizontal` to see the wrap-vs-raw difference on the same source.

## Decision log

- **Border presence carries the wrap implication, not a separate `NoWrap` axis.** Users who pick `HorizontalOnly` / `None` already mean "I want to copy this"; adding a separate `NoWrap` flag would duplicate the signal. Pre-wrap with `\n` if you want explicit breaks in raw mode.
- **Result and output boxes share the same contract as verbatim.** Same global knob, same intent. The three sites route through one helper (`renderBoxOrRaw`).
- **`applyBorderStyle` kept as the source of truth for the lipgloss-box path.** `effectiveSides` mirrors its resolution order (style > chars > default) so the two paths stay aligned.
- **Rule width = `r.width()`, not terminal width.** Matches the rest of the renderer's framing envelope. Content can run wider than the rules; the terminal soft-wraps that visually but the buffer stays byte-exact.

## Out of scope

- **Per-block override** so a single step can mix wrapped narrative with raw curl. Tracked as issue 66.
- **PlainRenderer's 8-space prefix on every verbatim line.** Separate renderer with no border concept; not affecting the TUI copy-paste pain point.

## Verification

- `make testall` clean across all modules (demokit, notebook, mathrepl).
- Smoke-ran `examples/verbatims/` with `--border full` vs `--border horizontal` to confirm the contrast on a real long curl payload.