### PR TITLE
demokit CLI: init + new scaffolding and extract migration tool (issues 70, 71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Compiled binaries
 /basic
 /graph
+/demokit
+cmd/demokit/demokit
 examples/basic/basic
 examples/graph/graph
 examples/dungeon/dungeon

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,6 +16,7 @@ This document describes how demokit is wired together internally — the files, 
 | `render.go` | `RenderContext{Demo, Trace, State}` + `EntryOpts{StepNumber}` — the contract every doc renderer consumes |
 | `render_trace.go` | `RenderEntryMD/HTML`, `RenderDocumentMD/HTML` |
 | `render_json.go` | `RenderDocumentJSON`, `JSONFromTrace`, `Demo.JSON()` + projection view structs |
+| `render_sidecar.go` | `Demo.Sidecar()` — emits the definition as sidecar markdown (inverse of `FromMarkdown`); backs `--doc sidecar` |
 | `markdown_load.go` | `Demo.FromMarkdown(path)` + `Demo.FromMarkdownBytes` + `Demo.Bind(id)` — sidecar markdown loader |
 | `web/` | Subpackage `package web`. Go-side embed surface (`TraceFragment`, `WriteBundle`, `PlayerJS`, `PlayerCSS`); registers `--doc bundle` with core via `init()`. Imported via `_ "github.com/panyam/demokit/web"` to enable bundle output. |
 | `web/player/` | Vanilla-JS Custom Element (`<demokit-demo>`) + scoped CSS, embedded into the `web` package binary via `//go:embed`. |
@@ -132,11 +133,16 @@ http.Get("https://api.example/...")
 |---|---|
 | `demokit init [dir]` | writes a base `walkthrough.mk` and one sample example (`--kind`, default `live`) so `make demo` runs immediately |
 | `demokit new <name> --kind=narrated\|live\|branching` | renders one example dir from an embedded starter (`templates/<kind>/*.tmpl`, substituting the titleized name) plus a per-example `Makefile` that `include`s `walkthrough.mk` |
-| `demokit extract <file.go> [--out dir]` | converts a Go walkthrough to sidecar form: `demo.md` (content) + `bindings.go` (behavior skeleton) |
+| `demokit extract <file.go> [--out file]` | rewires a Go walkthrough's **behavior** into a `bindings.go` skeleton (`Step(...).Run` → `Bind(id).Run`) |
 
 **Starters are a per-example gradient, not project modes:** `narrated` (sidecar only) ⊂ `live` (sidecar + `Bind`) ⊂ `branching` (Go routing/state). A project mixes them freely; `--kind` is a one-time generator choice, and the scaffold is dep-light (generated `main.go` imports only `demokit` + `harness`). The genuinely-common renderer wiring lives in `harness`, not in generated project code.
 
-**`extract` is a `go/ast` transform**, deliberately a first cut. It handles the linear builder pattern — `demokit.New(...)`/`Description`/`Actors` → frontmatter; `Step`/`Section` chains with `ID`/`Note`/`Arrow`/`DashedArrow`/`Verbatim*`/`Shell` → markdown; `Run`/`Coalesce`/`Parse`/`Timeout`/`Cancellable` carried verbatim into the `Bind` skeleton by source-slicing. It **guarantees unique `{#id}`s** (explicit `ID`, else slugified title, else `-2`/`-3` dedup). What it can't statically resolve — non-literal content, `Input(...)` declarations, project-specific content helpers like a `WireRecipe` wrapper — becomes a `TODO(extract)` marker with a stderr warning, never a silent drop. The emitted `demo.md` is verified by loading it back through demokit's own loader in tests.
+**Migration is two steps, split by what each source can give:**
+
+1. **Content → `--doc sidecar`** (a renderer, `render_sidecar.go`, `Demo.Sidecar()`). `go run ./mydemo --doc sidecar > demo.md` walks the live `Demo` and emits the inverse of `FromMarkdown`: frontmatter, `## title {#id}`, blockquote notes, `mermaid`/`inputs`/`refs` blocks, verbatim. Because it reads the resolved `Demo` model (never running steps), it handles everything — inputs, computed content — without mirroring the builder API. Round-trip tested (`FromMarkdown` → `Sidecar` → reload).
+2. **Behavior → `demokit extract`** (`go/ast`). Only the closures can't come from the model — a `func` value has no source — so this is the one piece that must read source. It slices each step's `Run`/`Coalesce`/`Parse`/`Timeout`/`Cancellable` args verbatim into `Bind(id).Run(...)`, and warns when a behavior-bearing step lacks an explicit `.ID()` (the join key demo.md and the binding must share).
+
+This split is deliberate: the brittle "know every content construct" logic lives once, in the `Sidecar` renderer over the `Demo` model, instead of being duplicated in an AST walker that drifts as the builder API changes. `extract`'s AST surface is just `Step`/`ID` + the behavior calls.
 
 ## Long-running steps: timeout + cancellation
 
@@ -194,6 +200,7 @@ Load warnings (unsupported mermaid syntax, content before the first heading) pri
 | `--doc html` | yes | `RenderDocumentHTML(ctx)` |
 | `--doc json` | no | `RenderDocumentJSON(ctx)` (definition only) |
 | `--doc json` | yes | `RenderDocumentJSON(ctx)` (definition + trace) |
+| `--doc sidecar` | ignored | `Demo.Sidecar()` — definition as sidecar markdown (inverse of `FromMarkdown`); ignores `--from` |
 | `--doc bundle [--out path]` | either | `web.WriteBundle(d, entries, path)` — self-contained HTML with player + CSS + trace inlined. Requires `_ "github.com/panyam/demokit/web"` import (registers via `RegisterDocFormat`). |
 
 Static-md and trace-md route to **different renderers** because they walk fundamentally different sources (declarations vs. recorded entries) and produce intentionally different shapes. The static visitor includes a "What you'll learn" notes summary, a consolidated mermaid sequence diagram, and a Run-it footer; the trace renderer produces a per-step walkthrough with captured outputs and inputs.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,6 +124,20 @@ http.Get("https://api.example/...")
 | `examples/graph/` | inline | branching state machine, `Coalesce`, `AutoAcceptAfter` countdown |
 | `examples/dungeon/` | sidecar | `FromMarkdownBytes` + `go:embed`, `Bind`, multiple cycles, `MaxVisits` guard, `int` input, Go-side state (the magic ring), cancellable streaming step (`listen`), live ANSI dragon scene |
 
+## CLI: scaffolding and extraction (`cmd/demokit`)
+
+`cmd/demokit` is a `package main` tool (stdlib only — `flag`, `go/parser`, `text/template`, `embed`) installed via `go install github.com/panyam/demokit/cmd/demokit@latest`. Three subcommands:
+
+| Command | Does |
+|---|---|
+| `demokit init [dir]` | writes a base `walkthrough.mk` and one sample example (`--kind`, default `live`) so `make demo` runs immediately |
+| `demokit new <name> --kind=narrated\|live\|branching` | renders one example dir from an embedded starter (`templates/<kind>/*.tmpl`, substituting the titleized name) plus a per-example `Makefile` that `include`s `walkthrough.mk` |
+| `demokit extract <file.go> [--out dir]` | converts a Go walkthrough to sidecar form: `demo.md` (content) + `bindings.go` (behavior skeleton) |
+
+**Starters are a per-example gradient, not project modes:** `narrated` (sidecar only) ⊂ `live` (sidecar + `Bind`) ⊂ `branching` (Go routing/state). A project mixes them freely; `--kind` is a one-time generator choice, and the scaffold is dep-light (generated `main.go` imports only `demokit` + `harness`). The genuinely-common renderer wiring lives in `harness`, not in generated project code.
+
+**`extract` is a `go/ast` transform**, deliberately a first cut. It handles the linear builder pattern — `demokit.New(...)`/`Description`/`Actors` → frontmatter; `Step`/`Section` chains with `ID`/`Note`/`Arrow`/`DashedArrow`/`Verbatim*`/`Shell` → markdown; `Run`/`Coalesce`/`Parse`/`Timeout`/`Cancellable` carried verbatim into the `Bind` skeleton by source-slicing. It **guarantees unique `{#id}`s** (explicit `ID`, else slugified title, else `-2`/`-3` dedup). What it can't statically resolve — non-literal content, `Input(...)` declarations, project-specific content helpers like a `WireRecipe` wrapper — becomes a `TODO(extract)` marker with a stderr warning, never a silent drop. The emitted `demo.md` is verified by loading it back through demokit's own loader in tests.
+
 ## Long-running steps: timeout + cancellation
 
 Steps that consume infinite or near-infinite streams (event listeners, polling loops, "wait for press-Enter") need a way to end. `StepDef.Timeout(d)` and `StepDef.Cancellable(b)` are two orthogonal knobs:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,14 @@ demokit new login --kind=live   # add an example from a starter
 
 `--kind` picks a starter on a gradient: **narrated** (sidecar markdown only, no Go), **live** (markdown content + Go behavior bound by step id), **branching** (Go-driven routing and state). They mix freely within a project — pick per example. Generated code imports only `demokit` and `harness`.
 
-Already have a Go-defined walkthrough and want to move its content into markdown? `demokit extract mydemo.go --out .` emits a `demo.md` (content) and a `bindings.go` skeleton (your `Run` closures, keyed by step id), assigning unique heading ids and flagging anything it can't statically convert with `TODO(extract)`.
+Already have a Go-defined walkthrough and want to move its content into markdown? It's two steps, split by what each source can give:
+
+```bash
+go run ./mydemo --doc sidecar > demo.md   # content, straight from the demo
+demokit extract mydemo.go --out bindings.go   # behavior: Run closures, keyed by step id
+```
+
+`--doc sidecar` is the inverse of `FromMarkdown`: it walks the live demo and emits frontmatter, notes, arrows, inputs, and verbatim blocks (it handles everything the demo declares, because it reads the built model, not the source). `extract` only does the part that can't come from the model — it can't reconstruct a `Run` closure from a function value, so it slices those from the source into a `Bind(id)` skeleton, warning when a bound step needs an explicit `.ID()`.
 
 ## A note on the API surface
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ go get github.com/panyam/demokit
 
 Go 1.22+. The TUI renderer also pulls in `charm.land/lipgloss/v2`.
 
+## Scaffolding a project (`demokit` CLI)
+
+```bash
+go install github.com/panyam/demokit/cmd/demokit@latest
+
+demokit init myproject          # base Makefile + a runnable sample example
+demokit new login --kind=live   # add an example from a starter
+```
+
+`--kind` picks a starter on a gradient: **narrated** (sidecar markdown only, no Go), **live** (markdown content + Go behavior bound by step id), **branching** (Go-driven routing and state). They mix freely within a project — pick per example. Generated code imports only `demokit` and `harness`.
+
+Already have a Go-defined walkthrough and want to move its content into markdown? `demokit extract mydemo.go --out .` emits a `demo.md` (content) and a `bindings.go` skeleton (your `Run` closures, keyed by step id), assigning unique heading ids and flagging anything it can't statically convert with `TODO(extract)`.
+
 ## A note on the API surface
 
 The builder pattern is deliberately verbose: `Step("name").ID("foo").Input(…).Coalesce(…).Run(…)`. There is no implicit magic — IDs default to `step-N` if you skip them, but anything you'll route to should have an explicit `ID`.

--- a/cmd/demokit/extract.go
+++ b/cmd/demokit/extract.go
@@ -7,19 +7,20 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
 
-// runExtract converts a Go walkthrough into sidecar form: a demo.md for the
-// content and a bindings.go skeleton for the behavior. Without --out it
-// prints both to stdout for inspection.
+// runExtract converts a Go walkthrough's behavior into a bindings.go skeleton:
+// each step's Run/Coalesce/… closures, rewired from Step(...).Run to
+// Bind(id).Run. Content (notes, arrows, verbatim, inputs) is NOT parsed here —
+// generate demo.md from the demo itself with `--doc sidecar`, which walks the
+// live Demo and so handles everything this static pass cannot.
 func runExtract(args []string) error {
 	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
-	outDir := fs.String("out", "", "directory to write demo.md and bindings.go (default: stdout)")
-	// Accept the file before or after flags: stdlib flag stops at the first
-	// positional, so pull a leading non-flag arg out before parsing.
+	out := fs.String("out", "", "file to write the bindings skeleton (default: stdout)")
+	// Accept the file before or after flags (stdlib flag stops at the first
+	// positional).
 	file := ""
 	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 		file, args = args[0], args[1:]
@@ -31,41 +32,34 @@ func runExtract(args []string) error {
 		file = fs.Arg(0)
 	}
 	if file == "" {
-		return fmt.Errorf("usage: demokit extract <file.go> [--out dir]")
+		return fmt.Errorf("usage: demokit extract <file.go> [--out file]")
 	}
 	src, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
-	res, err := extractFile(src)
+	res, err := extractBindings(src)
 	if err != nil {
 		return err
 	}
 	for _, w := range res.Warnings {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
-	if *outDir == "" {
-		fmt.Printf("===== demo.md =====\n%s\n===== bindings.go =====\n%s\n", res.DemoMD, res.BindingsGo)
+	fmt.Fprintln(os.Stderr, "note: generate the matching demo.md with:  go run <demo-dir> --doc sidecar > demo.md")
+	if *out == "" {
+		fmt.Print(res.BindingsGo)
 		return nil
 	}
-	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+	if err := os.WriteFile(*out, []byte(res.BindingsGo), 0o644); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(*outDir, "demo.md"), []byte(res.DemoMD), 0o644); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(*outDir, "bindings.go"), []byte(res.BindingsGo), 0o644); err != nil {
-		return err
-	}
-	fmt.Printf("wrote %s/demo.md and %s/bindings.go\n", *outDir, *outDir)
+	fmt.Printf("wrote %s\n", *out)
 	return nil
 }
 
-// extractResult is the output of extractFile: the rendered sidecar markdown,
-// a Go bindings skeleton, and any warnings about content that could not be
-// statically extracted (left as TODO markers rather than dropped).
+// extractResult is the output of extractBindings: the bindings skeleton plus
+// warnings (e.g. a behavior-bearing step missing an explicit id).
 type extractResult struct {
-	DemoMD     string
 	BindingsGo string
 	Warnings   []string
 }
@@ -75,75 +69,49 @@ type chainCall struct {
 	args []ast.Expr
 }
 
-type exVariant struct {
-	label, lang, content string
-	isDefault            bool
-}
-
-type exVerbatim struct {
-	title    string
-	variants []exVariant
-}
-
-type exItem struct {
-	section  bool
+type exStep struct {
 	id       string
 	title    string
-	note     string
-	body     string
-	mermaid  []string
-	verbatim []exVerbatim
-	behavior []string // rendered ".Run(...)" etc, for the Bind skeleton
+	behavior []string // rendered ".Run(...)" / ".Coalesce(...)" etc.
 }
 
-// extractFile parses a demokit walkthrough and returns the sidecar markdown
-// plus a bindings.go skeleton. It handles the linear builder pattern
-// (demokit.New(...) plus demo.Step(...)/demo.Section(...) chains with literal
-// content); non-literal content and unrecognized helpers become TODO markers
-// with a warning rather than silent drops.
-func extractFile(src []byte) (*extractResult, error) {
+// extractBindings parses a walkthrough and returns a bindings.go skeleton that
+// binds each step's behavior by id. Only the behavior calls and the step's
+// id/title are read; everything else is left to `--doc sidecar`.
+func extractBindings(src []byte) (*extractResult, error) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "input.go", src, 0)
+	f, err := parser.ParseFile(fset, "input.go", src, 0)
 	if err != nil {
 		return nil, err
 	}
-
-	demoVar, newCalls, body := findDemo(file)
+	demoVar, title, body := findDemo(f)
 	if demoVar == "" {
 		return nil, fmt.Errorf("no demokit.New(...) assignment found")
 	}
 
 	res := &extractResult{}
-	title, desc, actors := frontmatter(newCalls, &res.Warnings)
-
-	used := map[string]int{}
-	var items []exItem
+	var steps []exStep
 	for _, stmt := range body.List {
 		expr := stmtExpr(stmt)
 		if expr == nil {
 			continue
 		}
 		root, calls, ok := flattenChain(expr)
-		if !ok || root != demoVar || len(calls) == 0 {
+		if !ok || root != demoVar || len(calls) == 0 || calls[0].sel != "Step" {
 			continue
 		}
-		switch calls[0].sel {
-		case "Step":
-			items = append(items, parseStep(calls, src, fset, used, &res.Warnings))
-		case "Section":
-			items = append(items, parseSection(calls, used, &res.Warnings))
+		if st := parseStepBehavior(calls, src, fset, &res.Warnings); len(st.behavior) > 0 {
+			steps = append(steps, st)
 		}
 	}
-
-	res.DemoMD = renderMarkdown(title, desc, actors, items)
-	res.BindingsGo = renderBindings(title, items)
+	res.BindingsGo = renderBindings(title, steps)
 	return res, nil
 }
 
-// findDemo locates the `demoVar := demokit.New(...)...` assignment and the
-// function body that contains it, returning the demo variable name, the New
-// chain's calls, and the enclosing block.
-func findDemo(file *ast.File) (demoVar string, newCalls []chainCall, body *ast.BlockStmt) {
+// findDemo locates the `demoVar := demokit.New("title")...` assignment and the
+// enclosing function body, returning the demo variable, the literal title (if
+// any), and the block to scan for step chains.
+func findDemo(file *ast.File) (demoVar, title string, body *ast.BlockStmt) {
 	for _, decl := range file.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
 		if !ok || fd.Body == nil {
@@ -158,12 +126,18 @@ func findDemo(file *ast.File) (demoVar string, newCalls []chainCall, body *ast.B
 			if !ok || calls[0].sel != "New" {
 				continue
 			}
-			if id, ok := as.Lhs[0].(*ast.Ident); ok {
-				return id.Name, calls, fd.Body
+			id, ok := as.Lhs[0].(*ast.Ident)
+			if !ok {
+				continue
 			}
+			t := ""
+			if len(calls[0].args) == 1 {
+				t, _ = stringLit(calls[0].args[0])
+			}
+			return id.Name, t, fd.Body
 		}
 	}
-	return "", nil, nil
+	return "", "", nil
 }
 
 // flattenChain unwinds a method-call chain (a.B(...).C(...)) into its root
@@ -204,135 +178,32 @@ func stmtExpr(s ast.Stmt) ast.Expr {
 	return nil
 }
 
-func frontmatter(calls []chainCall, warnings *[]string) (title, desc string, actors [][2]string) {
-	for _, c := range calls {
-		switch c.sel {
-		case "New":
-			title = litArg(c, 0, "title", warnings)
-		case "Description":
-			desc = litArg(c, 0, "description", warnings)
-		case "Actors":
-			for _, a := range c.args {
-				if id, label, ok := parseActor(a); ok {
-					actors = append(actors, [2]string{id, label})
-				}
-			}
-		}
-	}
-	return
-}
-
-func parseActor(e ast.Expr) (id, label string, ok bool) {
-	ce, isCall := e.(*ast.CallExpr)
-	if !isCall {
-		return
-	}
-	se, isSel := ce.Fun.(*ast.SelectorExpr)
-	if !isSel || se.Sel.Name != "Actor" || len(ce.Args) < 2 {
-		return
-	}
-	id, ok1 := stringLit(ce.Args[0])
-	label, ok2 := stringLit(ce.Args[1])
-	return id, label, ok1 && ok2
-}
-
-func parseStep(calls []chainCall, src []byte, fset *token.FileSet, used map[string]int, warnings *[]string) exItem {
-	it := exItem{}
-	var explicitID string
+func parseStepBehavior(calls []chainCall, src []byte, fset *token.FileSet, warnings *[]string) exStep {
+	var st exStep
 	for _, c := range calls {
 		switch c.sel {
 		case "Step":
-			it.title = litArg(c, 0, "step title", warnings)
-		case "ID":
-			explicitID = litArg(c, 0, "id", warnings)
-		case "Note":
-			var lines []string
-			for i := range c.args {
-				lines = append(lines, litArg(c, i, "note", warnings))
+			if len(c.args) > 0 {
+				st.title, _ = stringLit(c.args[0])
 			}
-			it.note = appendNote(it.note, strings.Join(lines, "\n"))
-		case "Arrow":
-			it.mermaid = append(it.mermaid, fmt.Sprintf("%s ->> %s: %s",
-				litArg(c, 0, "arrow", warnings), litArg(c, 1, "arrow", warnings), litArg(c, 2, "arrow", warnings)))
-		case "DashedArrow":
-			it.mermaid = append(it.mermaid, fmt.Sprintf("%s -->> %s: %s",
-				litArg(c, 0, "arrow", warnings), litArg(c, 1, "arrow", warnings), litArg(c, 2, "arrow", warnings)))
-		case "VerbatimVariants":
-			it.verbatim = append(it.verbatim, parseVerbatimVariants(c, warnings))
-		case "VerbatimLang":
-			it.verbatim = append(it.verbatim, exVerbatim{title: litArg(c, 0, "verbatim", warnings),
-				variants: []exVariant{{lang: litArg(c, 1, "verbatim", warnings), content: litArg(c, 2, "verbatim", warnings)}}})
-		case "Verbatim":
-			it.verbatim = append(it.verbatim, exVerbatim{title: litArg(c, 0, "verbatim", warnings),
-				variants: []exVariant{{content: litArg(c, 1, "verbatim", warnings)}}})
-		case "Shell":
-			it.verbatim = append(it.verbatim, exVerbatim{variants: []exVariant{{lang: "bash", content: litArg(c, 0, "shell", warnings)}}})
+		case "ID":
+			if len(c.args) > 0 {
+				st.id, _ = stringLit(c.args[0])
+			}
 		case "Run", "Coalesce", "Parse", "Timeout", "Cancellable", "InputTimeout":
-			it.behavior = append(it.behavior, renderCall(c, src, fset))
-		case "Input":
-			*warnings = append(*warnings, fmt.Sprintf("step %q: Input(...) not extracted; declare it in a demo.md inputs block", it.title))
-			it.note = appendNote(it.note, "TODO(extract): declare this step's inputs in an `inputs` block")
+			st.behavior = append(st.behavior, renderCall(c, src, fset))
 		}
 	}
-	it.id = uniqueID(explicitID, it.title, used)
-	return it
-}
-
-func parseSection(calls []chainCall, used map[string]int, warnings *[]string) exItem {
-	it := exItem{section: true}
-	c := calls[0]
-	it.title = litArg(c, 0, "section title", warnings)
-	var lines []string
-	for i := 1; i < len(c.args); i++ {
-		lines = append(lines, litArg(c, i, "section body", warnings))
+	if len(st.behavior) > 0 && st.id == "" {
+		*warnings = append(*warnings, fmt.Sprintf("step %q has behavior but no .ID(); add an explicit id so demo.md and the binding agree", st.title))
+		st.id = "TODO-set-id-" + slugify(st.title)
 	}
-	it.body = strings.Join(lines, "\n")
-	it.id = uniqueID("", it.title, used)
-	return it
-}
-
-func parseVerbatimVariants(c chainCall, warnings *[]string) exVerbatim {
-	v := exVerbatim{}
-	if len(c.args) > 0 {
-		v.title, _ = stringLit(c.args[0])
-	}
-	for _, a := range c.args[1:] {
-		if va, ok := parseVariant(a); ok {
-			v.variants = append(v.variants, va)
-			continue
-		}
-		*warnings = append(*warnings, fmt.Sprintf("verbatim %q: a variant is not a literal MakeVariant(...) — emitted TODO", v.title))
-		v.variants = append(v.variants, exVariant{content: "TODO(extract): variant not statically extractable"})
-	}
-	return v
-}
-
-func parseVariant(e ast.Expr) (exVariant, bool) {
-	var v exVariant
-	if ce, isCall := e.(*ast.CallExpr); isCall {
-		if se, isSel := ce.Fun.(*ast.SelectorExpr); isSel && se.Sel.Name == "Default" {
-			v.isDefault = true
-			e = se.X
-		}
-	}
-	ce, isCall := e.(*ast.CallExpr)
-	if !isCall {
-		return v, false
-	}
-	se, isSel := ce.Fun.(*ast.SelectorExpr)
-	if !isSel || se.Sel.Name != "MakeVariant" || len(ce.Args) < 3 {
-		return v, false
-	}
-	label, ok1 := stringLit(ce.Args[0])
-	lang, ok2 := stringLit(ce.Args[1])
-	content, ok3 := stringLit(ce.Args[2])
-	v.label, v.lang, v.content = label, lang, content
-	return v, ok1 && ok2 && ok3
+	return st
 }
 
 // renderCall reconstructs a behavior call (".Run(...)", ".Coalesce(...)") by
-// slicing the original source for its arguments, so closures are carried over
-// verbatim into the bindings skeleton.
+// slicing the original source for its arguments, so closures (and their
+// comments and formatting) carry over verbatim.
 func renderCall(c chainCall, src []byte, fset *token.FileSet) string {
 	if len(c.args) == 0 {
 		return "." + c.sel + "()"
@@ -354,44 +225,32 @@ func stringLit(e ast.Expr) (string, bool) {
 	return s, true
 }
 
-// litArg returns the i-th argument as a string literal, or "TODO(extract)…"
-// plus a warning when it is missing or not a literal.
-func litArg(c chainCall, i int, what string, warnings *[]string) string {
-	if i >= len(c.args) {
-		return ""
+func renderBindings(title string, steps []exStep) string {
+	if title == "" {
+		title = "TODO: set title (overridden by demo.md frontmatter)"
 	}
-	if s, ok := stringLit(c.args[i]); ok {
-		return s
+	var b strings.Builder
+	b.WriteString("package main\n\n")
+	b.WriteString("import (\n\t_ \"embed\"\n\n\t\"github.com/panyam/demokit\"\n\t\"github.com/panyam/demokit/harness\"\n)\n\n")
+	b.WriteString("//go:embed demo.md\nvar demoMD []byte\n\n")
+	b.WriteString("// Generated by `demokit extract`. Content lives in demo.md (generate it\n")
+	b.WriteString("// with `--doc sidecar`); this file keeps the behavior. Fix imports and any\n")
+	b.WriteString("// TODO markers, then delete the original walkthrough.\n")
+	b.WriteString("func main() {\n")
+	fmt.Fprintf(&b, "\tdemo := demokit.New(%q).FromMarkdownBytes(demoMD)\n\n", title)
+	for _, st := range steps {
+		fmt.Fprintf(&b, "\tdemo.Bind(%q)", st.id)
+		for _, beh := range st.behavior {
+			b.WriteString(beh)
+		}
+		b.WriteString("\n\n")
 	}
-	*warnings = append(*warnings, fmt.Sprintf("%s: argument %d is not a string literal — emitted TODO", what, i))
-	return "TODO(extract): non-literal " + what
+	b.WriteString("\tharness.Run(demo)\n}\n")
+	return b.String()
 }
 
-func appendNote(existing, add string) string {
-	if existing == "" {
-		return add
-	}
-	return existing + "\n\n" + add
-}
-
-func uniqueID(explicit, title string, used map[string]int) string {
-	id := explicit
-	if id == "" {
-		id = slugify(title)
-	}
-	if id == "" {
-		id = "step"
-	}
-	n := used[id]
-	used[id]++
-	if n == 0 {
-		return id
-	}
-	return fmt.Sprintf("%s-%d", id, n+1)
-}
-
-// slugify mirrors demokit's heading slugifier (ASCII lower, non-alnum runs to
-// single hyphens). Duplicated here because demokit's copy is unexported.
+// slugify mirrors demokit's heading slugifier; used only for the placeholder
+// id in the missing-id warning path.
 func slugify(s string) string {
 	s = strings.ToLower(s)
 	var b strings.Builder
@@ -409,85 +268,4 @@ func slugify(s string) string {
 		}
 	}
 	return strings.TrimRight(b.String(), "-")
-}
-
-func renderMarkdown(title, desc string, actors [][2]string, items []exItem) string {
-	var b strings.Builder
-	b.WriteString("---\n")
-	b.WriteString("title: " + title + "\n")
-	if desc != "" {
-		b.WriteString("description: " + desc + "\n")
-	}
-	if len(actors) > 0 {
-		b.WriteString("actors:\n")
-		for _, a := range actors {
-			b.WriteString(fmt.Sprintf("  - { id: %s, label: %s }\n", a[0], a[1]))
-		}
-	}
-	b.WriteString("---\n\n")
-
-	for _, it := range items {
-		b.WriteString("## " + it.title + " {#" + it.id + "}\n\n")
-		if it.section {
-			if it.body != "" {
-				b.WriteString(it.body + "\n\n")
-			}
-			continue
-		}
-		if it.note != "" {
-			for line := range strings.SplitSeq(it.note, "\n") {
-				if line == "" {
-					b.WriteString(">\n")
-				} else {
-					b.WriteString("> " + line + "\n")
-				}
-			}
-			b.WriteString("\n")
-		}
-		if len(it.mermaid) > 0 {
-			b.WriteString("```mermaid\n")
-			for _, m := range it.mermaid {
-				b.WriteString(m + "\n")
-			}
-			b.WriteString("```\n\n")
-		}
-		for _, v := range it.verbatim {
-			for _, va := range v.variants {
-				attrs := []string{fmt.Sprintf("verbatim=%q", v.title)}
-				if va.label != "" {
-					attrs = append(attrs, "label="+va.label)
-				}
-				if va.isDefault {
-					attrs = append(attrs, "default=true")
-				}
-				b.WriteString("~~~" + va.lang + " {" + strings.Join(attrs, " ") + "}\n")
-				b.WriteString(va.content + "\n~~~\n")
-			}
-			b.WriteString("\n")
-		}
-	}
-	return b.String()
-}
-
-func renderBindings(title string, items []exItem) string {
-	var b strings.Builder
-	b.WriteString("package main\n\n")
-	b.WriteString("import (\n\t_ \"embed\"\n\n\t\"github.com/panyam/demokit\"\n\t\"github.com/panyam/demokit/harness\"\n)\n\n")
-	b.WriteString("//go:embed demo.md\nvar demoMD []byte\n\n")
-	b.WriteString("// Generated by `demokit extract`. Fix imports and any TODO(extract)\n")
-	b.WriteString("// markers, then delete the original walkthrough.\n")
-	b.WriteString("func main() {\n")
-	b.WriteString(fmt.Sprintf("\tdemo := demokit.New(%q).FromMarkdownBytes(demoMD)\n\n", title))
-	for _, it := range items {
-		if len(it.behavior) == 0 {
-			continue
-		}
-		b.WriteString(fmt.Sprintf("\tdemo.Bind(%q)", it.id))
-		for _, beh := range it.behavior {
-			b.WriteString(beh)
-		}
-		b.WriteString("\n\n")
-	}
-	b.WriteString("\tharness.Run(demo)\n}\n")
-	return b.String()
 }

--- a/cmd/demokit/extract.go
+++ b/cmd/demokit/extract.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// runExtract converts a Go walkthrough into sidecar form: a demo.md for the
+// content and a bindings.go skeleton for the behavior. Without --out it
+// prints both to stdout for inspection.
+func runExtract(args []string) error {
+	fs := flag.NewFlagSet("extract", flag.ContinueOnError)
+	outDir := fs.String("out", "", "directory to write demo.md and bindings.go (default: stdout)")
+	// Accept the file before or after flags: stdlib flag stops at the first
+	// positional, so pull a leading non-flag arg out before parsing.
+	file := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		file, args = args[0], args[1:]
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if file == "" {
+		file = fs.Arg(0)
+	}
+	if file == "" {
+		return fmt.Errorf("usage: demokit extract <file.go> [--out dir]")
+	}
+	src, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	res, err := extractFile(src)
+	if err != nil {
+		return err
+	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+	if *outDir == "" {
+		fmt.Printf("===== demo.md =====\n%s\n===== bindings.go =====\n%s\n", res.DemoMD, res.BindingsGo)
+		return nil
+	}
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(*outDir, "demo.md"), []byte(res.DemoMD), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(*outDir, "bindings.go"), []byte(res.BindingsGo), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %s/demo.md and %s/bindings.go\n", *outDir, *outDir)
+	return nil
+}
+
+// extractResult is the output of extractFile: the rendered sidecar markdown,
+// a Go bindings skeleton, and any warnings about content that could not be
+// statically extracted (left as TODO markers rather than dropped).
+type extractResult struct {
+	DemoMD     string
+	BindingsGo string
+	Warnings   []string
+}
+
+type chainCall struct {
+	sel  string
+	args []ast.Expr
+}
+
+type exVariant struct {
+	label, lang, content string
+	isDefault            bool
+}
+
+type exVerbatim struct {
+	title    string
+	variants []exVariant
+}
+
+type exItem struct {
+	section  bool
+	id       string
+	title    string
+	note     string
+	body     string
+	mermaid  []string
+	verbatim []exVerbatim
+	behavior []string // rendered ".Run(...)" etc, for the Bind skeleton
+}
+
+// extractFile parses a demokit walkthrough and returns the sidecar markdown
+// plus a bindings.go skeleton. It handles the linear builder pattern
+// (demokit.New(...) plus demo.Step(...)/demo.Section(...) chains with literal
+// content); non-literal content and unrecognized helpers become TODO markers
+// with a warning rather than silent drops.
+func extractFile(src []byte) (*extractResult, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "input.go", src, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	demoVar, newCalls, body := findDemo(file)
+	if demoVar == "" {
+		return nil, fmt.Errorf("no demokit.New(...) assignment found")
+	}
+
+	res := &extractResult{}
+	title, desc, actors := frontmatter(newCalls, &res.Warnings)
+
+	used := map[string]int{}
+	var items []exItem
+	for _, stmt := range body.List {
+		expr := stmtExpr(stmt)
+		if expr == nil {
+			continue
+		}
+		root, calls, ok := flattenChain(expr)
+		if !ok || root != demoVar || len(calls) == 0 {
+			continue
+		}
+		switch calls[0].sel {
+		case "Step":
+			items = append(items, parseStep(calls, src, fset, used, &res.Warnings))
+		case "Section":
+			items = append(items, parseSection(calls, used, &res.Warnings))
+		}
+	}
+
+	res.DemoMD = renderMarkdown(title, desc, actors, items)
+	res.BindingsGo = renderBindings(title, items)
+	return res, nil
+}
+
+// findDemo locates the `demoVar := demokit.New(...)...` assignment and the
+// function body that contains it, returning the demo variable name, the New
+// chain's calls, and the enclosing block.
+func findDemo(file *ast.File) (demoVar string, newCalls []chainCall, body *ast.BlockStmt) {
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		for _, stmt := range fd.Body.List {
+			as, ok := stmt.(*ast.AssignStmt)
+			if !ok || len(as.Lhs) != 1 || len(as.Rhs) != 1 {
+				continue
+			}
+			_, calls, ok := flattenChain(as.Rhs[0])
+			if !ok || calls[0].sel != "New" {
+				continue
+			}
+			if id, ok := as.Lhs[0].(*ast.Ident); ok {
+				return id.Name, calls, fd.Body
+			}
+		}
+	}
+	return "", nil, nil
+}
+
+// flattenChain unwinds a method-call chain (a.B(...).C(...)) into its root
+// identifier and the calls in source order.
+func flattenChain(e ast.Expr) (root string, calls []chainCall, ok bool) {
+	var rev []chainCall
+	for {
+		ce, isCall := e.(*ast.CallExpr)
+		if !isCall {
+			break
+		}
+		se, isSel := ce.Fun.(*ast.SelectorExpr)
+		if !isSel {
+			break
+		}
+		rev = append(rev, chainCall{sel: se.Sel.Name, args: ce.Args})
+		e = se.X
+	}
+	id, isID := e.(*ast.Ident)
+	if !isID || len(rev) == 0 {
+		return "", nil, false
+	}
+	for i := len(rev) - 1; i >= 0; i-- {
+		calls = append(calls, rev[i])
+	}
+	return id.Name, calls, true
+}
+
+func stmtExpr(s ast.Stmt) ast.Expr {
+	switch x := s.(type) {
+	case *ast.ExprStmt:
+		return x.X
+	case *ast.AssignStmt:
+		if len(x.Rhs) == 1 {
+			return x.Rhs[0]
+		}
+	}
+	return nil
+}
+
+func frontmatter(calls []chainCall, warnings *[]string) (title, desc string, actors [][2]string) {
+	for _, c := range calls {
+		switch c.sel {
+		case "New":
+			title = litArg(c, 0, "title", warnings)
+		case "Description":
+			desc = litArg(c, 0, "description", warnings)
+		case "Actors":
+			for _, a := range c.args {
+				if id, label, ok := parseActor(a); ok {
+					actors = append(actors, [2]string{id, label})
+				}
+			}
+		}
+	}
+	return
+}
+
+func parseActor(e ast.Expr) (id, label string, ok bool) {
+	ce, isCall := e.(*ast.CallExpr)
+	if !isCall {
+		return
+	}
+	se, isSel := ce.Fun.(*ast.SelectorExpr)
+	if !isSel || se.Sel.Name != "Actor" || len(ce.Args) < 2 {
+		return
+	}
+	id, ok1 := stringLit(ce.Args[0])
+	label, ok2 := stringLit(ce.Args[1])
+	return id, label, ok1 && ok2
+}
+
+func parseStep(calls []chainCall, src []byte, fset *token.FileSet, used map[string]int, warnings *[]string) exItem {
+	it := exItem{}
+	var explicitID string
+	for _, c := range calls {
+		switch c.sel {
+		case "Step":
+			it.title = litArg(c, 0, "step title", warnings)
+		case "ID":
+			explicitID = litArg(c, 0, "id", warnings)
+		case "Note":
+			var lines []string
+			for i := range c.args {
+				lines = append(lines, litArg(c, i, "note", warnings))
+			}
+			it.note = appendNote(it.note, strings.Join(lines, "\n"))
+		case "Arrow":
+			it.mermaid = append(it.mermaid, fmt.Sprintf("%s ->> %s: %s",
+				litArg(c, 0, "arrow", warnings), litArg(c, 1, "arrow", warnings), litArg(c, 2, "arrow", warnings)))
+		case "DashedArrow":
+			it.mermaid = append(it.mermaid, fmt.Sprintf("%s -->> %s: %s",
+				litArg(c, 0, "arrow", warnings), litArg(c, 1, "arrow", warnings), litArg(c, 2, "arrow", warnings)))
+		case "VerbatimVariants":
+			it.verbatim = append(it.verbatim, parseVerbatimVariants(c, warnings))
+		case "VerbatimLang":
+			it.verbatim = append(it.verbatim, exVerbatim{title: litArg(c, 0, "verbatim", warnings),
+				variants: []exVariant{{lang: litArg(c, 1, "verbatim", warnings), content: litArg(c, 2, "verbatim", warnings)}}})
+		case "Verbatim":
+			it.verbatim = append(it.verbatim, exVerbatim{title: litArg(c, 0, "verbatim", warnings),
+				variants: []exVariant{{content: litArg(c, 1, "verbatim", warnings)}}})
+		case "Shell":
+			it.verbatim = append(it.verbatim, exVerbatim{variants: []exVariant{{lang: "bash", content: litArg(c, 0, "shell", warnings)}}})
+		case "Run", "Coalesce", "Parse", "Timeout", "Cancellable", "InputTimeout":
+			it.behavior = append(it.behavior, renderCall(c, src, fset))
+		case "Input":
+			*warnings = append(*warnings, fmt.Sprintf("step %q: Input(...) not extracted; declare it in a demo.md inputs block", it.title))
+			it.note = appendNote(it.note, "TODO(extract): declare this step's inputs in an `inputs` block")
+		}
+	}
+	it.id = uniqueID(explicitID, it.title, used)
+	return it
+}
+
+func parseSection(calls []chainCall, used map[string]int, warnings *[]string) exItem {
+	it := exItem{section: true}
+	c := calls[0]
+	it.title = litArg(c, 0, "section title", warnings)
+	var lines []string
+	for i := 1; i < len(c.args); i++ {
+		lines = append(lines, litArg(c, i, "section body", warnings))
+	}
+	it.body = strings.Join(lines, "\n")
+	it.id = uniqueID("", it.title, used)
+	return it
+}
+
+func parseVerbatimVariants(c chainCall, warnings *[]string) exVerbatim {
+	v := exVerbatim{}
+	if len(c.args) > 0 {
+		v.title, _ = stringLit(c.args[0])
+	}
+	for _, a := range c.args[1:] {
+		if va, ok := parseVariant(a); ok {
+			v.variants = append(v.variants, va)
+			continue
+		}
+		*warnings = append(*warnings, fmt.Sprintf("verbatim %q: a variant is not a literal MakeVariant(...) — emitted TODO", v.title))
+		v.variants = append(v.variants, exVariant{content: "TODO(extract): variant not statically extractable"})
+	}
+	return v
+}
+
+func parseVariant(e ast.Expr) (exVariant, bool) {
+	var v exVariant
+	if ce, isCall := e.(*ast.CallExpr); isCall {
+		if se, isSel := ce.Fun.(*ast.SelectorExpr); isSel && se.Sel.Name == "Default" {
+			v.isDefault = true
+			e = se.X
+		}
+	}
+	ce, isCall := e.(*ast.CallExpr)
+	if !isCall {
+		return v, false
+	}
+	se, isSel := ce.Fun.(*ast.SelectorExpr)
+	if !isSel || se.Sel.Name != "MakeVariant" || len(ce.Args) < 3 {
+		return v, false
+	}
+	label, ok1 := stringLit(ce.Args[0])
+	lang, ok2 := stringLit(ce.Args[1])
+	content, ok3 := stringLit(ce.Args[2])
+	v.label, v.lang, v.content = label, lang, content
+	return v, ok1 && ok2 && ok3
+}
+
+// renderCall reconstructs a behavior call (".Run(...)", ".Coalesce(...)") by
+// slicing the original source for its arguments, so closures are carried over
+// verbatim into the bindings skeleton.
+func renderCall(c chainCall, src []byte, fset *token.FileSet) string {
+	if len(c.args) == 0 {
+		return "." + c.sel + "()"
+	}
+	from := fset.Position(c.args[0].Pos()).Offset
+	to := fset.Position(c.args[len(c.args)-1].End()).Offset
+	return "." + c.sel + "(" + string(src[from:to]) + ")"
+}
+
+func stringLit(e ast.Expr) (string, bool) {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(bl.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// litArg returns the i-th argument as a string literal, or "TODO(extract)…"
+// plus a warning when it is missing or not a literal.
+func litArg(c chainCall, i int, what string, warnings *[]string) string {
+	if i >= len(c.args) {
+		return ""
+	}
+	if s, ok := stringLit(c.args[i]); ok {
+		return s
+	}
+	*warnings = append(*warnings, fmt.Sprintf("%s: argument %d is not a string literal — emitted TODO", what, i))
+	return "TODO(extract): non-literal " + what
+}
+
+func appendNote(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	return existing + "\n\n" + add
+}
+
+func uniqueID(explicit, title string, used map[string]int) string {
+	id := explicit
+	if id == "" {
+		id = slugify(title)
+	}
+	if id == "" {
+		id = "step"
+	}
+	n := used[id]
+	used[id]++
+	if n == 0 {
+		return id
+	}
+	return fmt.Sprintf("%s-%d", id, n+1)
+}
+
+// slugify mirrors demokit's heading slugifier (ASCII lower, non-alnum runs to
+// single hyphens). Duplicated here because demokit's copy is unexported.
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+func renderMarkdown(title, desc string, actors [][2]string, items []exItem) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("title: " + title + "\n")
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	}
+	if len(actors) > 0 {
+		b.WriteString("actors:\n")
+		for _, a := range actors {
+			b.WriteString(fmt.Sprintf("  - { id: %s, label: %s }\n", a[0], a[1]))
+		}
+	}
+	b.WriteString("---\n\n")
+
+	for _, it := range items {
+		b.WriteString("## " + it.title + " {#" + it.id + "}\n\n")
+		if it.section {
+			if it.body != "" {
+				b.WriteString(it.body + "\n\n")
+			}
+			continue
+		}
+		if it.note != "" {
+			for line := range strings.SplitSeq(it.note, "\n") {
+				if line == "" {
+					b.WriteString(">\n")
+				} else {
+					b.WriteString("> " + line + "\n")
+				}
+			}
+			b.WriteString("\n")
+		}
+		if len(it.mermaid) > 0 {
+			b.WriteString("```mermaid\n")
+			for _, m := range it.mermaid {
+				b.WriteString(m + "\n")
+			}
+			b.WriteString("```\n\n")
+		}
+		for _, v := range it.verbatim {
+			for _, va := range v.variants {
+				attrs := []string{fmt.Sprintf("verbatim=%q", v.title)}
+				if va.label != "" {
+					attrs = append(attrs, "label="+va.label)
+				}
+				if va.isDefault {
+					attrs = append(attrs, "default=true")
+				}
+				b.WriteString("~~~" + va.lang + " {" + strings.Join(attrs, " ") + "}\n")
+				b.WriteString(va.content + "\n~~~\n")
+			}
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func renderBindings(title string, items []exItem) string {
+	var b strings.Builder
+	b.WriteString("package main\n\n")
+	b.WriteString("import (\n\t_ \"embed\"\n\n\t\"github.com/panyam/demokit\"\n\t\"github.com/panyam/demokit/harness\"\n)\n\n")
+	b.WriteString("//go:embed demo.md\nvar demoMD []byte\n\n")
+	b.WriteString("// Generated by `demokit extract`. Fix imports and any TODO(extract)\n")
+	b.WriteString("// markers, then delete the original walkthrough.\n")
+	b.WriteString("func main() {\n")
+	b.WriteString(fmt.Sprintf("\tdemo := demokit.New(%q).FromMarkdownBytes(demoMD)\n\n", title))
+	for _, it := range items {
+		if len(it.behavior) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("\tdemo.Bind(%q)", it.id))
+		for _, beh := range it.behavior {
+			b.WriteString(beh)
+		}
+		b.WriteString("\n\n")
+	}
+	b.WriteString("\tharness.Run(demo)\n}\n")
+	return b.String()
+}

--- a/cmd/demokit/extract_test.go
+++ b/cmd/demokit/extract_test.go
@@ -5,8 +5,6 @@ import (
 	"go/token"
 	"strings"
 	"testing"
-
-	"github.com/panyam/demokit"
 )
 
 const fixtureWalkthrough = `package main
@@ -17,33 +15,24 @@ import (
 )
 
 func main() {
-	demo := demokit.New("Fixture Demo").
-		Description("A test demo").
-		Actors(demokit.Actor("A", "Alpha"), demokit.Actor("B", "Beta"))
+	demo := demokit.New("Fixture Demo").Description("A test demo")
 
-	demo.Section("Intro", "first line", "second line")
+	demo.Section("Intro", "first line")
 
 	demo.Step("Connect").ID("connect").
-		Note("a note", "line two").
-		Arrow("A", "B", "hello").
-		DashedArrow("B", "A", "ack").
-		VerbatimVariants("Reproduce",
-			demokit.MakeVariant("curl", "bash", "curl x").Default(),
-			demokit.MakeVariant("go", "go", "http.Get()")).
+		Note("a note").
+		VerbatimVariants("Reproduce", demokit.MakeVariant("curl", "bash", "curl x").Default()).
+		Coalesce(func(m map[string]any) any { return m["x"] }).
 		Run(func(ctx demokit.StepContext) *demokit.StepResult {
 			fmt.Println("hi from connect")
 			return nil
 		})
 
-	demo.Step("Same Title").
+	demo.Step("No id step").
 		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
 
-	demo.Step("Same Title").
-		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
-
-	demo.Step("Has input").ID("inp").
-		Input(demokit.Choice("x", "y").Named("k", "K")).
-		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
+	demo.Step("Content only").ID("content").
+		Note("just prose, no behavior")
 
 	demo.Execute()
 }
@@ -51,99 +40,63 @@ func main() {
 
 func extractFixture(t *testing.T) *extractResult {
 	t.Helper()
-	res, err := extractFile([]byte(fixtureWalkthrough))
+	res, err := extractBindings([]byte(fixtureWalkthrough))
 	if err != nil {
-		t.Fatalf("extractFile: %v", err)
+		t.Fatalf("extractBindings: %v", err)
 	}
 	return res
 }
 
-// TestExtractContentToMarkdown checks that frontmatter, a section, notes,
-// mermaid arrows, and a multi-variant verbatim block all land in demo.md in
-// the expected sidecar form.
-func TestExtractContentToMarkdown(t *testing.T) {
-	md := extractFixture(t).DemoMD
-	wants := []string{
-		"title: Fixture Demo",
-		"description: A test demo",
-		"- { id: A, label: Alpha }",
-		"## Intro {#intro}",
-		"first line\nsecond line",
-		"## Connect {#connect}",
-		"> a note\n> line two",
-		"A ->> B: hello",
-		"B -->> A: ack",
-		`~~~bash {verbatim="Reproduce" label=curl default=true}`,
-		"curl x",
-		`~~~go {verbatim="Reproduce" label=go}`,
-		"http.Get()",
-	}
-	for _, w := range wants {
-		if !strings.Contains(md, w) {
-			t.Errorf("demo.md missing %q\n---\n%s", w, md)
-		}
-	}
-}
-
-// TestExtractUniqueIDs verifies colliding slugs are disambiguated in source
-// order and an explicit ID is preserved.
-func TestExtractUniqueIDs(t *testing.T) {
-	md := extractFixture(t).DemoMD
-	for _, want := range []string{"## Connect {#connect}", "## Same Title {#same-title}", "## Same Title {#same-title-2}", "## Has input {#inp}"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("demo.md missing heading/id %q", want)
-		}
-	}
-}
-
-// TestExtractInputBecomesTodo verifies a step with Input(...) yields a warning
-// and a TODO marker rather than a silent drop.
-func TestExtractInputBecomesTodo(t *testing.T) {
-	res := extractFixture(t)
-	if !strings.Contains(res.DemoMD, "TODO(extract)") {
-		t.Errorf("expected a TODO marker in demo.md for the Input step")
-	}
-	var found bool
-	for _, w := range res.Warnings {
-		if strings.Contains(w, "Input(") {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected an Input warning, got %v", res.Warnings)
-	}
-}
-
-// TestExtractDemoMDRoundTrips is the load-bearing check: the generated demo.md
-// must parse through demokit's own loader without error.
-func TestExtractDemoMDRoundTrips(t *testing.T) {
-	res := extractFixture(t)
-	// Loading the generated md and re-rendering proves it parsed into items
-	// (a load error would leave the demo empty).
-	md := demokit.New("x").FromMarkdownBytes([]byte(res.DemoMD)).Markdown()
-	for _, want := range []string{"Fixture Demo", "Connect", "Reproduce"} {
-		if !strings.Contains(md, want) {
-			t.Errorf("loaded+rendered demo missing %q:\n%s", want, md)
-		}
-	}
-}
-
-// TestExtractBindingsParse verifies bindings.go is valid Go and carries the
-// Run closures over verbatim, keyed by step id.
+// TestExtractBindingsParse verifies the skeleton is valid Go, carries the Run
+// and Coalesce closures verbatim, and binds them by step id.
 func TestExtractBindingsParse(t *testing.T) {
 	res := extractFixture(t)
 	if _, err := parser.ParseFile(token.NewFileSet(), "bindings.go", res.BindingsGo, 0); err != nil {
 		t.Fatalf("bindings.go does not parse: %v\n%s", err, res.BindingsGo)
 	}
-	for _, want := range []string{`demo.Bind("connect")`, `fmt.Println("hi from connect")`, `.Run(`} {
+	for _, want := range []string{
+		`demokit.New("Fixture Demo")`,
+		`demo.Bind("connect")`,
+		`.Coalesce(func(m map[string]any) any`,
+		`fmt.Println("hi from connect")`,
+		`harness.Run(demo)`,
+	} {
 		if !strings.Contains(res.BindingsGo, want) {
 			t.Errorf("bindings.go missing %q", want)
 		}
 	}
 }
 
+// TestExtractSkipsContentOnlySteps verifies a step with no behavior is not
+// bound (its content is demo.md's job, not bindings.go's).
+func TestExtractSkipsContentOnlySteps(t *testing.T) {
+	res := extractFixture(t)
+	if strings.Contains(res.BindingsGo, `demo.Bind("content")`) {
+		t.Errorf("content-only step should not be bound:\n%s", res.BindingsGo)
+	}
+}
+
+// TestExtractMissingIDWarns verifies a behavior-bearing step without an
+// explicit ID produces a warning and a TODO placeholder id (so the author
+// notices rather than getting a silently-wrong join key).
+func TestExtractMissingIDWarns(t *testing.T) {
+	res := extractFixture(t)
+	var warned bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "No id step") && strings.Contains(w, ".ID()") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("expected a missing-id warning, got %v", res.Warnings)
+	}
+	if !strings.Contains(res.BindingsGo, "TODO-set-id-no-id-step") {
+		t.Errorf("expected a TODO placeholder id in bindings.go:\n%s", res.BindingsGo)
+	}
+}
+
 func TestExtractNoDemoErrors(t *testing.T) {
-	_, err := extractFile([]byte("package main\nfunc main() {}\n"))
+	_, err := extractBindings([]byte("package main\nfunc main() {}\n"))
 	if err == nil {
 		t.Fatal("expected error when no demokit.New(...) is present")
 	}

--- a/cmd/demokit/extract_test.go
+++ b/cmd/demokit/extract_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/panyam/demokit"
+)
+
+const fixtureWalkthrough = `package main
+
+import (
+	"fmt"
+	"github.com/panyam/demokit"
+)
+
+func main() {
+	demo := demokit.New("Fixture Demo").
+		Description("A test demo").
+		Actors(demokit.Actor("A", "Alpha"), demokit.Actor("B", "Beta"))
+
+	demo.Section("Intro", "first line", "second line")
+
+	demo.Step("Connect").ID("connect").
+		Note("a note", "line two").
+		Arrow("A", "B", "hello").
+		DashedArrow("B", "A", "ack").
+		VerbatimVariants("Reproduce",
+			demokit.MakeVariant("curl", "bash", "curl x").Default(),
+			demokit.MakeVariant("go", "go", "http.Get()")).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			fmt.Println("hi from connect")
+			return nil
+		})
+
+	demo.Step("Same Title").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
+
+	demo.Step("Same Title").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
+
+	demo.Step("Has input").ID("inp").
+		Input(demokit.Choice("x", "y").Named("k", "K")).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult { return nil })
+
+	demo.Execute()
+}
+`
+
+func extractFixture(t *testing.T) *extractResult {
+	t.Helper()
+	res, err := extractFile([]byte(fixtureWalkthrough))
+	if err != nil {
+		t.Fatalf("extractFile: %v", err)
+	}
+	return res
+}
+
+// TestExtractContentToMarkdown checks that frontmatter, a section, notes,
+// mermaid arrows, and a multi-variant verbatim block all land in demo.md in
+// the expected sidecar form.
+func TestExtractContentToMarkdown(t *testing.T) {
+	md := extractFixture(t).DemoMD
+	wants := []string{
+		"title: Fixture Demo",
+		"description: A test demo",
+		"- { id: A, label: Alpha }",
+		"## Intro {#intro}",
+		"first line\nsecond line",
+		"## Connect {#connect}",
+		"> a note\n> line two",
+		"A ->> B: hello",
+		"B -->> A: ack",
+		`~~~bash {verbatim="Reproduce" label=curl default=true}`,
+		"curl x",
+		`~~~go {verbatim="Reproduce" label=go}`,
+		"http.Get()",
+	}
+	for _, w := range wants {
+		if !strings.Contains(md, w) {
+			t.Errorf("demo.md missing %q\n---\n%s", w, md)
+		}
+	}
+}
+
+// TestExtractUniqueIDs verifies colliding slugs are disambiguated in source
+// order and an explicit ID is preserved.
+func TestExtractUniqueIDs(t *testing.T) {
+	md := extractFixture(t).DemoMD
+	for _, want := range []string{"## Connect {#connect}", "## Same Title {#same-title}", "## Same Title {#same-title-2}", "## Has input {#inp}"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("demo.md missing heading/id %q", want)
+		}
+	}
+}
+
+// TestExtractInputBecomesTodo verifies a step with Input(...) yields a warning
+// and a TODO marker rather than a silent drop.
+func TestExtractInputBecomesTodo(t *testing.T) {
+	res := extractFixture(t)
+	if !strings.Contains(res.DemoMD, "TODO(extract)") {
+		t.Errorf("expected a TODO marker in demo.md for the Input step")
+	}
+	var found bool
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "Input(") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an Input warning, got %v", res.Warnings)
+	}
+}
+
+// TestExtractDemoMDRoundTrips is the load-bearing check: the generated demo.md
+// must parse through demokit's own loader without error.
+func TestExtractDemoMDRoundTrips(t *testing.T) {
+	res := extractFixture(t)
+	// Loading the generated md and re-rendering proves it parsed into items
+	// (a load error would leave the demo empty).
+	md := demokit.New("x").FromMarkdownBytes([]byte(res.DemoMD)).Markdown()
+	for _, want := range []string{"Fixture Demo", "Connect", "Reproduce"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("loaded+rendered demo missing %q:\n%s", want, md)
+		}
+	}
+}
+
+// TestExtractBindingsParse verifies bindings.go is valid Go and carries the
+// Run closures over verbatim, keyed by step id.
+func TestExtractBindingsParse(t *testing.T) {
+	res := extractFixture(t)
+	if _, err := parser.ParseFile(token.NewFileSet(), "bindings.go", res.BindingsGo, 0); err != nil {
+		t.Fatalf("bindings.go does not parse: %v\n%s", err, res.BindingsGo)
+	}
+	for _, want := range []string{`demo.Bind("connect")`, `fmt.Println("hi from connect")`, `.Run(`} {
+		if !strings.Contains(res.BindingsGo, want) {
+			t.Errorf("bindings.go missing %q", want)
+		}
+	}
+}
+
+func TestExtractNoDemoErrors(t *testing.T) {
+	_, err := extractFile([]byte("package main\nfunc main() {}\n"))
+	if err == nil {
+		t.Fatal("expected error when no demokit.New(...) is present")
+	}
+}

--- a/cmd/demokit/main.go
+++ b/cmd/demokit/main.go
@@ -1,0 +1,60 @@
+// Command demokit scaffolds and migrates demokit walkthroughs.
+//
+//	demokit init [dir]                       scaffold a project (Makefile + sample)
+//	demokit new <name> [--kind=KIND] [--dir] add one example from a starter
+//	demokit extract <file.go>                Go walkthrough -> sidecar markdown
+//
+// KIND is narrated | live | branching (default live). Install with:
+//
+//	go install github.com/panyam/demokit/cmd/demokit@latest
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+	cmd, args := os.Args[1], os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "init":
+		err = runInit(args)
+	case "new":
+		err = runNew(args)
+	case "extract":
+		err = runExtract(args)
+	case "help", "-h", "--help":
+		usage(os.Stdout)
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "demokit: unknown command %q\n\n", cmd)
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "demokit %s: %v\n", cmd, err)
+		os.Exit(1)
+	}
+}
+
+func usage(w io.Writer) {
+	fmt.Fprint(w, `demokit — scaffold and migrate walkthroughs
+
+Usage:
+  demokit init [dir]                          scaffold a project (Makefile + sample)
+  demokit new <name> [--kind=KIND] [--dir D]  add one example from a starter
+  demokit extract <file.go>                   Go walkthrough -> sidecar markdown + Bind skeleton
+
+KIND is one of: narrated | live | branching   (default: live)
+  narrated   sidecar markdown only, no Go behavior
+  live       markdown content + Go behavior bound by step id
+  branching  Go-driven routing and state
+`)
+}

--- a/cmd/demokit/scaffold.go
+++ b/cmd/demokit/scaffold.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"embed"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+// validKinds is the set of per-example starters, ordered as a gradient:
+// narrated (content only) ⊂ live (content + bound behavior) ⊂ branching
+// (Go-driven routing/state).
+var validKinds = map[string]bool{"narrated": true, "live": true, "branching": true}
+
+// runInit scaffolds a project: the base walkthrough.mk plus one sample
+// example so `make demo` works immediately. The optional positional arg is
+// the target directory (default "."). --kind picks the sample's starter.
+func runInit(args []string) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	kind := fs.String("kind", "live", "starter kind for the sample example: narrated|live|branching")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	root := "."
+	if fs.NArg() >= 1 {
+		root = fs.Arg(0)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+	mk, err := templatesFS.ReadFile("templates/walkthrough.mk")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(root, "walkthrough.mk"), mk, 0o644); err != nil {
+		return err
+	}
+	if err := scaffoldExample(root, "hello", *kind); err != nil {
+		return err
+	}
+	fmt.Printf("Scaffolded demokit project in %s:\n"+
+		"  walkthrough.mk   base Makefile fragment\n"+
+		"  hello/           %s sample\n\n"+
+		"Next: cd %s && make demo\n", root, *kind, filepath.Join(root, "hello"))
+	return nil
+}
+
+// runNew adds one example directory from a starter. Usage:
+//
+//	demokit new <name> [--kind=narrated|live|branching] [--dir=.]
+func runNew(args []string) error {
+	fs := flag.NewFlagSet("new", flag.ContinueOnError)
+	kind := fs.String("kind", "live", "starter kind: narrated|live|branching")
+	dir := fs.String("dir", ".", "parent directory to create the example in")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: demokit new <name> [--kind=narrated|live|branching] [--dir=.]")
+	}
+	return scaffoldExample(*dir, fs.Arg(0), *kind)
+}
+
+// scaffoldExample renders the starter of the given kind into root/name,
+// substituting the title (derived from name) into each template, and writes
+// a per-example Makefile that includes the project's walkthrough.mk. It
+// refuses to overwrite an existing directory.
+func scaffoldExample(root, name, kind string) error {
+	if !validKinds[kind] {
+		return fmt.Errorf("unknown kind %q (want narrated|live|branching)", kind)
+	}
+	dir := filepath.Join(root, name)
+	if _, err := os.Stat(dir); err == nil {
+		return fmt.Errorf("%s already exists", dir)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	data := struct{ Name, Title string }{Name: name, Title: titleize(name)}
+	entries, err := templatesFS.ReadDir("templates/" + kind)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		raw, err := templatesFS.ReadFile("templates/" + kind + "/" + e.Name())
+		if err != nil {
+			return err
+		}
+		tmpl, err := template.New(e.Name()).Parse(string(raw))
+		if err != nil {
+			return err
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, data); err != nil {
+			return err
+		}
+		out := filepath.Join(dir, strings.TrimSuffix(e.Name(), ".tmpl"))
+		if err := os.WriteFile(out, buf.Bytes(), 0o644); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("include ../walkthrough.mk\n"), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("Created %s (%s)\n", dir, kind)
+	return nil
+}
+
+// titleize turns an example name into a demo title: "my-cool-demo" ->
+// "My Cool Demo". Hyphens and underscores become spaces; each word is
+// capitalized.
+func titleize(name string) string {
+	fields := strings.FieldsFunc(name, func(r rune) bool { return r == '-' || r == '_' })
+	for i, f := range fields {
+		if f == "" {
+			continue
+		}
+		fields[i] = strings.ToUpper(f[:1]) + f[1:]
+	}
+	if len(fields) == 0 {
+		return name
+	}
+	return strings.Join(fields, " ")
+}

--- a/cmd/demokit/scaffold_test.go
+++ b/cmd/demokit/scaffold_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/demokit"
+)
+
+func TestTitleize(t *testing.T) {
+	cases := map[string]string{
+		"hello":         "Hello",
+		"my-cool-demo":  "My Cool Demo",
+		"token_refresh": "Token Refresh",
+	}
+	for in, want := range cases {
+		if got := titleize(in); got != want {
+			t.Errorf("titleize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestScaffoldKindsProduceValidProject verifies every starter writes a
+// parseable main.go, and that narrated/live sidecars load through demokit's
+// own markdown loader — the real acceptance check for generated content.
+func TestScaffoldKindsProduceValidProject(t *testing.T) {
+	for _, kind := range []string{"narrated", "live", "branching"} {
+		t.Run(kind, func(t *testing.T) {
+			root := t.TempDir()
+			if err := scaffoldExample(root, "ex", kind); err != nil {
+				t.Fatalf("scaffoldExample: %v", err)
+			}
+			dir := filepath.Join(root, "ex")
+
+			mainSrc, err := os.ReadFile(filepath.Join(dir, "main.go"))
+			if err != nil {
+				t.Fatalf("read main.go: %v", err)
+			}
+			if _, err := parser.ParseFile(token.NewFileSet(), "main.go", mainSrc, 0); err != nil {
+				t.Errorf("generated main.go does not parse: %v", err)
+			}
+			if !strings.Contains(string(mainSrc), `demokit.New("Ex")`) {
+				t.Errorf("generated main.go missing titleized New(\"Ex\")")
+			}
+
+			mdPath := filepath.Join(dir, "demo.md")
+			md, err := os.ReadFile(mdPath)
+			switch kind {
+			case "narrated", "live":
+				if err != nil {
+					t.Fatalf("expected demo.md for kind %s: %v", kind, err)
+				}
+				out := demokit.New("x").FromMarkdownBytes(md).Markdown()
+				if !strings.Contains(out, "Ex") {
+					t.Errorf("generated demo.md did not load/render:\n%s", out)
+				}
+			case "branching":
+				if err == nil {
+					t.Errorf("branching kind should not emit demo.md")
+				}
+			}
+
+			if _, err := os.Stat(filepath.Join(dir, "Makefile")); err != nil {
+				t.Errorf("missing per-example Makefile: %v", err)
+			}
+		})
+	}
+}
+
+func TestScaffoldInvalidKind(t *testing.T) {
+	if err := scaffoldExample(t.TempDir(), "ex", "bogus"); err == nil {
+		t.Fatal("expected error for unknown kind")
+	}
+}
+
+func TestScaffoldRefusesExisting(t *testing.T) {
+	root := t.TempDir()
+	if err := scaffoldExample(root, "ex", "live"); err != nil {
+		t.Fatalf("first scaffold: %v", err)
+	}
+	if err := scaffoldExample(root, "ex", "live"); err == nil {
+		t.Fatal("expected error when target dir already exists")
+	}
+}
+
+// TestInitScaffoldsProject verifies init writes the base Makefile fragment and
+// a runnable sample example.
+func TestInitScaffoldsProject(t *testing.T) {
+	root := t.TempDir()
+	if err := runInit([]string{root}); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	for _, p := range []string{"walkthrough.mk", "hello/main.go", "hello/demo.md", "hello/Makefile"} {
+		if _, err := os.Stat(filepath.Join(root, p)); err != nil {
+			t.Errorf("init did not create %s: %v", p, err)
+		}
+	}
+}

--- a/cmd/demokit/templates/branching/main.go.tmpl
+++ b/cmd/demokit/templates/branching/main.go.tmpl
@@ -1,0 +1,43 @@
+// {{.Title}} — a branching walkthrough.
+//
+// Routing and state live in Go: each step's Run returns a StepResult whose
+// Next names the step to visit. This is the depth case — use it when the
+// path depends on input or computed state rather than a fixed sequence.
+package main
+
+import (
+	"fmt"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/harness"
+)
+
+func main() {
+	demo := demokit.New("{{.Title}}").
+		Description("A branching demo: routing and state live in Go.").
+		MaxSteps(20).
+		MaxVisits(3)
+
+	demo.Step("Pick a path").ID("start").
+		Input(demokit.Choice("left", "right").Named("dir", "Which way?").WithDefault("left")).
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			if ctx.Inputs["dir"] == "left" {
+				return &demokit.StepResult{Next: "went-left"}
+			}
+			return &demokit.StepResult{Next: "went-right"}
+		})
+
+	demo.Step("Went left").ID("went-left").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			fmt.Println("You went left.")
+			return nil
+		})
+
+	demo.Step("Went right").ID("went-right").
+		Run(func(ctx demokit.StepContext) *demokit.StepResult {
+			fmt.Println("You went right.")
+			return nil
+		})
+
+	harness.Run(demo)
+}

--- a/cmd/demokit/templates/live/demo.md.tmpl
+++ b/cmd/demokit/templates/live/demo.md.tmpl
@@ -1,0 +1,22 @@
+---
+title: {{.Title}}
+description: A live walkthrough — content here, behavior in main.go.
+---
+
+## Overview {#overview}
+
+This demo keeps prose and snippets in markdown, and binds real behavior in
+Go via `demo.Bind("id")`. Edit the content here; edit the behavior in main.go.
+
+## Fetch something {#fetch}
+
+> This step runs real Go code — see `Bind("fetch")` in main.go. The note you
+> are reading and the snippet below are content, so they live here in markdown.
+
+~~~bash {verbatim="Reproduce on the wire" label=curl default=true}
+curl -s https://example.com/api
+~~~
+~~~go {verbatim="Reproduce on the wire" label=go}
+resp, _ := http.Get("https://example.com/api")
+defer resp.Body.Close()
+~~~

--- a/cmd/demokit/templates/live/main.go.tmpl
+++ b/cmd/demokit/templates/live/main.go.tmpl
@@ -1,0 +1,29 @@
+// {{.Title}} — a live walkthrough.
+//
+// Content (notes, snippets) lives in demo.md; behavior lives here in Go and
+// attaches to a step by its heading id via demo.Bind("id"). This is the
+// common shape for demos that make real calls while keeping prose in markdown.
+package main
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/harness"
+)
+
+//go:embed demo.md
+var demoMD []byte
+
+func main() {
+	demo := demokit.New("{{.Title}}").FromMarkdownBytes(demoMD)
+
+	// The "fetch" step's content is in demo.md; its behavior is here.
+	demo.Bind("fetch").Run(func(ctx demokit.StepContext) *demokit.StepResult {
+		fmt.Println("... do the real work here (HTTP call, command, etc.) ...")
+		return demokit.Info("fetched")
+	})
+
+	harness.Run(demo)
+}

--- a/cmd/demokit/templates/narrated/demo.md.tmpl
+++ b/cmd/demokit/templates/narrated/demo.md.tmpl
@@ -1,0 +1,24 @@
+---
+title: {{.Title}}
+description: A narrated walkthrough — all content lives in this markdown file.
+---
+
+## Welcome {#welcome}
+
+This is a narrated demo. Everything the audience sees is authored here in
+markdown: section prose, step notes, and snippets. Edit this file and run
+`make demo`.
+
+## A step with a note {#first-step}
+
+> Blockquotes become a step's note — the talk-track that explains what is
+> happening. Steps pause for the audience before advancing.
+
+## Show a command {#snippet}
+
+> Fenced blocks tagged with a `verbatim` attribute become copy-pasteable
+> snippets in the rendered demo.
+
+~~~bash {verbatim="Run this"}
+echo "hello from demokit"
+~~~

--- a/cmd/demokit/templates/narrated/main.go.tmpl
+++ b/cmd/demokit/templates/narrated/main.go.tmpl
@@ -1,0 +1,21 @@
+// {{.Title}} — a narrated walkthrough.
+//
+// All content lives in demo.md; this file just loads and runs it. There is
+// no Go behavior. To add behavior, graduate to the "live" kind: bind a Run
+// to a step id with demo.Bind("id").Run(...).
+package main
+
+import (
+	_ "embed"
+
+	"github.com/panyam/demokit"
+	"github.com/panyam/demokit/harness"
+)
+
+//go:embed demo.md
+var demoMD []byte
+
+func main() {
+	demo := demokit.New("{{.Title}}").FromMarkdownBytes(demoMD)
+	harness.Run(demo)
+}

--- a/cmd/demokit/templates/walkthrough.mk
+++ b/cmd/demokit/templates/walkthrough.mk
@@ -1,0 +1,38 @@
+# walkthrough.mk — base targets for a demokit walkthrough.
+#
+# A per-example Makefile includes this fragment (adjust the path depth):
+#
+#   include ../walkthrough.mk
+#
+# Override before the include if needed:
+#   DEMO_BIN      binary name for `make build`  (default: directory name)
+#   RECORD_TRACE  scratch trace path            (default: /tmp/<bin>.trace.json)
+
+DEMO_BIN     ?= $(notdir $(CURDIR))
+RECORD_TRACE ?= /tmp/$(DEMO_BIN).trace.json
+
+demo: ## Run the walkthrough (interactive, TUI)
+	go run . --tui
+
+note: ## Run in notebook mode (Bubble Tea cells)
+	go run . --note
+
+run: ## Run in plain mode
+	go run .
+
+readme: ## Regenerate WALKTHROUGH.md from the demo definition (static)
+	go run . --doc md > WALKTHROUGH.md
+
+record: ## Record a trace (interactive; press Enter to advance each step)
+	go run . --tui --record $(RECORD_TRACE)
+	@echo "Trace written to $(RECORD_TRACE)"
+
+bundle: ## Build a self-contained HTML player from the recorded trace
+	@mkdir -p bundle
+	go run . --doc bundle --from $(RECORD_TRACE) --out bundle/index.html
+
+build: ## Build the example binary
+	go build -o $(DEMO_BIN) .
+
+.PHONY: demo note run readme record bundle build
+.DEFAULT_GOAL := demo

--- a/demokit.go
+++ b/demokit.go
@@ -147,7 +147,7 @@ type DocHandler func(d *Demo, entries []TraceEntry, out string) error
 //	web.RegisterWith(demo)  // wires --doc bundle and --serve
 func (d *Demo) RegisterDocFormat(name string, h DocHandler) *Demo {
 	switch name {
-	case "md", "html", "json":
+	case "md", "html", "json", "sidecar":
 		panic("demokit: cannot override built-in doc format " + name)
 	}
 	if d.docHandlers == nil {
@@ -1063,6 +1063,11 @@ func (d *Demo) emitDoc(format, from string) {
 		fmt.Print(RenderDocumentHTML(RenderContext{Demo: d, Trace: entries}))
 	case "json":
 		fmt.Print(RenderDocumentJSON(RenderContext{Demo: d, Trace: entries}))
+	case "sidecar":
+		// Inverse of FromMarkdown: emit the definition as sidecar markdown.
+		// Definition-only (ignores any --from trace); the point is to lift
+		// inline content into a demo.md.
+		fmt.Print(d.Sidecar())
 	default:
 		// Registered formats (e.g. "bundle" via demokit/web). Hint
 		// at the most common case if it's missing.
@@ -1077,7 +1082,7 @@ func (d *Demo) emitDoc(format, from string) {
 				"demokit: --doc bundle is not enabled. Call web.RegisterWith(demo) before Execute (import github.com/panyam/demokit/web).")
 			return
 		}
-		fmt.Fprintf(os.Stderr, "demokit: unknown --doc format %q (want md|html|json or registered format)\n", format)
+		fmt.Fprintf(os.Stderr, "demokit: unknown --doc format %q (want md|html|json|sidecar or registered format)\n", format)
 	}
 }
 

--- a/render_sidecar.go
+++ b/render_sidecar.go
@@ -1,0 +1,156 @@
+package demokit
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Sidecar renders the demo definition as sidecar markdown — the inverse of
+// FromMarkdown. It is a pure function of the definition (it never runs
+// steps), so it is the robust way to lift an inline, Go-defined walkthrough's
+// content into a demo.md: behavior (Run/Coalesce closures) stays in Go, while
+// notes, arrows, refs, declared inputs, and verbatim blocks move to markdown.
+//
+// Round-trip: loading a demo.md and re-emitting via Sidecar reproduces the
+// same content (modulo formatting). Emitted by `--doc sidecar`.
+//
+// Step ids are the explicit StepDef id when set, else the slugified title,
+// deduplicated in declaration order so a heading's {#id} matches what Bind
+// expects.
+func (d *Demo) Sidecar() string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "title: %s\n", d.title)
+	if d.description != "" {
+		fmt.Fprintf(&b, "description: %s\n", d.description)
+	}
+	if len(d.actors) > 0 {
+		b.WriteString("actors:\n")
+		for _, a := range d.actors {
+			fmt.Fprintf(&b, "  - { id: %s, label: %s }\n", a.ID, a.Label)
+		}
+	}
+	b.WriteString("---\n\n")
+
+	used := map[string]int{}
+	for _, it := range d.items {
+		switch v := it.(type) {
+		case *SectionDef:
+			fmt.Fprintf(&b, "## %s {#%s}\n\n", v.title, sidecarID("", v.title, used))
+			if v.body != "" {
+				b.WriteString(v.body + "\n\n")
+			}
+		case *StepDef:
+			fmt.Fprintf(&b, "## %s {#%s}\n\n", v.title, sidecarID(v.id, v.title, used))
+			writeNoteSidecar(&b, v.note)
+			writeArrowsSidecar(&b, v.arrows)
+			writeInputsSidecar(&b, v.inputs)
+			writeRefsSidecar(&b, v.refs)
+			writeVerbatimSidecar(&b, v.verbatim)
+		}
+	}
+	return b.String()
+}
+
+func writeNoteSidecar(b *strings.Builder, note string) {
+	if note == "" {
+		return
+	}
+	for line := range strings.SplitSeq(note, "\n") {
+		if line == "" {
+			b.WriteString(">\n")
+		} else {
+			b.WriteString("> " + line + "\n")
+		}
+	}
+	b.WriteString("\n")
+}
+
+func writeArrowsSidecar(b *strings.Builder, arrows []arrowDef) {
+	if len(arrows) == 0 {
+		return
+	}
+	b.WriteString("```mermaid\n")
+	for _, a := range arrows {
+		op := "->>"
+		if a.dashed {
+			op = "-->>"
+		}
+		fmt.Fprintf(b, "%s %s %s: %s\n", a.from, op, a.to, a.label)
+	}
+	b.WriteString("```\n\n")
+}
+
+func writeInputsSidecar(b *strings.Builder, inputs []InputDef) {
+	if len(inputs) == 0 {
+		return
+	}
+	b.WriteString("```inputs\n")
+	for _, in := range inputs {
+		fmt.Fprintf(b, "- name: %s\n", in.Name)
+		if in.Prompt != "" {
+			fmt.Fprintf(b, "  prompt: %s\n", in.Prompt)
+		}
+		if in.Kind != "" {
+			fmt.Fprintf(b, "  type: %s\n", in.Kind)
+		}
+		if len(in.Options) > 0 {
+			fmt.Fprintf(b, "  options: [%s]\n", strings.Join(in.Options, ", "))
+		}
+		if in.Default != nil {
+			fmt.Fprintf(b, "  default: %v\n", in.Default)
+		}
+	}
+	b.WriteString("```\n\n")
+}
+
+func writeRefsSidecar(b *strings.Builder, refs []Ref) {
+	if len(refs) == 0 {
+		return
+	}
+	b.WriteString("```refs\n")
+	for _, r := range refs {
+		fmt.Fprintf(b, "- name: %s\n  url: %s\n", r.Name, r.URL)
+	}
+	b.WriteString("```\n\n")
+}
+
+// writeVerbatimSidecar emits verbatim blocks in the attribute-fence form the
+// loader reads: a shared verbatim="<title>" per block, per-variant label and
+// default=true, tilde fences so a ``` body can nest.
+func writeVerbatimSidecar(b *strings.Builder, blocks []verbatimBlock) {
+	for _, v := range blocks {
+		for _, va := range v.Variants {
+			attrs := fmt.Sprintf("verbatim=%q", v.Label)
+			if va.Label != "" {
+				attrs += " label=" + va.Label
+			}
+			if va.IsDefault {
+				attrs += " default=true"
+			}
+			fmt.Fprintf(b, "~~~%s {%s}\n", va.Lang, attrs)
+			b.WriteString(strings.TrimRight(va.Content, "\n"))
+			b.WriteString("\n~~~\n")
+		}
+		b.WriteString("\n")
+	}
+}
+
+// sidecarID resolves a stable heading id: explicit id, else slugified title,
+// deduplicated in declaration order (foo, foo-2, foo-3). Shares slugify with
+// the loader so a round-trip keeps the same ids.
+func sidecarID(explicit, title string, used map[string]int) string {
+	id := explicit
+	if id == "" {
+		id = slugify(title)
+	}
+	if id == "" {
+		id = "step"
+	}
+	n := used[id]
+	used[id]++
+	if n == 0 {
+		return id
+	}
+	return fmt.Sprintf("%s-%d", id, n+1)
+}

--- a/render_sidecar_test.go
+++ b/render_sidecar_test.go
@@ -1,0 +1,83 @@
+package demokit
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSidecarRoundTrip builds an inline demo exercising every content kind,
+// emits sidecar markdown, loads it back, and checks the content survives —
+// the load-bearing guarantee that Sidecar is the inverse of FromMarkdown.
+func TestSidecarRoundTrip(t *testing.T) {
+	orig := New("Round Trip").
+		Description("exercise every content kind").
+		Actors(Actor("A", "Alpha"), Actor("B", "Beta"))
+	orig.Section("Intro", "first line", "second line")
+	orig.Step("Connect").ID("connect").
+		Note("a note", "second paragraph").
+		Arrow("A", "B", "hello").
+		DashedArrow("B", "A", "ack").
+		Input(Choice("x", "y").Named("pick", "Pick one").WithDefault("x")).
+		VerbatimVariants("Reproduce",
+			MakeVariant("curl", "bash", "curl x").Default(),
+			MakeVariant("go", "go", "http.Get()"))
+
+	md := orig.Sidecar()
+
+	loaded := New("placeholder").FromMarkdownBytes([]byte(md))
+	if loaded.loadError != nil {
+		t.Fatalf("emitted sidecar did not load: %v\n---\n%s", loaded.loadError, md)
+	}
+
+	if loaded.title != "Round Trip" || loaded.description != "exercise every content kind" {
+		t.Errorf("frontmatter lost: title=%q desc=%q", loaded.title, loaded.description)
+	}
+	if len(loaded.actors) != 2 || loaded.actors[1].Label != "Beta" {
+		t.Errorf("actors lost: %+v", loaded.actors)
+	}
+	if len(loaded.items) != 2 {
+		t.Fatalf("items = %d, want 2 (section + step)", len(loaded.items))
+	}
+
+	sec, ok := loaded.items[0].(*SectionDef)
+	if !ok || !strings.Contains(sec.body, "second line") {
+		t.Errorf("section round-trip lost body: %+v", loaded.items[0])
+	}
+
+	step, ok := loaded.items[1].(*StepDef)
+	if !ok {
+		t.Fatalf("items[1] = %T, want *StepDef", loaded.items[1])
+	}
+	if step.id != "connect" {
+		t.Errorf("step id = %q, want connect", step.id)
+	}
+	if !strings.Contains(step.note, "a note") || !strings.Contains(step.note, "second paragraph") {
+		t.Errorf("note lost: %q", step.note)
+	}
+	if len(step.arrows) != 2 || step.arrows[0].label != "hello" || !step.arrows[1].dashed {
+		t.Errorf("arrows lost: %+v", step.arrows)
+	}
+	if len(step.inputs) != 1 || step.inputs[0].Name != "pick" || step.inputs[0].Kind != "choice" {
+		t.Errorf("inputs lost: %+v", step.inputs)
+	}
+	if len(step.verbatim) != 1 || len(step.verbatim[0].Variants) != 2 {
+		t.Fatalf("verbatim lost: %+v", step.verbatim)
+	}
+	if v := step.verbatim[0]; v.Label != "Reproduce" || !v.Variants[0].IsDefault || v.Variants[0].Content != "curl x" {
+		t.Errorf("verbatim round-trip wrong: %+v", v)
+	}
+}
+
+// TestSidecarDedupesIDs verifies steps without explicit ids get slugified,
+// deduplicated ids.
+func TestSidecarDedupesIDs(t *testing.T) {
+	d := New("T")
+	d.Step("Same Title")
+	d.Step("Same Title")
+	md := d.Sidecar()
+	for _, want := range []string{"{#same-title}", "{#same-title-2}"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("sidecar missing %q\n%s", want, md)
+		}
+	}
+}


### PR DESCRIPTION
Closes #70
Closes #71

## What changes

Adds the scaffolding (#70) and migration tooling (#71) for markdown-native authoring:

- **`--doc sidecar`** (new core renderer, `Demo.Sidecar()`) — the inverse of `FromMarkdown`. Walks the live `Demo` and emits a `demo.md` (frontmatter, notes, arrows, inputs, refs, verbatim). This is the content-migration path: `go run ./mydemo --doc sidecar > demo.md`.
- **`demokit` CLI** (`cmd/demokit`, stdlib-only, `go install .../cmd/demokit@latest`):
  - `demokit init [dir]` — base `walkthrough.mk` + a runnable sample so `make demo` works immediately.
  - `demokit new <name> --kind=narrated|live|branching` — one example dir from an embedded starter; kinds are a per-example gradient, generated code imports only `demokit` + `harness`.
  - `demokit extract <file.go>` — rewires **behavior**: slices each step's `Run`/`Coalesce`/`Timeout` closures into a `Bind(id)` skeleton.

Migration is two steps, split by what each source can provide: content from the renderer (it reads the resolved model), behavior from `extract` (a closure can't be reconstructed from a `func` value, so that part must read source).

This is what the mcpkit/iplane Phase-B migrations depend on.

## Reviewer's guide

Read in this order:
1. [render_sidecar.go](https://github.com/panyam/demokit/pull/74/files#diff-bce813e1485ea854562f23485c5974dc9d61719c98bfee3804c91ed938298281) — start here. `Demo.Sidecar()`: the content path, a pure function of the `Demo` model (walks `d.items`, never runs steps). This is where the "know every content construct" logic lives — once, next to the model.
2. [render_sidecar_test.go](https://github.com/panyam/demokit/pull/74/files#diff-0610985f013b977eb087135e7444264c016dcd2d761e4e717a3ab59125b72f05) — acceptance: build an inline demo with every content kind, emit, **reload through `FromMarkdown`**, assert it survives.
3. [cmd/demokit/extract.go](https://github.com/panyam/demokit/pull/74/files#diff-de4c7fd5fe66689109ad93610f60a1e01e8adbc79fbf8ec2cfd152f968aa386c) — the behavior path. `flattenChain` unwinds method chains; only `Step`/`ID` + `Run`/`Coalesce`/`Timeout`/… are read; `renderCall` source-slices closures into the `Bind` skeleton; warns on a bound step missing `.ID()`.
4. [cmd/demokit/extract_test.go](https://github.com/panyam/demokit/pull/74/files#diff-a9d9f073c5ec6564d87f5b96b1217e3e75f408c2470292726bec6ecd68121978) — bindings parse, closures carried verbatim, content-only steps skipped, missing-id warns.
5. [cmd/demokit/scaffold.go](https://github.com/panyam/demokit/pull/74/files#diff-05cdae02ebc7859db94c115e2d057497edcf396468ddc7498b8713478d3d646e) + `scaffold_test.go` — `init`/`new`; each kind's generated `main.go` parses and its `demo.md` loads via demokit.
6. [demokit.go](https://github.com/panyam/demokit/pull/74/files#diff-8d288d869eee51fb928e552417c1f39e03f623e07aaccfe068472e4c8feea6b3) — the `--doc sidecar` dispatch wiring.
7. [cmd/demokit/main.go](https://github.com/panyam/demokit/pull/74/files#diff-18f37cf5f9bc4f509519850bac3b9fc3936ae9d712d4706a3733766049a0048f), `cmd/demokit/templates/`, [ARCHITECTURE.md](https://github.com/panyam/demokit/pull/74/files#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfd), [README.md](https://github.com/panyam/demokit/pull/74/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

Skim or skip: `templates/*.tmpl` (content, not logic).

## Decision log

- **Content comes from a renderer, not the AST.** An earlier cut parsed content with `go/ast`, which meant mirroring the whole builder API (`Note`/`Arrow`/`Verbatim`/`Section`/…) — brittle, drifts as the API changes, and it punted on `Input(...)`. Moving content to `Demo.Sidecar()` (a `RenderContext` function) puts that logic once, next to the model; it handles inputs and computed content for free because it reads resolved values. The AST is kept only for the one thing the model can't give: the `Run` closure **source** (a `func` value has no text).
- **Closures carried verbatim by source-slicing** (token offsets) — preserves formatting/comments. `bindings.go` is a skeleton needing import fixup (stated in its header).
- **`extract` warns instead of guessing ids.** A behavior-bearing step without an explicit `.ID()` gets a warning + `TODO-set-id-…` placeholder, because that id is the join key `demo.md` and the binding must share. Bound steps need an explicit id anyway.
- **Output verified by loading, not string-matching.** `Sidecar` is round-trip tested (`FromMarkdown` → `Sidecar` → reload); the real `examples/graph` round-trips (14 items, 11 steps). Generated `main.go`/`bindings.go` are parsed; a generated `live` project compiles against demokit + harness.
- **Stdlib only** — no new deps, `go.mod` untouched.

## Risk / blast radius

- New surface: one core method (`Demo.Sidecar()`) + the `--doc sidecar` dispatch case, and a new self-contained `cmd/demokit` (`package main`). No behavior change to existing renderers, harness, or the Go API.
- Tests: `render_sidecar_test.go` (round-trip, id dedup), `cmd/demokit/*_test.go` (bindings parse/skip/warn, scaffold all kinds + init).
- Be paranoid about: `--doc sidecar` fidelity on demos with content the loader doesn't model (it emits what `StepDef` holds); `extract` correctly skipping content-only steps and flagging missing ids. Verified against `examples/graph` end-to-end.

## Before / after

`go run ./examples/graph --doc sidecar` emits a `demo.md` that reloads through demokit's loader as 14 items / 11 steps, including the `inputs` block the old AST cut couldn't produce. `demokit extract examples/graph/main.go` emits a `bindings.go` whose `Bind("triage").Coalesce(...).Run(...)` carries the original closure verbatim. A `demokit init` project compiles against demokit + harness.

## Out of scope (deliberately deferred)

- `extract` in-place rewrite of the original `main.go` (today it emits a fresh `bindings.go` skeleton) → possible follow-up.
- mcpkit / iplane adoption → already tracked (panyam/mcpkit 837, inference-book/inference-plane 164).

