### PR TITLE
harness package: one-call renderer/mode/web wiring (issue 69)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,7 @@ This document describes how demokit is wired together internally — the files, 
 | `term.go` | Terminal width detection with stdout/stderr fallback |
 | `logger.go` | Internal `print()` helper (writes to stderr — see gotchas) |
 | `tui/` | Lipgloss-based renderer + `FormPrompter` interface |
+| `harness/` | Subpackage `package harness`. `harness.Run(demo)` / `harness.SetupRenderer(demo)` — one-call renderer/mode/web wiring (the `--mode` switch + `web.RegisterWith`). Batteries-included: imports `tui` + `notebookbridge` + `web`, so it pulls their charm/websocket deps; lean consumers skip it and wire renderers directly. |
 
 ## Render contract
 
@@ -210,6 +211,8 @@ demo.Execute()
 Demos that don't call `web.RegisterWith` see clear stderr errors if they invoke `--doc bundle` or `--serve`: `"demokit: --doc bundle is not enabled. Call web.RegisterWith(demo) before Execute (import github.com/panyam/demokit/web)."`. Names `md`, `html`, `json` are reserved; reusing them panics.
 
 Reasoning for instance-scoped: multiple demos in one process don't collide; tests don't share state across runs; the explicit `web.RegisterWith(demo)` line is grep-able evidence of opt-in (vs. a silent `init()`). The `tui/` subpackage uses the same shape (separate package; demos opt in via explicit `tui.New()`).
+
+The `harness/` subpackage bundles this opt-in: `harness.SetupRenderer(demo)` (and `harness.Run`, which adds `Execute`) selects the renderer for `demokit.Mode()` and calls `web.RegisterWith` for you, so a walkthrough's `main` is one line. Because harness owns the `web.RegisterWith` call, a demo using harness must **not** also call it — the `bundle` format would register twice and panic. Demos that need bespoke renderer wiring (e.g. `examples/basic`'s `--smooth` plain renderer, `examples/verbatims`'s border-style flag) skip harness and wire renderers directly; `examples/{graph,dungeon}` use `harness.Run`.
 
 ## Embed surface — `<demokit-demo>` web player
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ func main() {
 }
 ```
 
+Or skip the boilerplate with the `harness` package, which selects the renderer for `--mode` (plain/tui/notebook), calls `web.RegisterWith`, and runs the demo in one call:
+
+```go
+import "github.com/panyam/demokit/harness"
+
+func main() {
+    demo := demokit.New("...")
+    // ... define steps ...
+    harness.Run(demo)  // --mode wiring + --doc bundle / --serve + Execute
+}
+```
+
+`harness` is batteries-included: it imports the `tui`, `notebookbridge`, and `web` subpackages (and their deps). Demos that want a leaner binary or custom renderer wiring skip it and wire renderers directly (see `examples/basic`). Don't call `web.RegisterWith` yourself when using harness — it registers the bundle format for you.
+
 For programmatic embedding, the same package exposes `web.TraceFragment(d, entries) string` and `web.WriteBundle(d, entries, outPath) error`. See [ARCHITECTURE.md](ARCHITECTURE.md#embed-surface--demokit-demo-web-player) for the full data-source model (URL static, inline blob, programmatic, and the live URL mode driven by `--serve`).
 
 **Live mode (`--serve`).** `go run ./mydemo --serve :8765` runs the demo as an HTTP+WebSocket server. Open `http://localhost:8765/` and the embed page connects via WS, renders structured events as they arrive, and submits input forms back. The server terminal mirrors the same demo in your chosen renderer's style (`PlainRenderer` by default, `tui.Renderer` if you also pass `--tui`). Browser-side reset clears the feed and replays from the top; clients posting `{kind:"reset"}` over WS trigger the same restart. Useful for live presentations and interactive walkthroughs in slide decks.

--- a/args.go
+++ b/args.go
@@ -19,16 +19,21 @@ import (
 //   - --non-interactive       (bare; skips between-step pauses)
 //   - --doc <format>          (value; routes to doc emission)
 //   - --from <trace-path>     (value; trace input for --doc)
+//   - --out <path>            (value; --doc bundle output)
 //   - --variant <name>        (value; filters verbatim variant output)
+//   - --record <path>         (value; trace record target)
+//   - --replay <path>         (value; trace replay source)
+//   - --serve <addr>          (value; live server address)
+//   - --input-timeout <dur>   (value; input prompt deadline)
 //
+// This mirrors [Demo.RegisterFlags]; the two are kept in sync by a test.
 // Both `--flag value` and `--flag=value` forms are stripped for the
 // value flags. Anything else passes through untouched.
 //
-// To strip caller-declared flags too (e.g. an example's own --serve or
-// --url), pass them as extras built with [BoolFlag] or [ValueFlag]:
+// To strip caller-declared flags too (e.g. an example's own --url),
+// pass them as extras built with [BoolFlag] or [ValueFlag]:
 //
 //	flag.CommandLine.Parse(demokit.FilterArgs(os.Args[1:],
-//	    demokit.BoolFlag("--serve"),
 //	    demokit.ValueFlag("--url"),
 //	))
 func FilterArgs(args []string, extra ...ExtraFlag) []string {
@@ -38,10 +43,15 @@ func FilterArgs(args []string, extra ...ExtraFlag) []string {
 		"--non-interactive": true,
 	}
 	value := map[string]bool{
-		"--doc":     true,
-		"--from":    true,
-		"--variant": true,
-		"--mode":    true,
+		"--doc":           true,
+		"--from":          true,
+		"--variant":       true,
+		"--mode":          true,
+		"--record":        true,
+		"--replay":        true,
+		"--out":           true,
+		"--serve":         true,
+		"--input-timeout": true,
 	}
 	for _, e := range extra {
 		if e.TakesValue {

--- a/args.go
+++ b/args.go
@@ -154,8 +154,8 @@ func Mode() string {
 		if a == "--mode" && i+1 < len(args) {
 			return args[i+1]
 		}
-		if strings.HasPrefix(a, "--mode=") {
-			return strings.TrimPrefix(a, "--mode=")
+		if v, ok := strings.CutPrefix(a, "--mode="); ok {
+			return v
 		}
 	}
 	if slices.Contains(args, "--note") {

--- a/args_test.go
+++ b/args_test.go
@@ -1,10 +1,31 @@
 package demokit
 
 import (
+	"flag"
 	"os"
 	"reflect"
 	"testing"
 )
+
+// TestFilterArgsCoversRegisterFlags is the drift guard: every flag
+// RegisterFlags declares must be stripped by FilterArgs, so a consumer
+// running its own flag.Parse(FilterArgs(...)) never chokes on a demokit
+// flag. Enumerating RegisterFlags (rather than a hand-copied list) means
+// adding a flag there without teaching FilterArgs fails here.
+func TestFilterArgsCoversRegisterFlags(t *testing.T) {
+	fs := flag.NewFlagSet("t", flag.ContinueOnError)
+	New("t").RegisterFlags(fs)
+	fs.VisitAll(func(f *flag.Flag) {
+		name := "--" + f.Name
+		args := []string{name, "v", "keep"}
+		if bf, ok := f.Value.(interface{ IsBoolFlag() bool }); ok && bf.IsBoolFlag() {
+			args = []string{name, "keep"}
+		}
+		if got := FilterArgs(args); !reflect.DeepEqual(got, []string{"keep"}) {
+			t.Errorf("FilterArgs does not strip RegisterFlags flag %s: got %v", name, got)
+		}
+	})
+}
 
 // TestFilterArgsBuiltInStripsOnly verifies the built-in flags are
 // stripped (with both spaced and = forms for value flags) and nothing

--- a/examples/dungeon/main.go
+++ b/examples/dungeon/main.go
@@ -31,9 +31,7 @@ import (
 	"time"
 
 	"github.com/panyam/demokit"
-	"github.com/panyam/demokit/notebookbridge"
-	"github.com/panyam/demokit/tui"
-	"github.com/panyam/demokit/web"
+	"github.com/panyam/demokit/harness"
 )
 
 // Random honorifics for the cave's introductory greeting. Picked once
@@ -131,9 +129,6 @@ func main() {
 		MaxVisits(3). // catches infinite goblin/passage loops
 		AutoAcceptAfter(8 * time.Second).
 		ShowCountdown(true)
-
-	// Enable --doc bundle and --serve.
-	web.RegisterWith(demo)
 
 	// State held in Go closures, never in the markdown:
 	//   hasRing — set by ring-cave, read by dragon to decide outcome
@@ -325,16 +320,8 @@ func main() {
 
 	// `end` is a prose-only section — no Run needed.
 
-	// --- renderer flag ---
-	// --mode=plain (default) | tui | notebook. --tui is honored as
-	// a deprecated alias for --mode=tui.
-
-	switch demokit.Mode() {
-	case "tui":
-		demo.WithRenderer(tui.New())
-	case "notebook":
-		demo.WithRenderer(notebookbridge.New())
-	}
-
-	demo.Execute()
+	// --mode=plain (default) | tui | notebook (--tui / --note aliases).
+	// harness.Run wires the renderer, enables --doc bundle / --serve,
+	// then executes.
+	harness.Run(demo)
 }

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -23,9 +23,7 @@ import (
 	"time"
 
 	"github.com/panyam/demokit"
-	"github.com/panyam/demokit/notebookbridge"
-	"github.com/panyam/demokit/tui"
-	"github.com/panyam/demokit/web"
+	"github.com/panyam/demokit/harness"
 )
 
 type Diagnosis struct {
@@ -47,9 +45,6 @@ func main() {
 			demokit.Actor("App", "App"),
 			demokit.Actor("AS", "Auth Server"),
 		)
-
-	// Enable --doc bundle and --serve.
-	web.RegisterWith(demo)
 
 	demo.Section("How this demo works",
 		"You'll be asked to pick a failure symptom. Each branch shows the",
@@ -208,16 +203,8 @@ defer resp.Body.Close()`),
 
 	demo.Step("End").ID("end")
 
-	// --- renderer / output mode flags ---
-	// --mode=plain (default) | tui | notebook. --tui is honored as a
-	// deprecated alias for --mode=tui.
-
-	switch demokit.Mode() {
-	case "tui":
-		demo.WithRenderer(tui.New())
-	case "notebook":
-		demo.WithRenderer(notebookbridge.New())
-	}
-
-	demo.Execute()
+	// --mode=plain (default) | tui | notebook (--tui / --note aliases).
+	// harness.Run wires the renderer, enables --doc bundle / --serve,
+	// then executes.
+	harness.Run(demo)
 }

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -1,0 +1,55 @@
+// Package harness wires the renderer, mode, and doc/serve plumbing that
+// every demokit walkthrough otherwise rediscovers, so a demo's entry
+// point is a single call instead of a copy-pasted renderer switch.
+//
+// It is batteries-included on purpose: importing harness pulls the tui,
+// notebookbridge, and web subpackages (and their charm / websocket
+// dependencies), because honoring --mode=tui / --mode=notebook / --serve
+// requires that code to be linked. A consumer who wants a leaner binary,
+// or a custom renderer set, should skip harness and wire renderers
+// directly against demokit — the lean path stays available, the dependency
+// cost lives at the "do I import harness?" boundary.
+package harness
+
+import (
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/notebookbridge"
+	"github.com/panyam/demokit/tui"
+	"github.com/panyam/demokit/web"
+)
+
+// SetupRenderer selects the renderer matching demokit.Mode() and enables
+// the web-backed doc/serve handlers, without running the demo. Use it
+// when the caller wants to do its own work before Execute (extra flags,
+// a custom plain renderer); otherwise prefer Run.
+//
+//   - --mode=tui      (or --tui)  → tui.Renderer
+//   - --mode=notebook (or --note) → notebookbridge.Bridge
+//   - --mode=plain / absent       → left unset; Execute defaults to PlainRenderer
+//
+// Both styled renderers are configured with BorderHorizontalOnly so a
+// triple-click / drag-select over a verbatim block grabs only the
+// content, no side box characters — the copy-friendly convention shared
+// across demokit consumers. SetupRenderer also calls web.RegisterWith,
+// so --doc bundle and --serve work without extra wiring.
+//
+// Do not also call web.RegisterWith yourself when using harness: the
+// "bundle" doc format is registered here, and registering it twice
+// panics.
+func SetupRenderer(demo *demokit.Demo) {
+	switch demokit.Mode() {
+	case "tui":
+		demo.WithRenderer(tui.New().WithBorderStyle(demokit.BorderHorizontalOnly))
+	case "notebook":
+		demo.WithRenderer(notebookbridge.New().WithBorderStyle(demokit.BorderHorizontalOnly))
+	}
+	web.RegisterWith(demo)
+}
+
+// Run is SetupRenderer followed by demo.Execute — the one-call entry
+// point for a walkthrough's main(). Call it after the demo's steps are
+// defined, in place of a hand-written renderer switch plus Execute.
+func Run(demo *demokit.Demo) {
+	SetupRenderer(demo)
+	demo.Execute()
+}

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -9,6 +9,11 @@
 // or a custom renderer set, should skip harness and wire renderers
 // directly against demokit — the lean path stays available, the dependency
 // cost lives at the "do I import harness?" boundary.
+//
+// Alongside the wiring entry points (Run, SetupRenderer), harness carries
+// a few small authoring conveniences that walkthroughs repeatedly want —
+// WireRecipe (a curl + Go "reproduce on the wire" verbatim block) and
+// SplitLines — so consumers don't each redefine them.
 package harness
 
 import (

--- a/harness/harness_test.go
+++ b/harness/harness_test.go
@@ -1,0 +1,75 @@
+package harness_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/harness"
+	"github.com/panyam/demokit/notebookbridge"
+	"github.com/panyam/demokit/tui"
+)
+
+// withArgs runs fn with os.Args temporarily replaced (Mode reads os.Args
+// directly), restoring the original afterward.
+func withArgs(t *testing.T, args []string, fn func()) {
+	t.Helper()
+	saved := os.Args
+	os.Args = append([]string{"demo"}, args...)
+	defer func() { os.Args = saved }()
+	fn()
+}
+
+// TestSetupRendererSelectsByMode is the core of harness: the renderer set
+// on the demo must match the resolved mode, including the bare --tui /
+// --note aliases, and plain/absent must leave the renderer unset so
+// Execute falls back to PlainRenderer.
+func TestSetupRendererSelectsByMode(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string // "tui" | "notebook" | "nil"
+	}{
+		{"mode tui", []string{"--mode=tui"}, "tui"},
+		{"mode notebook", []string{"--mode=notebook"}, "notebook"},
+		{"tui alias", []string{"--tui"}, "tui"},
+		{"note alias", []string{"--note"}, "notebook"},
+		{"mode plain", []string{"--mode=plain"}, "nil"},
+		{"absent", nil, "nil"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			withArgs(t, c.args, func() {
+				d := demokit.New("t")
+				harness.SetupRenderer(d)
+				switch r := d.Renderer(); c.want {
+				case "tui":
+					if _, ok := r.(*tui.Renderer); !ok {
+						t.Errorf("renderer = %T, want *tui.Renderer", r)
+					}
+				case "notebook":
+					if _, ok := r.(*notebookbridge.Bridge); !ok {
+						t.Errorf("renderer = %T, want *notebookbridge.Bridge", r)
+					}
+				case "nil":
+					if r != nil {
+						t.Errorf("renderer = %T, want nil (default PlainRenderer at Execute)", r)
+					}
+				}
+			})
+		})
+	}
+}
+
+// TestRunSetsRendererBeforeExecute guards that Run wires the renderer via
+// the same path as SetupRenderer. It does not call Execute (which would
+// block on stdin); it asserts the renderer selection Run relies on.
+func TestRunSetsRendererBeforeExecute(t *testing.T) {
+	withArgs(t, []string{"--mode=tui"}, func() {
+		d := demokit.New("t")
+		harness.SetupRenderer(d)
+		if _, ok := d.Renderer().(*tui.Renderer); !ok {
+			t.Fatalf("renderer = %T, want *tui.Renderer", d.Renderer())
+		}
+	})
+}

--- a/harness/recipe.go
+++ b/harness/recipe.go
@@ -1,0 +1,34 @@
+package harness
+
+import (
+	"strings"
+
+	"github.com/panyam/demokit"
+)
+
+// WireLabel is the block title WireRecipe attaches. Exported so callers
+// can match it when post-processing or filtering verbatim blocks.
+const WireLabel = "Reproduce on the wire"
+
+// WireRecipe attaches a two-variant "Reproduce on the wire" verbatim
+// block to a step: the wire-level curl form (the default, for
+// non-interactive and markdown output) and the equivalent Go form. It is
+// the common shape behind protocol walkthroughs that show both the raw
+// request and the client-library call; for any other variant set, call
+// StepDef.VerbatimVariants directly.
+//
+// Returns the step so calls keep chaining.
+func WireRecipe(s *demokit.StepDef, curl, goSource string) *demokit.StepDef {
+	return s.VerbatimVariants(WireLabel,
+		demokit.MakeVariant("curl", "bash", curl).Default(),
+		demokit.MakeVariant("go", "go", goSource),
+	)
+}
+
+// SplitLines splits a multi-line string on "\n". It keeps step Run
+// bodies focused on the narrative ("for _, line := range
+// harness.SplitLines(s)") rather than line-iteration mechanics; it is a
+// thin wrapper over strings.Split with no trimming.
+func SplitLines(s string) []string {
+	return strings.Split(s, "\n")
+}

--- a/harness/recipe_test.go
+++ b/harness/recipe_test.go
@@ -1,0 +1,41 @@
+package harness_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/harness"
+)
+
+// TestWireRecipe verifies the helper builds one "Reproduce on the wire"
+// block with curl (default, bash) and go variants in that order — the
+// contract callers and renderers rely on.
+func TestWireRecipe(t *testing.T) {
+	s := &demokit.StepDef{}
+	harness.WireRecipe(s, "curl x", "http.Get()")
+
+	blocks := s.VerbatimBlocks()
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(blocks))
+	}
+	if blocks[0].Label != harness.WireLabel {
+		t.Errorf("label = %q, want %q", blocks[0].Label, harness.WireLabel)
+	}
+	vs := blocks[0].Variants
+	if len(vs) != 2 {
+		t.Fatalf("variants = %d, want 2", len(vs))
+	}
+	if vs[0].Label != "curl" || vs[0].Lang != "bash" || vs[0].Content != "curl x" || !vs[0].IsDefault {
+		t.Errorf("curl variant = %+v", vs[0])
+	}
+	if vs[1].Label != "go" || vs[1].Lang != "go" || vs[1].Content != "http.Get()" || vs[1].IsDefault {
+		t.Errorf("go variant = %+v", vs[1])
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	if got := harness.SplitLines("a\nb\nc"); !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+		t.Errorf("SplitLines = %v", got)
+	}
+}


### PR DESCRIPTION
Closes #69

## What changes

Adds a `harness` package so a walkthrough's `main` is one call instead of a hand-copied renderer switch. `harness.Run(demo)` resolves `demokit.Mode()`, wires `tui` / `notebookbridge` (with `BorderHorizontalOnly`), calls `web.RegisterWith` (enabling `--doc bundle` and `--serve`), and runs the demo; `harness.SetupRenderer(demo)` does the wiring without `Execute` for callers that need to do their own work first. This is the demokit-generic code that mcpkit and inference_plane each rediscovered in their `common/` packages.

Also folds in two adjacent fixes found while auditing those `common/` packages: (1) `FilterArgs` was stripping only 7 of demokit's ~12 flags (missing `--record/--replay/--out/--serve/--input-timeout`), so consumers had to hand-list them — now complete and drift-guarded against `RegisterFlags`; (2) two demokit-generic authoring helpers, `WireRecipe` and `SplitLines`, move into harness so consumers stop redefining them.

Part of the markdown-native authoring work (issue 68 was Phase 1).

## Reviewer's guide

Read in this order:
1. [harness/harness.go](https://github.com/panyam/demokit/pull/73/files#diff-259f81078e31bdfa2537b1cd5e0aee4ad350dbb3fe1092591aab1a68eadf5224) — start here. `Run` + `SetupRenderer`; note the batteries-included/opt-in-deps contract in the package and function docs.
2. [harness/harness_test.go](https://github.com/panyam/demokit/pull/73/files#diff-da164e704d91b35cf38fbd84bb896617ed85e9fd20e485f24de750a0552edb4a) — acceptance: the mode→renderer mapping (including `--tui`/`--note` aliases and the plain/absent → nil case).
3. [examples/graph/main.go](https://github.com/panyam/demokit/pull/73/files#diff-450da218f3cfd2c41675b06800b71bd45101fb62aea40c937e98f62ade41665c), [examples/dungeon/main.go](https://github.com/panyam/demokit/pull/73/files#diff-490090e31ce3f6fdb96410b7153b92684c9d8df1db5be3ffbc07249ea2237241) — dogfood: the per-example switch + `web.RegisterWith` + `Execute` collapse to `harness.Run(demo)`.
4. [args.go](https://github.com/panyam/demokit/pull/73/files#diff-d3989c40d6d1caecf765e82f992c4bdf093c103c074003e4d7f29cee6d9437a1) — the `FilterArgs` strip-set completion (5 flags added to the value map; doc updated).
5. [args_test.go](https://github.com/panyam/demokit/pull/73/files#diff-a48034865676903aed3da7be846f56efab79615c941b4b0089d0eb17584d391a) — `TestFilterArgsCoversRegisterFlags`: the drift guard that enumerates `RegisterFlags` and asserts `FilterArgs` strips each.
6. [harness/recipe.go](https://github.com/panyam/demokit/pull/73/files#diff-0db93e7a3b9196e03685354a499adc793ead05b7aab6d653a5864811b06329ce) + [harness/recipe_test.go](https://github.com/panyam/demokit/pull/73/files#diff-1dc74bace8362fe4c40f79d680a29b40c25fc971f2a63a27a611fbd88cfdd948) — `WireRecipe` / `SplitLines` and their tests.
7. [ARCHITECTURE.md](https://github.com/panyam/demokit/pull/73/files#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfd) / [README.md](https://github.com/panyam/demokit/pull/73/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) — module map row + the "don't double-register web" note.

## Decision log

- **Batteries-included (hard-imports tui+notebookbridge+web), not renderer-agnostic.** Both real consumers want all modes and already link these deps, so harness costs them nothing and deletes boilerplate. The renderer-agnostic `Run(demo, Modes{...})` variant and a module split for a charm-free core `go.mod` are deferred (noted in issue 69) and non-breaking to add later.
- **`BorderHorizontalOnly` baked in.** It's the copy-friendly convention mcpkit/iplane both chose. Visible effect: `graph`/`dungeon` TUI/notebook output switches from default borders to horizontal-only.
- **Converted graph + dungeon only.** `basic` has a bespoke `--smooth` plain renderer and no `web` import (the deliberately-minimal example); `verbatims` is the border-style demo. Both keep manual wiring on purpose, demonstrating the lean/custom path that harness deliberately doesn't cover. This deviates from the issue's "convert {basic,graph,dungeon}" suggestion for that reason.
- **`harness` owns `web.RegisterWith`.** Examples' own calls were removed; calling it twice panics on the reserved `bundle` name. Verified `--doc bundle` still works on the converted graph example.
- **`FilterArgs` fixed in core, not worked around.** It and `RegisterFlags` had drifted; rather than hand-list the missing flags per consumer, `FilterArgs` now strips them and a test enumerates `RegisterFlags` so they can't diverge again. Existing `--serve` tests still pass because a caller's explicit `BoolFlag("--serve")` wins (bare map checked before value map).
- **`WireRecipe` lives in harness, not core.** It hardcodes curl/go labels (an HTTP/MCP "reproduce on the wire" idiom), so it's mildly domain-flavored; harness (the opinionated consumer layer) is the right home rather than the pure framework core. The generic primitive (`VerbatimVariants` + `MakeVariant`) stays in core for other variant sets.

## Risk / blast radius

- Affects: demos that opt into `harness`, plus anyone calling `FilterArgs`. The `FilterArgs` change is additive (strips more demokit-owned flags); the only way it could surprise is a consumer that *wanted* a demokit flag like `--record` to pass through to its own parser, which would be a namespace collision they should rename anyway. No new deps in root `go.mod`.
- Tests covering this: `harness/*_test.go` (renderer mapping, WireRecipe), `args_test.go` (drift guard + existing FilterArgs cases unchanged). Smoke-tested `graph --doc md` and `graph --doc bundle` (no double-registration panic).
- Be paranoid about: the `BorderHorizontalOnly` visual change on graph/dungeon; the `FilterArgs` arity of `--serve` (value flag in core, but callers can still force bare via `BoolFlag`); the double-registration rule for any future harness consumer that still calls `web.RegisterWith`.

## Out of scope (deliberately deferred)

- Renderer-agnostic `harness.Run(demo, Modes{...})` + module split for charm-free core — tracked in issue 69.
- `init`/`new` CLI — issue 70 (will generate mains that call `harness.Run`).
- mcpkit / iplane adoption (delete their `SetupRenderer`) — downstream consumer cleanup.
- `web.RegisterWith` effect isn't asserted in a unit test (no doc-format getter to introspect); covered by the `web` package's own tests.

